### PR TITLE
test-utils crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4107,6 +4107,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-utils"
+version = "0.1.0"
+dependencies = [
+ "cas_object",
+ "mdb_shard",
+ "merklehash",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
     "utils",
     "xet_error",
     "cas_object",
-    "cas_types",
+    "cas_types", "test-utils",
 ]
 
 exclude = [

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "test-utils"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rand = "0.8.5"
+cas_object = { path = "../cas_object" }
+merklehash = { path = "../merklehash" }
+mdb_shard = { path = "../mdb_shard" }

--- a/test-utils/src/cas_object.rs
+++ b/test-utils/src/cas_object.rs
@@ -1,0 +1,143 @@
+use std::io::{Cursor, Write};
+
+use cas_object::{serialize_chunk, CasChunkInfo, CasObject, CompressionScheme};
+use merklehash::compute_data_hash;
+use rand::Rng;
+
+pub fn gen_random_bytes(uncompressed_chunk_size: u32) -> Vec<u8> {
+    let mut rng = rand::thread_rng();
+    let mut data = vec![0u8; uncompressed_chunk_size as usize];
+    rng.fill(&mut data[..]);
+    data
+}
+
+fn build_cas_object(
+    num_chunks: u32,
+    uncompressed_chunk_size: u32,
+    use_random_chunk_size: bool,
+    compression_scheme: CompressionScheme,
+) -> (CasObject, Vec<u8>, Vec<u8>) {
+    let mut c = CasObject::default();
+
+    let mut chunk_size_info = Vec::<CasChunkInfo>::new();
+    let mut writer = Cursor::new(Vec::<u8>::new());
+
+    let mut total_bytes = 0;
+    let mut uncompressed_bytes: u32 = 0;
+
+    let mut data_contents_raw =
+        Vec::<u8>::with_capacity(num_chunks as usize * uncompressed_chunk_size as usize);
+
+    for _idx in 0..num_chunks {
+        let chunk_size: u32 = if use_random_chunk_size {
+            let mut rng = rand::thread_rng();
+            rng.gen_range(512..=uncompressed_chunk_size)
+        } else {
+            uncompressed_chunk_size
+        };
+
+        let bytes = gen_random_bytes(chunk_size);
+        let len: u32 = bytes.len() as u32;
+
+        data_contents_raw.extend_from_slice(&bytes);
+
+        // build chunk, create ChunkInfo and keep going
+
+        let bytes_written = serialize_chunk(&bytes, &mut writer, compression_scheme).unwrap();
+
+        let chunk_info = CasChunkInfo {
+            start_byte_index: total_bytes,
+            cumulative_uncompressed_len: uncompressed_bytes + len,
+        };
+
+        chunk_size_info.push(chunk_info);
+        total_bytes += bytes_written as u32;
+        uncompressed_bytes += len;
+    }
+
+    let chunk_info = CasChunkInfo {
+        start_byte_index: total_bytes,
+        cumulative_uncompressed_len: uncompressed_bytes,
+    };
+    chunk_size_info.push(chunk_info);
+
+    c.info.num_chunks = chunk_size_info.len() as u32;
+
+    c.info.cashash = compute_data_hash(writer.get_ref());
+    c.info.chunk_size_info = chunk_size_info;
+
+    // now serialize info to end Xorb length
+    let len = c.info.serialize(&mut writer).unwrap();
+    c.info_length = len as u32;
+
+    writer.write_all(&c.info_length.to_le_bytes()).unwrap();
+
+    (c, writer.get_ref().to_vec(), data_contents_raw)
+}
+
+const DEFAULT_NUM_CHUNKS: u32 = 100;
+const DEFAULT_UNCOMPRESSED_CHUNK_SIZE: u32 = 1000;
+const DEFAULT_COMPRESSION_SCHEME: CompressionScheme = CompressionScheme::None;
+
+#[derive(Debug, Clone)]
+pub struct TestCasObjectBuilder {
+    num_chunks: u32,
+    uncompressed_chunk_size: u32,
+    use_random_chunk_size: bool,
+    compression_scheme: CompressionScheme,
+}
+
+impl Default for TestCasObjectBuilder {
+    fn default() -> Self {
+        Self {
+            num_chunks: DEFAULT_NUM_CHUNKS,
+            uncompressed_chunk_size: DEFAULT_UNCOMPRESSED_CHUNK_SIZE,
+            use_random_chunk_size: false,
+            compression_scheme: DEFAULT_COMPRESSION_SCHEME,
+        }
+    }
+}
+
+impl TestCasObjectBuilder {
+    pub fn build(&self) -> (CasObject, Vec<u8>, Vec<u8>) {
+        let TestCasObjectBuilder {
+            num_chunks,
+            uncompressed_chunk_size,
+            use_random_chunk_size,
+            compression_scheme,
+        } = self;
+        build_cas_object(
+            *num_chunks,
+            *uncompressed_chunk_size,
+            *use_random_chunk_size,
+            *compression_scheme,
+        )
+    }
+
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn num_chunks<T: Into<u32>>(&mut self, num_chunks: T) -> &mut Self {
+        self.num_chunks = num_chunks.into();
+        self
+    }
+
+    pub fn uncompressed_chunk_size<T: Into<u32>>(
+        &mut self,
+        uncompressed_chunk_size: T,
+    ) -> &mut Self {
+        self.uncompressed_chunk_size = uncompressed_chunk_size.into();
+        self
+    }
+
+    pub fn random_chunk_size<T: Into<u32>>(&mut self) -> &mut Self {
+        self.use_random_chunk_size = true;
+        self
+    }
+
+    pub fn compression_scheme(&mut self, compression_scheme: CompressionScheme) -> &mut Self {
+        self.compression_scheme = compression_scheme;
+        self
+    }
+}

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod cas_object;
+pub mod shard;

--- a/test-utils/src/shard.rs
+++ b/test-utils/src/shard.rs
@@ -1,0 +1,87 @@
+use std::io::Write;
+
+use mdb_shard::{
+    cas_structs::{CASChunkSequenceEntry, CASChunkSequenceHeader, MDBCASInfo},
+    file_structs::{FileDataSequenceEntry, FileDataSequenceHeader, MDBFileInfo},
+    shard_in_memory::MDBInMemoryShard,
+    MDBShardInfo,
+};
+use merklehash::{HashedWrite, MerkleHash};
+use rand::{
+    rngs::{SmallRng, StdRng},
+    Rng, SeedableRng,
+};
+
+fn rng_hash(seed: u64) -> MerkleHash {
+    let mut rng = SmallRng::seed_from_u64(seed);
+    MerkleHash::from([rng.gen(), rng.gen(), rng.gen(), rng.gen()])
+}
+
+pub fn gen_random_shard(
+    cas_block_sizes: &[usize],
+    file_chunk_range_sizes: &[usize],
+) -> mdb_shard::error::Result<MDBInMemoryShard> {
+    let seed: u64 = rand::random();
+    gen_random_shard_with_seed(seed, cas_block_sizes, file_chunk_range_sizes)
+}
+
+pub fn gen_random_shard_with_seed(
+    seed: u64,
+    cas_block_sizes: &[usize],
+    file_chunk_range_sizes: &[usize],
+) -> mdb_shard::error::Result<MDBInMemoryShard> {
+    // generate the cas content stuff.
+    let mut shard = MDBInMemoryShard::default();
+    let mut rng = StdRng::seed_from_u64(seed);
+
+    for cas_block_size in cas_block_sizes {
+        let mut cas_block = Vec::<_>::new();
+        let mut pos = 0u32;
+
+        for _ in 0..*cas_block_size {
+            cas_block.push(CASChunkSequenceEntry::new(
+                rng_hash(rng.gen()),
+                rng.gen_range(10000..20000),
+                pos,
+            ));
+            pos += rng.gen_range(10000..20000);
+        }
+
+        shard.add_cas_block(MDBCASInfo {
+            metadata: CASChunkSequenceHeader::new(rng_hash(rng.gen()), *cas_block_size, pos),
+            chunks: cas_block,
+        })?;
+    }
+
+    for file_block_size in file_chunk_range_sizes {
+        let file_hash = rng_hash(rng.gen());
+
+        let file_contents: Vec<_> = (0..*file_block_size)
+            .map(|_| {
+                let lb = rng.gen_range(0..10000);
+                let ub = lb + rng.gen_range(0..10000);
+                FileDataSequenceEntry::new(rng_hash(rng.gen()), ub - lb, lb, ub)
+            })
+            .collect();
+
+        shard.add_file_reconstruction_info(MDBFileInfo {
+            metadata: FileDataSequenceHeader::new(file_hash, *file_block_size),
+            segments: file_contents,
+        })?;
+    }
+
+    Ok(shard)
+}
+
+pub fn get_shard_hash(shard: &MDBInMemoryShard) -> mdb_shard::error::Result<MerkleHash> {
+    let mut hashed_write; // Need to access after file is closed.
+
+    hashed_write = HashedWrite::new(std::io::empty());
+    MDBShardInfo::serialize_from(&mut hashed_write, shard)?;
+
+    // Get the hash
+    hashed_write.flush()?; // not actually necessary with std::io::Empty
+    let shard_hash = hashed_write.hash();
+
+    Ok(shard_hash)
+}


### PR DESCRIPTION
helper crate to share test utilities like generating cas_objects and shards, mainly for use in cas_server