### PR TITLE
Adding the auth to the default headers instead of to each call

### DIFF
--- a/cas_client/src/remote_client.rs
+++ b/cas_client/src/remote_client.rs
@@ -106,7 +106,18 @@ impl Default for CASAPIClient {
 
 impl CASAPIClient {
     pub fn new(endpoint: &str, token: Option<String>) -> Self {
-        let client = reqwest::Client::builder().build().unwrap();
+        let mut headers = HeaderMap::new();
+        if let Some(tok) = &token {
+            headers.insert(
+                reqwest::header::AUTHORIZATION,
+                HeaderValue::from_str(&format!("Bearer {}", tok)).unwrap(),
+            );
+        }
+
+        let client = reqwest::Client::builder()
+            .default_headers(headers)
+            .build()
+            .unwrap();
         Self {
             client,
             endpoint: endpoint.to_string(),
@@ -116,12 +127,7 @@ impl CASAPIClient {
 
     pub async fn exists(&self, key: &Key) -> Result<bool> {
         let url = Url::parse(&format!("{}/xorb/{key}", self.endpoint))?;
-        let response = self
-            .client
-            .head(url)
-            .headers(self.request_headers())
-            .send()
-            .await?;
+        let response = self.client.head(url).send().await?;
         match response.status() {
             StatusCode::OK => Ok(true),
             StatusCode::NOT_FOUND => Ok(false),
@@ -133,12 +139,7 @@ impl CASAPIClient {
 
     pub async fn get_length(&self, key: &Key) -> Result<Option<u64>> {
         let url = Url::parse(&format!("{}/xorb/{key}", self.endpoint))?;
-        let response = self
-            .client
-            .head(url)
-            .headers(self.request_headers())
-            .send()
-            .await?;
+        let response = self.client.head(url).send().await?;
         let status = response.status();
         if status == StatusCode::NOT_FOUND {
             return Ok(None);
@@ -189,13 +190,7 @@ impl CASAPIClient {
         writer.set_position(0);
         let data = writer.into_inner();
 
-        let response = self
-            .client
-            .post(url)
-            .headers(self.request_headers())
-            .body(data)
-            .send()
-            .await?;
+        let response = self.client.post(url).body(data).send().await?;
         let response_body = response.bytes().await?;
         let response_parsed: UploadXorbResponse = serde_json::from_reader(response_body.reader())?;
 
@@ -247,12 +242,7 @@ impl CASAPIClient {
             file_id.hex()
         ))?;
 
-        let response = self
-            .client
-            .get(url)
-            .headers(self.request_headers())
-            .send()
-            .await?;
+        let response = self.client.get(url).send().await?;
         let response_body = response.bytes().await?;
         let response_parsed: QueryReconstructionResponse =
             serde_json::from_reader(response_body.reader())?;
@@ -262,27 +252,11 @@ impl CASAPIClient {
 
     pub async fn shard_query_chunk(&self, key: &Key) -> Result<QueryChunkResponse> {
         let url = Url::parse(&format!("{}/chunk/{key}", self.endpoint))?;
-        let response = self
-            .client
-            .get(url)
-            .headers(self.request_headers())
-            .send()
-            .await?;
+        let response = self.client.get(url).send().await?;
         let response_body = response.bytes().await?;
         let response_parsed: QueryChunkResponse = serde_json::from_reader(response_body.reader())?;
 
         Ok(response_parsed)
-    }
-
-    fn request_headers(&self) -> HeaderMap {
-        let mut headers = HeaderMap::new();
-        if let Some(tok) = &self.token {
-            headers.insert(
-                "Authorization",
-                HeaderValue::from_str(&format!("Bearer {}", tok)).unwrap(),
-            );
-        }
-        headers
     }
 
     async fn post_json<ReqT, RespT>(&self, url: Url, request_body: &ReqT) -> Result<RespT>


### PR DESCRIPTION
This clean the headers up from the different reqwest::send calls. 

Middleware required a little too much boilerplate, though it's likely going to be the final solution here when we add token refresh logic.

Resolves STO-63.