### PR TITLE
Use struct bookend for sequential scan

### DIFF
--- a/mdb_shard/src/shard_format.rs
+++ b/mdb_shard/src/shard_format.rs
@@ -575,15 +575,9 @@ impl MDBShardInfo {
 
         reader.seek(SeekFrom::Start(self.metadata.file_info_offset))?;
 
-        for _ in 0..self.num_file_entries() {
-            if let Some(mdb_file) = MDBFileInfo::deserialize(reader)? {
-                ret.push(mdb_file);
-            } else {
-                break;
-            }
+        while let Some(mdb_file) = MDBFileInfo::deserialize(reader)? {
+            ret.push(mdb_file);
         }
-
-        debug_assert!(ret.len() == self.num_file_entries());
 
         Ok(ret)
     }
@@ -634,12 +628,7 @@ impl MDBShardInfo {
 
         reader.seek(SeekFrom::Start(self.metadata.cas_info_offset))?;
 
-        for _ in 0..(self.num_cas_entries() as u32) {
-            let Some(cas_info) = MDBCASInfo::deserialize(reader)? else {
-                return Err(MDBShardError::InternalError(anyhow!(
-                    "corrupted shard, detected cas info bookend before deserializing all cas block info"
-                )));
-            };
+        while let Some(cas_info) = MDBCASInfo::deserialize(reader)? {
             ret.push(cas_info);
         }
 


### PR DESCRIPTION
Function `read_all_cas_blocks_full()` and `read_all_file_info_sections()` are called in `read_cas_chunks_for_global_dedup()` when building the global dedup table on cas servers. Since the server may choose not to keep lookup tables after shard verification, `file_lookup_num_entry` and `cas_lookup_num_entry` in the shard footer may become 0, leaving them invalid for scanning all file info and cas info. We thus instead use the struct bookend to detect the end.