### PR TITLE
Use `thread_name_fn` instead of `thread_name` for threadpool names

### DIFF
--- a/utils/src/threadpool.rs
+++ b/utils/src/threadpool.rs
@@ -54,7 +54,6 @@ use std::sync::atomic::Ordering::SeqCst;
 use tokio::{self, task::JoinHandle};
 use tracing::info;
 
-
 const THREADPOOL_NUM_WORKER_THREADS: usize = 4; // 4 active threads
 const THREADPOOL_THREAD_ID_PREFIX: &str = "hf-xet"; // thread names will be hf-xet-0, hf-xet-1, etc.
 const THREADPOOL_STACK_SIZE: usize = 8_000_000; // 8MB stack size


### PR DESCRIPTION
The `runtime::Builder`'s `thread_name` helper is a static naming function. With our name, it causes all threads to look like:
```
thread.name: hf-xet-
```

Instead, we should be using the [thread_name_fn](https://docs.rs/tokio/latest/tokio/runtime/struct.Builder.html#method.thread_name_fn) method to have a dynamic thread name with an associated counter. Now, thread names will look like:
```
thread.name: hf-xet-1
```