### PR TITLE
CAS block dedup-able only after cas put succeeds

### DIFF
--- a/data/src/data_processing.rs
+++ b/data/src/data_processing.rs
@@ -238,10 +238,10 @@ pub(crate) async fn register_new_cas_block(
         .collect();
 
     if !cas_info.chunks.is_empty() {
-        shard_manager.add_cas_block(cas_info).await?;
-
         cas.put(cas_prefix, &cas_hash, take(&mut cas_data.data), chunk_boundaries)
             .await?;
+
+        shard_manager.add_cas_block(cas_info).await?;
     } else {
         debug_assert_eq!(cas_hash, MerkleHash::default());
     }


### PR DESCRIPTION
Our PointerFileTranslator is kept in-memory throughout the entire life of a python process [[1]](https://github.com/huggingface-internal/xet-core/blob/6cfc838b1659aa0002fc3837ec3f2414c9595b0a/data/src/data_client.rs#L27). Now imagine using iPython and the first `upload_folder` failed on `cas.put` [[2]](https://github.com/huggingface-internal/xet-core/blob/6cfc838b1659aa0002fc3837ec3f2414c9595b0a/data/src/data_processing.rs#L243) xorb `A`. Because `shard_manager.add_cas_block` [[3]](https://github.com/huggingface-internal/xet-core/blob/6cfc838b1659aa0002fc3837ec3f2414c9595b0a/data/src/data_processing.rs#L241) happens before `cas.put` this xorb `A` is already dedup-able in the in-memory shard. Now in iPython we execute `upload_folder` again on the same files, this xorb `A` will be used to dedup but it never reached the CAS server before.