### PR TITLE
Skip register shard that are already registered

### DIFF
--- a/data/src/remote_shard_interface.rs
+++ b/data/src/remote_shard_interface.rs
@@ -245,10 +245,9 @@ impl RemoteShardInterface {
         let shard_manager = self.shard_manager()?;
         let cache_dir = self.shard_cache_directory()?;
 
-        // Shard is expired, we need to evit the previous registration.
         if shard_manager.shard_is_registered(shard_hash).await {
-            info!("register_local_shard: re-register {shard_hash:?}.");
-            todo!()
+            info!("register_local_shard: shard {shard_hash:?} already registered, ignore.");
+            return Ok(());
         }
 
         let shard_file = cache_dir.join(local_shard_name(shard_hash));


### PR DESCRIPTION
In both situations where writing [protected shard obtained from CAS server](https://github.com/huggingface-internal/xet-core/blob/b2988320aecc65dc12be9614cbee05e4b0c63add/cas_client/src/http_shard_client.rs#L162) and [local generated shard](https://github.com/huggingface-internal/xet-core/blob/b2988320aecc65dc12be9614cbee05e4b0c63add/mdb_shard/src/shard_in_memory.rs#L217) to disk, the shard hash is computed from the entire file content obtained from `HashedWrite`, thus shards with the same file name means exactly same content, and therefore there's no need to re-register.