### PR TITLE
Only load the shard chunk dedup tables for the upload path

### DIFF
--- a/cas_client/src/local_shard_client.rs
+++ b/cas_client/src/local_shard_client.rs
@@ -24,7 +24,7 @@ pub struct LocalShardClient {
 }
 
 impl LocalShardClient {
-    pub async fn new(cas_directory: &Path) -> Result<Self> {
+    pub async fn new(cas_directory: &Path, download_only_mode: bool) -> Result<Self> {
         let shard_directory = cas_directory.join("shards");
         if !shard_directory.exists() {
             std::fs::create_dir_all(&shard_directory).map_err(|e| {
@@ -32,8 +32,8 @@ impl LocalShardClient {
             })?;
         }
 
-        let shard_manager = ShardFileManager::load_dir(&shard_directory).await?;
-        shard_manager.load_and_cleanup_shards_by_path(&[&shard_directory]).await?;
+        // This loads and cleans all the shards in the session directory; no need to do it explicitly
+        let shard_manager = ShardFileManager::load_dir(&shard_directory, download_only_mode).await?;
 
         let global_dedup = DiskBasedGlobalDedupTable::open_or_create(cas_directory.join("ddb").join("chunk2shard.db"))?;
 

--- a/data/src/bin/example.rs
+++ b/data/src/bin/example.rs
@@ -166,7 +166,7 @@ async fn clean(mut reader: impl Read, mut writer: impl Write) -> Result<()> {
 
     let mut read_buf = vec![0u8; READ_BLOCK_SIZE];
 
-    let translator = PointerFileTranslator::new(default_clean_config()?, get_threadpool(), None).await?;
+    let translator = PointerFileTranslator::new(default_clean_config()?, get_threadpool(), None, false).await?;
 
     let handle = translator.start_clean(1024, None).await?;
 
@@ -214,7 +214,7 @@ async fn smudge(mut reader: impl Read, writer: &mut Box<dyn Write + Send>) -> Re
         return Ok(());
     }
 
-    let translator = PointerFileTranslator::new(default_smudge_config()?, get_threadpool(), None).await?;
+    let translator = PointerFileTranslator::new(default_smudge_config()?, get_threadpool(), None, true).await?;
 
     translator.smudge_file_from_pointer(&pointer_file, writer, None, None).await?;
 

--- a/data/src/data_client.rs
+++ b/data/src/data_client.rs
@@ -98,7 +98,7 @@ pub async fn upload_async(
     let (config, _tempdir) =
         default_config(endpoint.unwrap_or(DEFAULT_CAS_ENDPOINT.to_string()), token_info, token_refresher)?;
 
-    let processor = Arc::new(PointerFileTranslator::new(config, threadpool, progress_updater).await?);
+    let processor = Arc::new(PointerFileTranslator::new(config, threadpool, progress_updater, false).await?);
 
     // for all files, clean them, producing pointer files.
     let pointers = tokio_par_for_each(file_paths, MAX_CONCURRENT_UPLOADS, |f, _| async {
@@ -141,7 +141,7 @@ pub async fn download_async(
     };
     let pointer_files_plus = pointer_files.into_iter().zip(updaters).collect::<Vec<_>>();
 
-    let processor = &Arc::new(PointerFileTranslator::new(config, threadpool, None).await?);
+    let processor = &Arc::new(PointerFileTranslator::new(config, threadpool, None, true).await?);
     let paths =
         tokio_par_for_each(pointer_files_plus, MAX_CONCURRENT_DOWNLOADS, |(pointer_file, updater), _| async move {
             let proc = processor.clone();

--- a/data/src/data_processing.rs
+++ b/data/src/data_processing.rs
@@ -81,8 +81,9 @@ impl PointerFileTranslator {
         config: TranslatorConfig,
         threadpool: Arc<ThreadPool>,
         upload_progress_updater: Option<Arc<dyn ProgressUpdater>>,
+        download_only: bool,
     ) -> Result<PointerFileTranslator> {
-        let shard_manager = Arc::new(create_shard_manager(&config.shard_storage_config).await?);
+        let shard_manager = Arc::new(create_shard_manager(&config.shard_storage_config, download_only).await?);
 
         let cas_client = create_cas_client(
             &config.cas_storage_config,
@@ -100,6 +101,7 @@ impl PointerFileTranslator {
                     Some(cas_client.clone()),
                     dedup.repo_salt,
                     threadpool.clone(),
+                    download_only,
                 )
                 .await?
             } else {

--- a/data/src/remote_shard_interface.rs
+++ b/data/src/remote_shard_interface.rs
@@ -47,7 +47,7 @@ impl RemoteShardInterface {
         shard_storage_config: &StorageConfig,
         threadpool: Arc<ThreadPool>,
     ) -> Result<Arc<Self>> {
-        Self::new(file_query_policy, shard_storage_config, None, None, None, threadpool).await
+        Self::new(file_query_policy, shard_storage_config, None, None, None, threadpool, true).await
     }
 
     pub async fn new(
@@ -57,18 +57,19 @@ impl RemoteShardInterface {
         cas: Option<Arc<dyn Client + Send + Sync>>,
         repo_salt: Option<RepoSalt>,
         threadpool: Arc<ThreadPool>,
+        download_only: bool,
     ) -> Result<Arc<Self>> {
         let shard_client = {
             if file_query_policy != FileQueryPolicy::LocalOnly {
                 debug!("data_processing: Setting up file reconstructor to query shard server.");
-                create_shard_client(shard_storage_config).await.ok()
+                create_shard_client(shard_storage_config, download_only).await.ok()
             } else {
                 None
             }
         };
 
         let shard_manager = if file_query_policy != FileQueryPolicy::ServerOnly && shard_manager.is_none() {
-            Some(Arc::new(create_shard_manager(shard_storage_config).await?))
+            Some(Arc::new(create_shard_manager(shard_storage_config, download_only).await?))
         } else {
             shard_manager
         };

--- a/mdb_shard/src/shard_benchmark.rs
+++ b/mdb_shard/src/shard_benchmark.rs
@@ -77,7 +77,7 @@ async fn run_shard_benchmark(
 
     // Now, spawn tasks to
     let counter = Arc::new(AtomicUsize::new(0));
-    let mdb = Arc::new(ShardFileManager::load_dir(dir).await?);
+    let mdb = Arc::new(ShardFileManager::load_dir(dir, false).await?);
 
     let start_time = Instant::now();
 

--- a/mdb_shard/src/shard_file_manager.rs
+++ b/mdb_shard/src/shard_file_manager.rs
@@ -107,6 +107,7 @@ pub struct ShardFileManager {
     shard_bookkeeper: Arc<RwLock<ShardBookkeeper>>,
     current_state: Arc<RwLock<MDBShardFlushGuard>>,
     target_shard_min_size: u64,
+    chunk_dedup_disabled: bool,
 }
 
 /// Shard file manager to manage all the shards.  It is fully thread-safe and async enabled.
@@ -128,7 +129,11 @@ pub struct ShardFileManager {
 /// // new_shards is the list of new shards for this session.
 impl ShardFileManager {
     /// Creates a new shard file manager at the
-    pub async fn new(session_directory: &Path, load_and_clean_directory: bool) -> Result<Self> {
+    pub async fn new(
+        session_directory: &Path,
+        load_and_clean_directory: bool,
+        disable_chunk_dedup: bool,
+    ) -> Result<Self> {
         let session_directory = {
             if session_directory == PathBuf::default() {
                 None
@@ -147,6 +152,7 @@ impl ShardFileManager {
                 session_directory: session_directory.clone(),
             })),
             target_shard_min_size: MDB_SHARD_MIN_TARGET_SIZE,
+            chunk_dedup_disabled: disable_chunk_dedup,
         };
 
         if load_and_clean_directory {
@@ -159,8 +165,8 @@ impl ShardFileManager {
     }
 
     /// Construct a new shard file manager that uses session_directory as the temporary dumping  
-    pub async fn load_dir(session_directory: &Path) -> Result<Self> {
-        Self::new(session_directory, true).await
+    pub async fn load_dir(session_directory: &Path, disable_chunk_dedup: bool) -> Result<Self> {
+        Self::new(session_directory, true, disable_chunk_dedup).await
     }
 
     /// Sets the target value of a shard file size.  By default, it is given by MDB_SHARD_MIN_TARGET_SIZE
@@ -253,7 +259,8 @@ impl ShardFileManager {
                 sbkp_lg.shard_collections.push(KeyedShardCollection::new(shard_hmac_key));
             }
 
-            let update_chunk_lookup = sbkp_lg.total_indexed_chunks < *CHUNK_INDEX_TABLE_MAX_SIZE;
+            let update_chunk_lookup =
+                !self.chunk_dedup_disabled && sbkp_lg.total_indexed_chunks < *CHUNK_INDEX_TABLE_MAX_SIZE;
 
             // Now add in the chunk indices.
             let shard_index;
@@ -360,6 +367,12 @@ impl ShardFileManager {
         &self,
         query_hashes: &[MerkleHash],
     ) -> Result<Option<(usize, FileDataSequenceEntry)>> {
+        if self.chunk_dedup_disabled {
+            return Err(MDBShardError::Other(
+                "Logic Error: shard_manager not initialized for dedup but dedup attempted.".to_owned(),
+            ));
+        }
+
         // First attempt the in-memory version of this.
         {
             let lg = self.current_state.read().await;
@@ -570,7 +583,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(seed);
 
         let shard_dir = shard_dir.as_ref();
-        let mut sfm = ShardFileManager::load_dir(shard_dir).await?;
+        let mut sfm = ShardFileManager::load_dir(shard_dir, false).await?;
         let mut reference_shard = MDBInMemoryShard::default();
 
         for _ in 0..n_shards {
@@ -705,7 +718,7 @@ mod tests {
         let mut mdb_in_mem = MDBInMemoryShard::default();
 
         {
-            let mut mdb = ShardFileManager::load_dir(tmp_dir.path()).await?;
+            let mut mdb = ShardFileManager::load_dir(tmp_dir.path(), false).await?;
 
             fill_with_specific_shard(&mut mdb, &mut mdb_in_mem, &[(0, &[(11, 5)])], &[(100, &[(200, (0, 5))])]).await?;
 
@@ -721,7 +734,7 @@ mod tests {
         }
         {
             // Now, make sure that this happens if this directory is opened up
-            let mut mdb2 = ShardFileManager::load_dir(tmp_dir.path()).await?;
+            let mut mdb2 = ShardFileManager::load_dir(tmp_dir.path(), false).await?;
 
             // Make sure it's all in there this round.
             verify_mdb_shards_match(&mdb2, &mdb_in_mem, true).await?;
@@ -750,7 +763,7 @@ mod tests {
     async fn test_larger_simulated() -> Result<()> {
         let tmp_dir = TempDir::new("gitxet_shard_test_2")?;
         let mut mdb_in_mem = MDBInMemoryShard::default();
-        let mut mdb = ShardFileManager::load_dir(tmp_dir.path()).await?;
+        let mut mdb = ShardFileManager::load_dir(tmp_dir.path(), false).await?;
 
         for i in 0..10 {
             fill_with_random_shard(&mut mdb, &mut mdb_in_mem, i, &[1, 5, 10, 8], &[4, 3, 5, 9, 4, 6]).await?;
@@ -769,7 +782,7 @@ mod tests {
             mdb.flush().await?;
 
             // Now, make sure that this happens if this directory is opened up
-            let mdb2 = ShardFileManager::load_dir(tmp_dir.path()).await?;
+            let mdb2 = ShardFileManager::load_dir(tmp_dir.path(), false).await?;
 
             // Make sure it's all in there this round.
             verify_mdb_shards_match(&mdb2, &mdb_in_mem, true).await?;
@@ -785,7 +798,7 @@ mod tests {
         for sesh in 0..3 {
             for i in 0..10 {
                 {
-                    let mut mdb = ShardFileManager::load_dir(tmp_dir.path()).await.unwrap();
+                    let mut mdb = ShardFileManager::load_dir(tmp_dir.path(), false).await.unwrap();
                     fill_with_random_shard(
                         &mut mdb,
                         &mut mdb_in_mem,
@@ -825,7 +838,7 @@ mod tests {
 
             {
                 // Now, make sure that this happens if this directory is opened up
-                let mdb2 = ShardFileManager::load_dir(tmp_dir.path()).await.unwrap();
+                let mdb2 = ShardFileManager::load_dir(tmp_dir.path(), false).await.unwrap();
 
                 verify_mdb_shards_match(&mdb2, &mdb_in_mem, true).await.unwrap();
             }
@@ -841,12 +854,12 @@ mod tests {
         const T: u64 = 10000;
 
         {
-            let mut mdb = ShardFileManager::load_dir(tmp_dir.path()).await?;
+            let mut mdb = ShardFileManager::load_dir(tmp_dir.path(), false).await?;
             mdb.set_target_shard_min_size(T); // Set the targe shard size really low
             fill_with_random_shard(&mut mdb, &mut mdb_in_mem, 0, &[16; 16], &[16; 16]).await?;
         }
         {
-            let mut mdb = ShardFileManager::load_dir(tmp_dir.path()).await?;
+            let mut mdb = ShardFileManager::load_dir(tmp_dir.path(), false).await?;
 
             verify_mdb_shards_match(&mdb, &mdb_in_mem, true).await?;
 
@@ -858,7 +871,7 @@ mod tests {
 
         // Reload and verify
         {
-            let mdb = ShardFileManager::load_dir(tmp_dir.path()).await?;
+            let mdb = ShardFileManager::load_dir(tmp_dir.path(), false).await?;
             verify_mdb_shards_match(&mdb, &mdb_in_mem, true).await?;
         }
 
@@ -876,7 +889,7 @@ mod tests {
 
         // Reload and verify
         {
-            let mdb = ShardFileManager::load_dir(tmp_dir.path()).await?;
+            let mdb = ShardFileManager::load_dir(tmp_dir.path(), false).await?;
             verify_mdb_shards_match(&mdb, &mdb_in_mem, true).await?;
         }
 
@@ -891,7 +904,7 @@ mod tests {
         const T: u64 = 4096;
 
         for i in 0..5 {
-            let mut mdb = ShardFileManager::load_dir(tmp_dir.path()).await?;
+            let mut mdb = ShardFileManager::load_dir(tmp_dir.path(), false).await?;
             mdb.set_target_shard_min_size(T); // Set the targe shard size really low
             fill_with_random_shard(&mut mdb, &mut mdb_in_mem, i, &[5; 25], &[5; 25]).await?;
 
@@ -913,7 +926,7 @@ mod tests {
         let mut target_size = T;
         loop {
             // Now, make sure that this happens if this directory is opened up
-            let mut mdb2 = ShardFileManager::load_dir(tmp_dir.path()).await?;
+            let mut mdb2 = ShardFileManager::load_dir(tmp_dir.path(), false).await?;
             mdb2.set_target_shard_min_size(target_size);
 
             // Make sure it's all in there this round.
@@ -953,7 +966,7 @@ mod tests {
 
         // First, load all of these with a shard file manager and check them.
         {
-            let shard_file_manager = ShardFileManager::load_dir(tmp_dir_path).await?;
+            let shard_file_manager = ShardFileManager::load_dir(tmp_dir_path, false).await?;
             shard_file_manager.load_and_cleanup_shards_by_path(&[tmp_dir_path]).await?;
             verify_mdb_shards_match(&shard_file_manager, &ref_shard, true).await?;
         }
@@ -1004,7 +1017,7 @@ mod tests {
             }
 
             // Now, verify that everything still works great.
-            let shard_file_manager = ShardFileManager::load_dir(tmp_dir_path_keyed).await?;
+            let shard_file_manager = ShardFileManager::load_dir(tmp_dir_path_keyed, false).await?;
             shard_file_manager
                 .load_and_cleanup_shards_by_path(&[tmp_dir_path_keyed])
                 .await?;
@@ -1040,7 +1053,7 @@ mod tests {
 
         {
             // Make sure this one gets loaded properly.
-            let shard_file_manager = ShardFileManager::new(tmp_dir_path_keyed, false).await?;
+            let shard_file_manager = ShardFileManager::new(tmp_dir_path_keyed, false, false).await?;
             let loaded_shards = shard_file_manager
                 .register_shards_by_path(&[tmp_dir_path_keyed], false, Duration::new(100, 0))
                 .await?;
@@ -1054,7 +1067,7 @@ mod tests {
 
         {
             // Now, it shouldn't load any of them.
-            let shard_file_manager = ShardFileManager::new(tmp_dir_path_keyed, false).await?;
+            let shard_file_manager = ShardFileManager::new(tmp_dir_path_keyed, false, false).await?;
             let loaded_shards = shard_file_manager
                 .register_shards_by_path(&[tmp_dir_path_keyed], false, Duration::new(100, 0))
                 .await?;
@@ -1070,7 +1083,7 @@ mod tests {
         // Try again, but allow deletion.  Make sure it gets cleaned up.
         {
             // Now, it shouldn't load any of them.
-            let shard_file_manager = ShardFileManager::new(tmp_dir_path_keyed, false).await?;
+            let shard_file_manager = ShardFileManager::new(tmp_dir_path_keyed, false, false).await?;
             let loaded_shards = shard_file_manager
                 .register_shards_by_path(&[tmp_dir_path_keyed], true, Duration::new(0, 0))
                 .await?;
@@ -1090,7 +1103,7 @@ mod tests {
         let mut mdb_in_mem = MDBInMemoryShard::default();
 
         {
-            let mut mdb = ShardFileManager::load_dir(tmp_dir.path()).await?;
+            let mut mdb = ShardFileManager::load_dir(tmp_dir.path(), false).await?;
 
             fill_with_specific_shard(&mut mdb, &mut mdb_in_mem, &[(0, &[(11, 5)])], &[(100, &[(200, (0, 5))])]).await?;
 
@@ -1100,7 +1113,7 @@ mod tests {
 
         {
             // Now, make sure that this happens if this directory is opened up
-            let mdb2 = ShardFileManager::load_dir(tmp_dir.path()).await?;
+            let mdb2 = ShardFileManager::load_dir(tmp_dir.path(), false).await?;
 
             // Make sure it's all in there this round.
             verify_mdb_shards_match(&mdb2, &mdb_in_mem, true).await?;


### PR DESCRIPTION
Currently, the shard chunk lookup tables are read and loaded on startup for both upload and download.  However, they are only needed for upload.  This PR disables this step for the download path, as the current setup will be either one or the other, not both.

(In the old xet-core, these tables were loaded in the background, so this was less of an issue but meant more async and locking annoyance and so was dropped during the keyed hash update).