### PR TITLE
XetRuntime: new concurrent runtime for isolating async. 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,6 +761,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2042,6 +2064,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2055,6 +2087,12 @@ name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+
+[[package]]
+name = "oneshot"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e296cf87e61c9cfc1a61c3c63a0f7f286ed4554e0e22be84e8a38e1d264a2a29"
 
 [[package]]
 name = "oorandom"
@@ -4108,6 +4146,22 @@ dependencies = [
  "rustversion",
  "trybuild",
  "xet-error-impl",
+]
+
+[[package]]
+name = "xet_runtime"
+version = "0.14.5"
+dependencies = [
+ "crossbeam",
+ "futures",
+ "lazy_static",
+ "num_cpus",
+ "oneshot",
+ "rayon",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "xet_error",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4153,6 +4153,7 @@ name = "xet_runtime"
 version = "0.14.5"
 dependencies = [
  "crossbeam",
+ "error_printer",
  "futures",
  "lazy_static",
  "num_cpus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "cas_object",
     "cas_types",
     "chunk_cache",
+    "xet_runtime"
 ]
 
 exclude = ["hf_xet", "chunk_cache_bench"]

--- a/xet_runtime/Cargo.toml
+++ b/xet_runtime/Cargo.toml
@@ -9,6 +9,7 @@ path = "src/lib.rs"
 
 [dependencies]
 xet_error = { path = "../xet_error" }
+error_printer = { path = "../error_printer" }
 futures = "0.3.28"
 
 tokio = { version = "1.41", features = ["full"] }

--- a/xet_runtime/Cargo.toml
+++ b/xet_runtime/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "xet_runtime"
+version = "0.14.5"
+edition = "2021"
+
+[lib]
+name = "xet_runtime"
+path = "src/lib.rs"
+
+[dependencies]
+xet_error = { path = "../xet_error" }
+futures = "0.3.28"
+
+tokio = { version = "1.41", features = ["full"] }
+rayon = "1"
+oneshot = "0.1.8"
+crossbeam = "0.8"
+tracing = "0.1.*"
+num_cpus = "1.16.0"
+lazy_static = "1"
+
+[dev-dependencies]
+tempfile = "3.14.0"
+
+[features]
+strict = []

--- a/xet_runtime/src/errors.rs
+++ b/xet_runtime/src/errors.rs
@@ -1,0 +1,53 @@
+use tracing::error;
+use xet_error::Error;
+
+/// An error class for everyone to wrap that indicates cancellation.
+#[derive(Debug, Error)]
+pub struct RuntimeCancellation {}
+
+impl std::fmt::Display for RuntimeCancellation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "RuntimeCancellation")
+    }
+}
+
+/// Define an error time for spawning external threads.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum XetRuntimeError {
+    #[error("Error Initializing Async Runtime: {0:?}")]
+    AsyncRuntimeInitializationError(#[from] std::io::Error),
+
+    #[error("Error Initializing Compute Runtime: {0:?}")]
+    ComputeRuntimeInitializationError(String),
+
+    #[error("Task Panic: {0:?}.")]
+    TaskPanic(String),
+
+    #[error("Task cancelled; possible runtime shutdown in progress ({0}).")]
+    TaskCanceled(String),
+
+    #[error("Async Task Join Error: {0}")]
+    OtherJoinError(tokio::task::JoinError),
+
+    #[error("RuntimeCancellation")]
+    RuntimeCancellation(#[from] RuntimeCancellation),
+
+    #[error("ask runtime error: {0}")]
+    Other(String),
+}
+
+pub type Result<T> = std::result::Result<T, XetRuntimeError>;
+
+pub(crate) fn map_join_error(e: tokio::task::JoinError) -> XetRuntimeError {
+    if e.is_panic() {
+        // The task panic'd.  Pass this exception on.
+        error!("Panic reported on xet worker task: {e:?}");
+        XetRuntimeError::TaskPanic(format!("{e:?}"))
+    } else if e.is_cancelled() {
+        // Likely caused by the runtime shutting down (e.g. with a keyboard CTRL-C).
+        XetRuntimeError::TaskCanceled(format!("{e}"))
+    } else {
+        XetRuntimeError::OtherJoinError(e)
+    }
+}

--- a/xet_runtime/src/lib.rs
+++ b/xet_runtime/src/lib.rs
@@ -1,0 +1,7 @@
+mod errors;
+mod primatives;
+mod runtime_executor;
+
+pub use errors::{RuntimeCancellation, XetRuntimeError};
+pub use primatives::{AsyncJoinHandle, AsyncJoinSet, ComputeJoinHandle, ComputeJoinSet};
+pub use runtime_executor::{cancellation_requested, check_runtime_cancellation, xet_runtime, XetRuntime};

--- a/xet_runtime/src/lib.rs
+++ b/xet_runtime/src/lib.rs
@@ -2,6 +2,6 @@ mod errors;
 mod primatives;
 mod runtime_executor;
 
-pub use errors::{RuntimeCancellation, XetRuntimeError};
+pub use errors::{Result, RuntimeCancellation, XetRuntimeError};
 pub use primatives::{AsyncJoinHandle, AsyncJoinSet, ComputeJoinHandle, ComputeJoinSet};
-pub use runtime_executor::{cancellation_requested, check_runtime_cancellation, xet_runtime, XetRuntime};
+pub use runtime_executor::{xet_runtime, xet_runtime_checked, XetRuntime};

--- a/xet_runtime/src/primatives.rs
+++ b/xet_runtime/src/primatives.rs
@@ -7,6 +7,22 @@ use rayon::ThreadPool;
 
 use crate::errors::{map_join_error, Result, XetRuntimeError};
 
+/// Join handle for a task on the compute runtime.  
+///
+/// This struct should only be instantiated through xet_runtime().spawn_compute_task(...).
+///
+/// # Example:
+///
+/// ```
+/// use xet_runtime::{xet_runtime, ComputeJoinHandle};
+/// let handle: ComputeJoinHandle<_> = xet_runtime().spawn_compute_task(|| 99).unwrap();
+///
+/// // From synchronous code:
+/// assert_eq!(handle.join().unwrap(), 99);
+///
+/// // From async code:
+/// // assert_eq!(handle.await?, 99);
+/// ```
 pub struct ComputeJoinHandle<T: Send + Sync> {
     task_result: oneshot::Receiver<T>, /* Use the other join handle to figure out when the previous job is
                                         * done. */
@@ -18,14 +34,46 @@ impl<T: Send + Sync> ComputeJoinHandle<T> {
         (Self { task_result }, sender)
     }
 
-    /// Blocks the current thread until the task has finished.  Do not use in async code; in async code,
-    /// use .await on this to await the result.
+    /// Blocks the current thread until the CPU-bound task has finished.  
+    /// Use this only in synchronous code; in async code, just use `.await`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the underlying task panicked.  
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use xet_runtime::{xet_runtime, ComputeJoinHandle};
+    /// let handle: ComputeJoinHandle<_> = xet_runtime().spawn_compute_task(|| 42).unwrap();
+    /// let result = handle.join().unwrap();
+    /// assert_eq!(result, 42);
+    /// ```
     pub fn join(self) -> Result<T> {
         self.task_result
             .recv()
             .map_err(|e| XetRuntimeError::Other(format!("ComputeJoinHandle: {e:?}")))
     }
 
+    /// Attempts to retrieve the result without blocking.  
+    ///
+    /// - Returns `Ok(Some(value))` if the task is complete.
+    /// - Returns `Ok(None)` if the task is still running.
+    /// - Returns an `Err(...)` variant if
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use xet_runtime::{xet_runtime, ComputeJoinHandle};
+    /// let handle: ComputeJoinHandle<_> = xet_runtime().spawn_compute_task(|| 42).unwrap();
+    ///
+    /// // Possibly do some work here...
+    /// match handle.try_join() {
+    ///     Ok(Some(value)) => println!("Value is ready: {}", value),
+    ///     Ok(None) => println!("Still running"),
+    ///     Err(e) => eprintln!("Error: {:?}", e),
+    /// }
+    /// ```    
     pub fn try_join(&self) -> Result<Option<T>> {
         match self.task_result.try_recv() {
             Err(oneshot::TryRecvError::Empty) => Ok(None),
@@ -35,7 +83,16 @@ impl<T: Send + Sync> ComputeJoinHandle<T> {
     }
 }
 
-// Implement .await as a trait
+/// Implements `.await` for [`ComputeJoinHandle`], allowing async code to
+/// wait on it directly:
+///
+/// ```ignore
+/// async fn async_code() -> Result<()> {
+///     let handle = xet_runtime().spawn_compute_task(|| 42)?;
+///     let result = handle.await?;
+///     assert_eq!(result, 42);
+///     Ok(())
+/// }
 impl<T: Send + Sync> Future for ComputeJoinHandle<T> {
     type Output = Result<T>;
     fn poll(mut self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> std::task::Poll<Self::Output> {
@@ -45,7 +102,30 @@ impl<T: Send + Sync> Future for ComputeJoinHandle<T> {
     }
 }
 
-/// Join handle for a task on the async runtime.  
+/// A handle for an async task spawned via
+/// [`XetRuntime::spawn_async_task`](crate::XetRuntime::spawn_async_task).
+///
+/// # Overview
+///
+/// `AsyncJoinHandle` allows you to retrieve the result of an async function
+/// running on the Tokio runtime. You can:
+///
+/// - **Block in synchronous code** with [`AsyncJoinHandle::join`], or
+/// - **Await in async code** by using `.await` directly on the handle.
+///
+/// # Examples
+///
+/// ```
+/// # use xet_runtime::{xet_runtime, AsyncJoinHandle};
+/// let handle: AsyncJoinHandle<_> = xet_runtime().spawn_async_task(async { 99 }).unwrap();
+///
+/// // From synchronous code, block until the async task completes:
+/// let val = handle.join().unwrap();
+/// assert_eq!(val, 99);
+///
+/// // Or from async code, you could do:
+/// // let val = handle.await?;
+/// ```
 pub struct AsyncJoinHandle<T: Send + Sync> {
     // Just wrap the inner struct and translates any errors to XetRuntimeErrors.
     inner: tokio::task::JoinHandle<T>,
@@ -53,18 +133,43 @@ pub struct AsyncJoinHandle<T: Send + Sync> {
 }
 
 impl<T: Send + Sync> AsyncJoinHandle<T> {
+    /// Internal constructor; use XetRuntime::spawn_async_task
     pub(crate) fn new(runtime_handle: tokio::runtime::Handle, inner: tokio::task::JoinHandle<T>) -> Self {
         Self { inner, runtime_handle }
     }
 
-    /// Join on an async task from the sync runtime.  Use join_handle.await it the
-    /// async context.  
+    /// Blocks until the async task completes, returning the task's output.
+    ///
+    /// Use this only in non-async code. In async code, you can
+    /// simply do `let result = handle.await?`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the async task panics or if joining fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use xet_runtime::{xet_runtime, AsyncJoinHandle};
+    /// let handle = xet_runtime().spawn_async_task(async { 42 }).unwrap();
+    /// assert_eq!(handle.join().unwrap(), 42);
+    /// ```
     pub fn join(self) -> Result<T> {
         self.runtime_handle.block_on(self.inner).map_err(map_join_error)
     }
 }
 
-// Implements .await on the join handle.
+/// Implements `.await` for [`AsyncJoinHandle`], allowing async code to
+/// wait on it directly:
+///
+/// ```ignore
+/// async fn async_code() -> Result<()> {
+///     let handle = xet_runtime().spawn_async_task(async { 42 })?;
+///     let result = handle.await?;
+///     assert_eq!(result, 42);
+///     Ok(())
+/// }
+/// ```
 impl<T: Send + Sync> Future for AsyncJoinHandle<T> {
     type Output = Result<T>;
     fn poll(mut self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> std::task::Poll<Self::Output> {
@@ -72,23 +177,56 @@ impl<T: Send + Sync> Future for AsyncJoinHandle<T> {
     }
 }
 
-// Join Sets
+/// A set for managing multiple compute tasks whose results can be retrieved as they complete.
+/// You can process tasks as they finish without waiting for them all to
+/// complete (unlike a simple `par_for` call, which collects all results).
+///
+/// # Overview
+///
+/// `ComputeJoinSet` maintains a collection of tasks. You can:
+///
+/// - [`spawn`](Self::spawn) tasks (unordered)
+/// - [`spawn_fifo`](Self::spawn_fifo) tasks (FIFO-ordered)
+/// - retrieve each completed result via [`join_next`](Self::join_next) or [`try_join_next`](Self::try_join_next)
+///
+/// Create a `ComputeJoinSet` via
+/// [`XetRuntime::compute_joinset`](crate::XetRuntime::compute_joinset):
+///
+/// Example:
+///
+/// ```
+/// use xet_runtime::xet_runtime;
+/// let mut join_set = xet_runtime().compute_joinset::<i32>();
+///
+/// join_set.spawn(|| 42);
+/// join_set.spawn(|| 99);
+///
+/// let mut results = vec![];
+///
+/// while let Some(res) = join_set.join_next().unwrap() {
+///     results.push(res);
+/// }
+///
+/// results.sort();
+///
+/// assert_eq!(results, vec![42, 99]);
+/// ```
+pub struct ComputeJoinSet<T: Send + Sync + 'static> {
+    thread_pool: Arc<ThreadPool>,
 
-struct _ComputeJoinSetSharedData<T: Send + Sync + 'static> {
+    receiver: crossbeam::channel::Receiver<T>,
+
+    shared_data: Arc<ComputeJoinSetSharedData<T>>,
+}
+
+/// Internal helper struct for the join set.
+struct ComputeJoinSetSharedData<T: Send + Sync + 'static> {
     // The channel on which to send new results.
     result_sender: crossbeam::channel::Sender<T>,
 
     // The total number of results to expect, either in the channel or coming from
     // still-running tasks
     incoming_result_count: AtomicUsize,
-}
-
-pub struct ComputeJoinSet<T: Send + Sync + 'static> {
-    thread_pool: Arc<ThreadPool>,
-
-    receiver: crossbeam::channel::Receiver<T>,
-
-    shared_data: Arc<_ComputeJoinSetSharedData<T>>,
 }
 
 impl<T: Send + Sync + 'static> ComputeJoinSet<T> {
@@ -98,15 +236,64 @@ impl<T: Send + Sync + 'static> ComputeJoinSet<T> {
         Self {
             thread_pool,
             receiver,
-            shared_data: Arc::new(_ComputeJoinSetSharedData {
+            shared_data: Arc::new(ComputeJoinSetSharedData {
                 result_sender,
                 incoming_result_count: AtomicUsize::new(0),
             }),
         }
     }
 
-    /// Spawns a new task onto the Rayon threadpool.
+    /// Spawns a new *FIFO* task onto the Rayon threadpool. Tasks spawned with
+    /// `spawn_fifo` will wait for previously spawned FIFO tasks to *start*
+    /// before they themselves begin.
+    ///
+    /// This does not imply they will *finish* in FIFO order, only *start*.
+    ///
+    /// # Example:
+    ///
+    /// ```
+    /// # use xet_runtime::{xet_runtime, ComputeJoinSet};
+    /// # let rt = xet_runtime();
+    /// # let mut join_set = rt.compute_joinset::<i32>();
+    /// join_set.spawn_fifo(|| 42);
+    /// join_set.spawn_fifo(|| 99);
+    ///
+    /// while let Some(val) = join_set.join_next().unwrap() {
+    ///     println!("Got val: {}", val);
+    /// }
+    /// ```
+    pub fn spawn_fifo<F>(&self, task: F)
+    where
+        F: FnOnce() -> T + Send + 'static,
+    {
+        self.spawn_impl(task, true);
+    }
+
+    /// Spawns a new *unordered* task on the compute threadpool.
+    /// This may run in parallel with other tasks in any order.
+    ///
+    /// # Example:
+    ///
+    /// ```
+    /// # use xet_runtime::{xet_runtime, ComputeJoinSet};
+    /// # let rt = xet_runtime();
+    /// # let mut join_set = rt.compute_joinset::<i32>();
+    /// join_set.spawn(|| 42);
+    /// join_set.spawn(|| 99);
+    ///
+    /// // collect results
+    /// while let Some(val) = join_set.join_next().unwrap() {
+    ///     println!("Got val: {}", val);
+    /// }
+    /// ```
     pub fn spawn<F>(&self, task: F)
+    where
+        F: FnOnce() -> T + Send + 'static,
+    {
+        self.spawn_impl(task, false);
+    }
+
+    fn spawn_impl<F>(&self, task: F, fifo: bool)
     where
         F: FnOnce() -> T + Send + 'static,
     {
@@ -115,7 +302,7 @@ impl<T: Send + Sync + 'static> ComputeJoinSet<T> {
         // One more task to expect incoming.
         shared_data.incoming_result_count.fetch_add(1, Ordering::SeqCst);
 
-        self.thread_pool.spawn(move || {
+        let exec = move || {
             let result = task();
             // Send the result back to the ComputeJoinSet.
             if shared_data.result_sender.send(result).is_err() {
@@ -127,11 +314,33 @@ impl<T: Send + Sync + 'static> ComputeJoinSet<T> {
                 // This one errored out, so nothing more to be done.
                 shared_data.incoming_result_count.fetch_sub(1, Ordering::SeqCst);
             }
-        });
+        };
+        if fifo {
+            self.thread_pool.spawn_fifo(exec);
+        } else {
+            self.thread_pool.spawn(exec);
+        }
     }
 
-    /// Tries to get the next completed task result if available without blocking;
-    /// If not present, then
+    /// Attempts to retrieve a completed task result without blocking.
+    ///
+    /// - Returns `Ok(Some(value))` if a task has completed.
+    /// - Returns `Ok(None)` if no tasks have completed yet.
+    /// - Returns `Err(...)` if there’s a channel or internal error.
+    ///
+    /// # Example:
+    ///
+    /// ```
+    /// # use xet_runtime::{xet_runtime, ComputeJoinSet};
+    /// # let rt = xet_runtime();
+    /// # let mut join_set = rt.compute_joinset::<i32>();
+    /// join_set.spawn(|| 42);
+    /// match join_set.try_join_next() {
+    ///     Ok(Some(val)) => println!("Value: {}", val),
+    ///     Ok(None) => println!("Not ready yet"),
+    ///     Err(e) => eprintln!("Error: {:?}", e),
+    /// }
+    /// ```    
     pub fn try_join_next(&mut self) -> Result<Option<T>> {
         let ret = match self.receiver.try_recv() {
             Ok(v) => Ok(Some(v)),
@@ -146,8 +355,22 @@ impl<T: Send + Sync + 'static> ComputeJoinSet<T> {
         ret
     }
 
-    /// Waits for the next completed task result, blocking if necessary.
-    /// Returns `None` if all tasks are complete.
+    /// Waits until at least one of the running tasks completes, returning its result.
+    /// Returns `Ok(None)` if there are no more tasks left.
+    ///
+    /// # Example:
+    ///
+    /// ```
+    /// # use xet_runtime::{xet_runtime, ComputeJoinSet};
+    /// # let rt = xet_runtime();
+    /// # let mut join_set = rt.compute_joinset::<i32>();
+    /// join_set.spawn(|| 42);
+    /// join_set.spawn(|| 99);
+    ///
+    /// while let Some(val) = join_set.join_next().unwrap() {
+    ///     println!("Got val: {}", val);
+    /// }
+    /// ```
     pub fn join_next(&mut self) -> Result<Option<T>> {
         // Note: the &mut self here forces us to have exclusive access; otherwise
         // there is a race condition in which another join_next steals the result between
@@ -177,9 +400,32 @@ impl<T: Send + Sync + 'static> ComputeJoinSet<T> {
     }
 }
 
-/// An async wrapper class around the tokio JoinSet that provides two additional things:
-/// - tasks are spawned explicitly on the runtime handle.
-/// - This will allow us to swap out tokio perhaps down the road if we want to...
+/// A set for managing multiple async tasks whose results can be retrieved as they complete.
+///
+/// # Overview
+///
+/// `AsyncJoinSet` maintains a collection of async tasks. You can:
+///
+/// - [`spawn`](Self::spawn) new futures, all running in parallel,
+/// - retrieve each completed result via [`join_next`](Self::join_next) (async) or
+///   [`join_next_blocking`](Self::join_next_blocking) (sync),
+/// - [`abort_all`](Self::abort_all) if needed.
+///
+/// Typically, you create an `AsyncJoinSet` via
+/// [`XetRuntime::async_joinset`](crate::XetRuntime::async_joinset):
+///
+/// ```ignore
+/// let mut join_set = xet_runtime().async_joinset();
+/// join_set.spawn(async { 42 });
+/// join_set.spawn(async { 99 });
+///
+/// // In async code:
+/// while let Some(val) = join_set.join_next().await.unwrap() {
+///     println!("Got: {}", val);
+/// }
+/// ```
+///
+/// This is similar to [`ComputeJoinSet`], but for async tasks.
 pub struct AsyncJoinSet<T> {
     join_set: tokio::task::JoinSet<T>,
     runtime_handle: tokio::runtime::Handle,
@@ -189,6 +435,7 @@ impl<T> AsyncJoinSet<T>
 where
     T: Send + 'static,
 {
+    /// Internal constructor; this should be used through xet_runtime::async_joinset.
     pub(crate) fn new(runtime_handle: tokio::runtime::Handle) -> Self {
         Self {
             join_set: tokio::task::JoinSet::new(),
@@ -196,26 +443,65 @@ where
         }
     }
 
-    /// Spawns a task on the runtime associated with this wrapper
-    pub fn spawn<F>(&mut self, task: F) -> tokio::task::AbortHandle
+    /// Spawns an async future into this join set.
+    ///
+    /// # Example:
+    ///
+    /// ```
+    /// use std::time::Duration;
+    ///
+    /// use xet_runtime::{xet_runtime, AsyncJoinSet};
+    /// let mut join_set = xet_runtime().async_joinset::<u64>();
+    ///
+    /// // Spawn an async sleep:
+    /// join_set.spawn(async {
+    ///     tokio::time::sleep(Duration::from_millis(10)).await;
+    ///     42
+    /// });
+    /// ```
+    pub fn spawn<F>(&mut self, task: F)
     where
         F: std::future::Future<Output = T> + Send + 'static,
     {
-        self.join_set.spawn_on(task, &self.runtime_handle)
+        let _ = self.join_set.spawn_on(task, &self.runtime_handle);
     }
 
-    /// Aborts all tasks in the join set
-    pub fn abort_all(&mut self) {
-        self.join_set.abort_all();
-    }
-
-    /// Removes and returns the next task result from the join set
+    /// Returns the next completed task’s result in an async manner.
+    /// If there are no tasks left, returns `Ok(None)`.
+    ///
+    /// # Example:
+    ///
+    /// ```ignore
+    /// use xet_runtime::{xet_runtime, AsyncJoinSet};
+    ///
+    /// let mut join_set = xet_runtime().async_joinset();
+    ///
+    /// while let Some(val) = join_set.join_next().await? {
+    ///     println!("Task returned: {}", val);
+    /// }
+    /// ```  
     pub async fn join_next(&mut self) -> Result<Option<T>> {
         self.join_set.join_next().await.transpose().map_err(map_join_error)
     }
 
-    /// Removes and returns the next task result from the join set; to be called
-    /// only from outside the async runtime.
+    /// Removes and returns the next completed task’s result, blocking
+    /// until one is ready. Similar to [`join_next`](Self::join_next), but
+    /// for sync code.
+    ///
+    /// If no tasks remain, returns `Ok(None)`.
+    ///
+    /// # Example:
+    ///
+    /// ```ignore
+    /// use xet_runtime::{xet_runtime, AsyncJoinSet};
+    /// let mut join_set = xet_runtime().async_joinset();
+    /// // ...
+    /// let next = join_set.join_next_blocking().unwrap();
+    /// match next {
+    ///     Some(val) => println!("Got {}", val),
+    ///     None => println!("No tasks remain"),
+    /// }
+    /// ```
     pub fn join_next_blocking(&mut self) -> Result<Option<T>> {
         let jnh = self.join_set.join_next();
         self.runtime_handle.block_on(jnh).transpose().map_err(map_join_error)
@@ -226,7 +512,8 @@ where
         self.join_set.is_empty()
     }
 
-    /// Returns the number of tasks currently in the join set
+    /// Returns the number of tasks currently in the join set, including completed tasks with
+    /// results that have not yet been retrieved.
     pub fn len(&self) -> usize {
         self.join_set.len()
     }
@@ -269,6 +556,27 @@ mod tests {
         // Spawn some tasks
         for i in 0..5 {
             join_set.spawn(move || i * 2);
+        }
+
+        // Collect results
+        let mut results = vec![];
+        while let Ok(Some(result)) = join_set.join_next() {
+            results.push(result);
+        }
+
+        // Ensure all tasks completed
+        results.sort();
+        assert_eq!(results, vec![0, 2, 4, 6, 8]);
+    }
+
+    #[test]
+    fn test_spawn_and_join_next_fifo() {
+        let thread_pool = Arc::new(ThreadPoolBuilder::new().num_threads(1).build().unwrap());
+        let mut join_set = ComputeJoinSet::new(thread_pool);
+
+        // Spawn some tasks
+        for i in 0..5 {
+            join_set.spawn_fifo(move || i * 2);
         }
 
         // Collect results

--- a/xet_runtime/src/primatives.rs
+++ b/xet_runtime/src/primatives.rs
@@ -218,10 +218,7 @@ where
     /// only from outside the async runtime.
     pub fn join_next_blocking(&mut self) -> Result<Option<T>> {
         let jnh = self.join_set.join_next();
-        self.runtime_handle
-            .block_on(async move { jnh.await })
-            .transpose()
-            .map_err(map_join_error)
+        self.runtime_handle.block_on(jnh).transpose().map_err(map_join_error)
     }
 
     /// Returns whether the join set is empty

--- a/xet_runtime/src/primatives.rs
+++ b/xet_runtime/src/primatives.rs
@@ -1,0 +1,392 @@
+use std::future::Future;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use futures::FutureExt;
+use rayon::ThreadPool;
+
+use crate::errors::{map_join_error, Result, XetRuntimeError};
+
+pub struct ComputeJoinHandle<T: Send + Sync> {
+    task_result: oneshot::Receiver<T>, /* Use the other join handle to figure out when the previous job is
+                                        * done. */
+}
+
+impl<T: Send + Sync> ComputeJoinHandle<T> {
+    pub(crate) fn create() -> (Self, oneshot::Sender<T>) {
+        let (sender, task_result) = oneshot::channel();
+        (Self { task_result }, sender)
+    }
+
+    /// Blocks the current thread until the task has finished.  Do not use in async code; in async code,
+    /// use .await on this to await the result.
+    pub fn join(self) -> Result<T> {
+        self.task_result
+            .recv()
+            .map_err(|e| XetRuntimeError::Other(format!("ComputeJoinHandle: {e:?}")))
+    }
+
+    pub fn try_join(&self) -> Result<Option<T>> {
+        match self.task_result.try_recv() {
+            Err(oneshot::TryRecvError::Empty) => Ok(None),
+            Err(e) => Err(XetRuntimeError::Other(format!("ComputeJoinHandle: {e:?}"))),
+            Ok(r) => Ok(Some(r)),
+        }
+    }
+}
+
+// Implement .await as a trait
+impl<T: Send + Sync> Future for ComputeJoinHandle<T> {
+    type Output = Result<T>;
+    fn poll(mut self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> std::task::Poll<Self::Output> {
+        self.task_result
+            .poll_unpin(cx)
+            .map_err(|e| XetRuntimeError::Other(format!("ComputeJoinHandle: {e:?}")))
+    }
+}
+
+/// Join handle for a task on the async runtime.  
+pub struct AsyncJoinHandle<T: Send + Sync> {
+    // Just wrap the inner struct and translates any errors to XetRuntimeErrors.
+    inner: tokio::task::JoinHandle<T>,
+}
+
+impl<T: Send + Sync> AsyncJoinHandle<T> {
+    pub(crate) fn new(inner: tokio::task::JoinHandle<T>) -> Self {
+        Self { inner }
+    }
+
+    /// Awaits the task, for API consistency with the ComputeJoinHandle
+    pub async fn join(self) -> Result<T> {
+        self.inner.await.map_err(map_join_error)
+    }
+}
+
+// Implements .await on the join handle.
+impl<T: Send + Sync> Future for AsyncJoinHandle<T> {
+    type Output = Result<T>;
+    fn poll(mut self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> std::task::Poll<Self::Output> {
+        self.inner.poll_unpin(cx).map_err(map_join_error)
+    }
+}
+
+// Join Sets
+
+struct _ComputeJoinSetSharedData<T: Send + Sync + 'static> {
+    // The channel on which to send new results.
+    result_sender: crossbeam::channel::Sender<T>,
+
+    // The total number of results to expect, either in the channel or coming from
+    // still-running tasks
+    incoming_result_count: AtomicUsize,
+}
+
+pub struct ComputeJoinSet<T: Send + Sync + 'static> {
+    thread_pool: Arc<ThreadPool>,
+
+    receiver: crossbeam::channel::Receiver<T>,
+
+    shared_data: Arc<_ComputeJoinSetSharedData<T>>,
+}
+
+impl<T: Send + Sync + 'static> ComputeJoinSet<T> {
+    /// Creates a new `ComputeJoinSet` with the provided Rayon `ThreadPool`.
+    pub(crate) fn new(thread_pool: Arc<ThreadPool>) -> Self {
+        let (result_sender, receiver) = crossbeam::channel::unbounded();
+        Self {
+            thread_pool,
+            receiver,
+            shared_data: Arc::new(_ComputeJoinSetSharedData {
+                result_sender,
+                incoming_result_count: AtomicUsize::new(0),
+            }),
+        }
+    }
+
+    /// Spawns a new task onto the Rayon threadpool.
+    pub fn spawn<F>(&self, task: F)
+    where
+        F: FnOnce() -> T + Send + 'static,
+    {
+        let shared_data = self.shared_data.clone();
+
+        // One more task to expect incoming.
+        shared_data.incoming_result_count.fetch_add(1, Ordering::SeqCst);
+
+        self.thread_pool.spawn(move || {
+            let result = task();
+            // Send the result back to the ComputeJoinSet.
+            if shared_data.result_sender.send(result).is_err() {
+                // Receiver has been dropped, ignore the result but this is a programming bug; likely
+                // going to occur only under a panic rewind threading situation.
+                if cfg!(debug_assertions) {
+                    eprintln!("Error in ComputeJoinSet: Send failed as receiver dropped.");
+                }
+                // This one errored out, so nothing more to be done.
+                shared_data.incoming_result_count.fetch_sub(1, Ordering::SeqCst);
+            }
+        });
+    }
+
+    /// Tries to get the next completed task result if available without blocking;
+    /// If not present, then
+    pub fn try_join_next(&mut self) -> Result<Option<T>> {
+        let ret = match self.receiver.try_recv() {
+            Ok(v) => Ok(Some(v)),
+            Err(crossbeam::channel::TryRecvError::Empty) => {
+                return Ok(None);
+            },
+            Err(e) => Err(XetRuntimeError::Other(format!("JoinSet: Channel discarded/send closed ({e})."))),
+        };
+
+        self.shared_data.incoming_result_count.fetch_sub(1, Ordering::SeqCst);
+
+        ret
+    }
+
+    /// Waits for the next completed task result, blocking if necessary.
+    /// Returns `None` if all tasks are complete.
+    pub fn join_next(&mut self) -> Result<Option<T>> {
+        // Note: the &mut self here forces us to have exclusive access; otherwise
+        // there is a race condition in which another join_next steals the result between
+        // testing the sender count and receiving the result, causing this join_next to
+        // block forever.  Exclusive access prevents this.
+        if self.shared_data.incoming_result_count.load(Ordering::SeqCst) == 0 {
+            // None left to account for.
+            return Ok(None);
+        }
+
+        let ret = match self.receiver.recv() {
+            Ok(result) => Ok(Some(result)),
+            Err(e) => Err(XetRuntimeError::Other(format!("JoinSet: Channel discarded/send closed ({e})."))),
+        };
+        self.shared_data.incoming_result_count.fetch_sub(1, Ordering::SeqCst);
+        ret
+    }
+
+    /// Checks if no tasks are present or all tasks have completed.
+    pub fn is_empty(&self) -> bool {
+        self.shared_data.incoming_result_count.load(Ordering::Acquire) == 0
+    }
+
+    /// Returns the number of tasks currently running or completed with results waiting.
+    pub fn len(&self) -> usize {
+        self.shared_data.incoming_result_count.load(Ordering::Acquire)
+    }
+}
+
+/// An async wrapper class around the tokio JoinSet that provides two additional things:
+/// - tasks are spawned explicitly on the runtime handle.
+/// - This will allow us to swap out tokio perhaps down the road if we want to...
+pub struct AsyncJoinSet<T> {
+    join_set: tokio::task::JoinSet<T>,
+    runtime_handle: tokio::runtime::Handle,
+}
+
+impl<T> AsyncJoinSet<T>
+where
+    T: Send + 'static,
+{
+    pub(crate) fn new(runtime_handle: tokio::runtime::Handle) -> Self {
+        Self {
+            join_set: tokio::task::JoinSet::new(),
+            runtime_handle,
+        }
+    }
+
+    /// Spawns a task on the runtime associated with this wrapper
+    pub fn spawn<F>(&mut self, task: F) -> tokio::task::AbortHandle
+    where
+        F: std::future::Future<Output = T> + Send + 'static,
+    {
+        self.join_set.spawn_on(task, &self.runtime_handle)
+    }
+
+    /// Aborts all tasks in the join set
+    pub fn abort_all(&mut self) {
+        self.join_set.abort_all();
+    }
+
+    /// Removes and returns the next task result from the join set
+    pub async fn join_next(&mut self) -> Result<Option<T>> {
+        self.join_set.join_next().await.transpose().map_err(map_join_error)
+    }
+
+    /// Returns whether the join set is empty
+    pub fn is_empty(&self) -> bool {
+        self.join_set.is_empty()
+    }
+
+    /// Returns the number of tasks currently in the join set
+    pub fn len(&self) -> usize {
+        self.join_set.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use rayon::ThreadPoolBuilder;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_async_join_set() {
+        let handle = tokio::runtime::Handle::try_current().unwrap().clone();
+
+        let mut join_set = AsyncJoinSet::new(handle);
+
+        for i in 0..5 {
+            join_set.spawn(async move { i * 2 });
+        }
+
+        let mut results = vec![];
+
+        while let Some(result) = join_set.join_next().await.unwrap() {
+            results.push(result);
+        }
+
+        results.sort();
+        assert_eq!(results, vec![0, 2, 4, 6, 8]);
+    }
+
+    #[test]
+    fn test_spawn_and_join_next() {
+        let thread_pool = Arc::new(ThreadPoolBuilder::new().num_threads(1).build().unwrap());
+        let mut join_set = ComputeJoinSet::new(thread_pool);
+
+        // Spawn some tasks
+        for i in 0..5 {
+            join_set.spawn(move || i * 2);
+        }
+
+        // Collect results
+        let mut results = vec![];
+        while let Ok(Some(result)) = join_set.join_next() {
+            results.push(result);
+        }
+
+        // Ensure all tasks completed
+        results.sort();
+        assert_eq!(results, vec![0, 2, 4, 6, 8]);
+    }
+
+    #[test]
+    fn test_try_join_next() {
+        let thread_pool = Arc::new(ThreadPoolBuilder::new().num_threads(2).build().unwrap());
+        let mut join_set = ComputeJoinSet::new(thread_pool);
+
+        // Spawn a task
+        join_set.spawn(|| 42);
+
+        assert!(!join_set.is_empty());
+        assert_eq!(join_set.len(), 1);
+
+        // Allow some time for the task to complete
+        std::thread::sleep(Duration::from_millis(100));
+
+        assert!(!join_set.is_empty());
+        assert_eq!(join_set.len(), 1);
+
+        // Try to join next result
+        let result = join_set.try_join_next();
+        assert_eq!(result.unwrap(), Some(42));
+        assert!(join_set.is_empty());
+        assert_eq!(join_set.len(), 0);
+
+        // No more tasks left
+        let result = join_set.try_join_next();
+        assert_eq!(result.unwrap(), None);
+        assert!(join_set.is_empty());
+        assert_eq!(join_set.len(), 0);
+    }
+
+    #[test]
+    fn test_is_empty() {
+        let thread_pool = Arc::new(ThreadPoolBuilder::new().num_threads(2).build().unwrap());
+        let mut join_set = ComputeJoinSet::new(thread_pool);
+
+        assert!(join_set.is_empty());
+
+        // Spawn a task
+        join_set.spawn(|| {
+            std::thread::sleep(Duration::from_millis(100));
+            1
+        });
+
+        assert!(!join_set.is_empty());
+
+        // Wait for the task to complete
+        let r = join_set.join_next().unwrap();
+
+        assert_eq!(r, Some(1));
+
+        assert!(join_set.is_empty());
+
+        let r = join_set.join_next().unwrap();
+        assert!(r.is_none());
+    }
+
+    #[test]
+    fn test_no_block_on_empty_join_next() {
+        let thread_pool = Arc::new(ThreadPoolBuilder::new().num_threads(2).build().unwrap());
+        let mut join_set = ComputeJoinSet::<bool>::new(thread_pool);
+
+        // No tasks spawned
+        assert_eq!(join_set.join_next().unwrap(), None);
+    }
+
+    #[test]
+    fn test_multiple_tasks_1() {
+        let thread_pool = Arc::new(ThreadPoolBuilder::new().num_threads(4).build().unwrap());
+        let mut join_set = ComputeJoinSet::new(thread_pool);
+
+        // Spawn multiple tasks
+        let mut reference = Vec::new();
+        for i in 0..100 {
+            join_set.spawn(move || i * i);
+            reference.push(i * i);
+        }
+
+        let mut results = vec![];
+        while let Ok(Some(result)) = join_set.join_next() {
+            results.push(result);
+        }
+
+        results.sort();
+        reference.sort();
+        assert_eq!(results, reference);
+    }
+    #[test]
+    fn test_multiple_tasks_2() {
+        let thread_pool = Arc::new(ThreadPoolBuilder::new().num_threads(4).build().unwrap());
+        let mut join_set = ComputeJoinSet::new(thread_pool);
+
+        // Spawn multiple tasks
+        let mut reference = Vec::new();
+        let mut results = vec![];
+
+        for i in 0..200 {
+            join_set.spawn(move || {
+                std::thread::sleep(Duration::from_millis(i % 10));
+                i * i
+            });
+
+            reference.push(i * i);
+
+            while let Some(v) = join_set.try_join_next().unwrap() {
+                results.push(v);
+            }
+        }
+
+        while let Ok(Some(result)) = join_set.join_next() {
+            results.push(result);
+        }
+
+        results.sort();
+        reference.sort();
+        assert_eq!(results, reference);
+    }
+}

--- a/xet_runtime/src/runtime_executor.rs
+++ b/xet_runtime/src/runtime_executor.rs
@@ -1,0 +1,524 @@
+use std::future::Future;
+use std::sync::atomic::Ordering::SeqCst;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use lazy_static::lazy_static;
+use tracing::debug;
+
+use crate::errors::{map_join_error, Result, RuntimeCancellation, XetRuntimeError};
+use crate::primatives::{AsyncJoinSet, ComputeJoinHandle, ComputeJoinSet};
+use crate::AsyncJoinHandle;
+
+const ASYNC_THREADPOOL_NUM_WORKER_THREADS: usize = 4; // 4 active threads
+const ASYNC_THREADPOOL_THREAD_ID_PREFIX: &str = "hf-xet-async"; // thread names will be hf-xet-async-0, hf-xet-async-1, etc.
+const THREADPOOL_STACK_SIZE: usize = 8_000_000; // 8MB stack size
+
+const COMPUTE_THREADPOOL_NUM_WORKER_THREADS: usize = 4;
+
+const COMPUTE_THREADPOOL_THREAD_ID_PREFIX: &str = "hf-xet-comp"; // thread names will be hf-xet-comp-0, hf-xet-comp-1, etc.
+
+lazy_static! {
+    static ref XET_RUNTIME: XetRuntime = XetRuntime::new().expect("Error Starting Xet Runtime");
+}
+
+pub fn xet_runtime() -> &'static XetRuntime {
+    &XET_RUNTIME
+}
+
+#[inline]
+pub fn cancellation_requested() -> bool {
+    xet_runtime().cancelation_requested()
+}
+
+/// Call this function within long-running loops or tasks to check whether a cancellation request
+/// (e.g. a CTRL-C press) has happened.  If so, it returns an error that can be handled outside.  
+#[inline]
+pub fn check_runtime_cancellation() -> std::result::Result<(), RuntimeCancellation> {
+    xet_runtime().check_for_cancellation()
+}
+
+#[derive(Debug)]
+pub struct XetRuntime {
+    //
+    async_runtime: tokio::runtime::Runtime,
+
+    // The number of external threads calling into this threadpool
+    external_executor_count: AtomicUsize,
+
+    // Are we in the middle of a sigint shutdown?
+    cancelation_requested: AtomicBool,
+
+    // The rayon threadpool for tasks?
+    compute_threadpool: Arc<rayon::ThreadPool>,
+}
+
+impl XetRuntime {
+    /// Constructs the runtime.  Should typically be used from runtime() as the lazily initialized
+    /// static global above
+    pub fn new() -> Result<Self> {
+        let async_runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(ASYNC_THREADPOOL_NUM_WORKER_THREADS) // 4 active threads
+            .thread_name_fn(get_async_thread_name) // thread names will be hf-xet-0, hf-xet-1, etc.
+            .thread_stack_size(THREADPOOL_STACK_SIZE) // 8MB stack size, default is 2MB
+            .enable_all() // enable all features, including IO/Timer/Signal/Reactor
+            .build()
+            .map_err(XetRuntimeError::AsyncRuntimeInitializationError)?;
+
+        let compute_threadpool = rayon::ThreadPoolBuilder::new()
+            .num_threads(COMPUTE_THREADPOOL_NUM_WORKER_THREADS.min(num_cpus::get() - 2).max(1)) // Use the number of CPUs by default
+            .stack_size(THREADPOOL_STACK_SIZE) // 8MB stack size, default is 2MB
+            .thread_name(|idx| format!("{COMPUTE_THREADPOOL_THREAD_ID_PREFIX}-{idx}"))
+            .build()
+            .map_err(|e| {
+                XetRuntimeError::ComputeRuntimeInitializationError(format!("Failed to initialize thread pool: {:?}", e))
+            })?;
+
+        Ok(Self {
+            async_runtime,
+            external_executor_count: AtomicUsize::new(0),
+            cancelation_requested: AtomicBool::new(false),
+            compute_threadpool: Arc::new(compute_threadpool),
+        })
+    }
+
+    /// Spawns a compute task to be run on the current compute thread pool,
+    /// returning a join handle to the result.  This task may be run in any
+    /// order relative to the other tasks in the worker pool.
+    pub fn spawn_compute_task<T: Send + Sync + 'static>(
+        &self,
+        task: impl FnOnce() -> T + Send + 'static,
+    ) -> Result<ComputeJoinHandle<T>> {
+        self.check_for_cancellation()?;
+
+        let (jh, tx) = ComputeJoinHandle::create();
+
+        self.compute_threadpool.spawn(move || {
+            let result = task();
+            let _ = tx.send(result).map_err(|e| {
+                debug!("Return result on join handle encountered error: {e:?}");
+                e
+            });
+        });
+
+        Ok(jh)
+    }
+
+    /// Spawns a compute task to be run on the current compute thread pool with FIFO
+    /// priority relative to other fifo threads.  All other FIFO spawned tasks will be started before
+    /// this one is started.  This does not mean that this task will *finish* after
+    /// the other tasks.
+    pub fn spawn_compute_task_fifo<T: Send + Sync + 'static>(
+        &self,
+        task: impl FnOnce() -> T + Send + 'static,
+    ) -> Result<ComputeJoinHandle<T>> {
+        self.check_for_cancellation()?;
+
+        let (jh, tx) = ComputeJoinHandle::create();
+
+        self.compute_threadpool.spawn_fifo(move || {
+            let result = task();
+            let _ = tx.send(result).map_err(|e| {
+                debug!("Return result on join handle encountered error: {e:?}");
+                e
+            });
+        });
+
+        Ok(jh)
+    }
+
+    /// From an async context, run a compute task, yielding while that task finishes to avoid tying up an
+    /// async worker.
+    pub async fn run_compute_task_from_async<T: Send + Sync + 'static>(
+        &self,
+        task: impl FnOnce() -> T + Send + 'static,
+    ) -> Result<T> {
+        self.spawn_compute_task(task)?.await
+    }
+
+    /// Run an async task within the current runtime.  Should not be called from within a
+    /// an async worker thread; this may lead to deadlock as it queues a task but then blocks
+    /// and ties up the current worker while waiting for that task to complete.
+    pub fn run_async_task<F>(&self, future: F) -> Result<F::Output>
+    where
+        F: std::future::Future + Send + 'static,
+        F::Output: Send + Sync + 'static,
+    {
+        self.check_for_cancellation()?;
+
+        self.async_runtime.block_on(async move {
+            // Run the actual task on a task worker thread so we can get back information
+            // on issues, including reporting panics as runtime errors.
+            tokio::spawn(future).await.map_err(map_join_error)
+        })
+    }
+
+    /// Spawn an async task to run in the background on the current pool of async worker threads.
+    pub fn spawn_async_task<F>(&self, future: F) -> AsyncJoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + Sync + 'static,
+    {
+        // If the runtime has been shut down, this will immediately abort.
+        AsyncJoinHandle::new(self.async_runtime.spawn(future))
+    }
+
+    /// Runs a set of compute functions in parallel on the input, returning a vector of results.
+    pub fn par_for<F, T, I, E>(&self, inputs: I, func: F) -> std::result::Result<Vec<T>, E>
+    where
+        I: rayon::iter::IntoParallelIterator + Send,
+        F: Fn(I::Item) -> std::result::Result<T, E> + Send + Sync,
+        T: Send,
+        I::Item: Send,
+        E: Send + std::fmt::Debug,
+    {
+        let error = std::sync::Mutex::new(None); // To capture the first error safely across threads.
+        let error_occured = AtomicBool::new(false);
+
+        use rayon::iter::ParallelIterator;
+
+        let results: Vec<Option<T>> = self.compute_threadpool.install(|| {
+            inputs
+                .into_par_iter()
+                .map(|item| {
+                    if error_occured.load(Ordering::Acquire) {
+                        // If an error has already been captured, skip further processing.
+                        return None;
+                    }
+
+                    match func(item) {
+                        Ok(result) => Some(result),
+                        Err(e) => {
+                            // Capture the first error in the Mutex.
+                            error_occured.store(true, Ordering::SeqCst);
+                            *error.lock().unwrap() = Some(e);
+                            None
+                        },
+                    }
+                })
+                .collect()
+        });
+
+        // If an error occurred, return it; otherwise, unwrap the results.
+        if let Some(err) = error.into_inner().unwrap() {
+            Err(err)
+        } else {
+            Ok(results.into_iter().map(|r| r.unwrap()).collect())
+        }
+    }
+
+    /// Runs a set of compute functions in parallel on the input.
+    pub fn par_for_each<F, I, E>(&self, inputs: I, func: F) -> std::result::Result<(), E>
+    where
+        I: rayon::iter::IntoParallelIterator + Send,
+        F: Fn(I::Item) -> std::result::Result<(), E> + Send + Sync,
+        I::Item: Send,
+        E: Send + std::fmt::Debug,
+    {
+        let error = std::sync::Mutex::new(None); // To capture the first error safely across threads.
+        let error_occured = AtomicBool::new(false);
+
+        use rayon::iter::ParallelIterator;
+
+        self.compute_threadpool.install(|| {
+            inputs.into_par_iter().for_each(|item| {
+                if error_occured.load(Ordering::Acquire) {
+                    // If an error has already been captured, skip further processing.
+                    return;
+                }
+
+                if let Err(e) = func(item) {
+                    // Capture the first error in the Mutex.
+                    error_occured.store(true, Ordering::SeqCst);
+                    *error.lock().unwrap() = Some(e);
+                }
+            });
+        });
+
+        // If an error occurred, return it; otherwise, unwrap the results.
+        if let Some(err) = error.into_inner().unwrap() {
+            Err(err)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Enter the runtime from an external call, running the given task as the entry point
+    /// and returning the result.
+    pub fn enter_runtime<Out: Send + Sync>(&self, task: impl FnOnce() -> Out) -> Result<Out> {
+        self.check_for_cancellation()?;
+
+        self.increment_external_executor_count();
+
+        let ret = if self.cancelation_requested() {
+            Err(XetRuntimeError::RuntimeCancellation(RuntimeCancellation {}))
+        } else {
+            Ok(task())
+        };
+
+        self.decrement_external_executor_count();
+        ret
+    }
+
+    /// Enter the runtime from an external call, running the given async task as the entry point
+    /// and returning the result.
+    ///
+    /// This function should ONLY be used by threads outside of tokio; it should not be called
+    /// from within a task running on the runtime worker pool.  Doing so can lead to deadlocking.
+    pub fn enter_runtime_async<F>(&self, future: F) -> Result<F::Output>
+    where
+        F: std::future::Future + Send + 'static,
+        F::Output: Send + Sync,
+    {
+        self.check_for_cancellation()?;
+
+        self.increment_external_executor_count();
+        let ret = self.run_async_task(future);
+        self.decrement_external_executor_count();
+        ret
+    }
+
+    /// Create a JoinSet for use on the compute runtime.  A JoinSet allows a place for spawning a set of tasks
+    /// that can complete out of order.  Results are available as soon as any job completes.
+    pub fn compute_joinset<ResultType: Send + Sync + 'static>(&self) -> ComputeJoinSet<ResultType> {
+        ComputeJoinSet::new(self.compute_threadpool.clone())
+    }
+
+    /// Create an async JoinSet for use on the async runtime.  A JoinSet allows a place for spawning a set of tasks
+    /// that can complete out of order.  Results are available as soon as any job completes.
+    pub fn async_joinset<ResultType: Send + Sync + 'static>(&self) -> AsyncJoinSet<ResultType> {
+        AsyncJoinSet::new(self.async_runtime.handle().clone())
+    }
+
+    /// Gives the number of current calls in the enter_runtime_* methods.
+    #[inline]
+    pub fn external_executor_count(&self) -> usize {
+        self.external_executor_count.load(Ordering::SeqCst)
+    }
+
+    /// Sets a global flag to signal that all tasks should be canceled.  
+    /// It is up to individual tasks to call check_for_cancellation when appropriate,
+    /// preferably as frequently as possible.  
+    pub fn request_task_cancellation(&self) {
+        // Issue the flag to cause all the tasks to cancel.
+        self.cancelation_requested.store(true, Ordering::SeqCst);
+    }
+
+    /// Returns true if we're in the middle of a cancellation request (E.g. CTRL-C).
+    /// and false otherwise.
+    #[inline]
+    pub fn cancelation_requested(&self) -> bool {
+        self.cancelation_requested.load(Ordering::SeqCst)
+    }
+
+    /// If a cancellation has been requested, returns a RuntimeCancellation error.  Otherwise
+    /// does nothing.  
+    #[inline]
+    pub fn check_for_cancellation(&self) -> std::result::Result<(), RuntimeCancellation> {
+        if self.cancelation_requested() {
+            Err(RuntimeCancellation {})
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Increments the count of other threads entering the runtime.
+    #[inline]
+    fn increment_external_executor_count(&self) {
+        self.external_executor_count.fetch_add(1, Ordering::SeqCst);
+    }
+
+    /// Decrements the count of other threads entering the runtime.
+    /// Increments the count of other threads entering the runtime.
+    #[inline]
+    fn decrement_external_executor_count(&self) {
+        let prev_count = self.external_executor_count.fetch_sub(1, Ordering::SeqCst);
+        debug_assert_ne!(prev_count, 0);
+
+        if prev_count == 1 {
+            // This is the last thread leaving the runtime, so make sure the cancellation flag is cleared.
+            self.cancelation_requested.store(false, Ordering::Relaxed);
+        }
+    }
+}
+
+/// gets the name of a new thread for the threadpool. Names are prefixed with
+/// `ASYNC_THREADPOOL_THREAD_ID_PREFIX` and suffixed with a global counter:
+/// e.g. hf-xet-0, hf-xet-1, hf-xet-2, ...
+fn get_async_thread_name() -> String {
+    static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
+    let id = ATOMIC_ID.fetch_add(1, SeqCst);
+    format!("{ASYNC_THREADPOOL_THREAD_ID_PREFIX}-{id}")
+}
+
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_runtime_initialization() {
+        let runtime = XetRuntime::new();
+        assert!(runtime.is_ok(), "Failed to initialize XetRuntime: {:?}", runtime.err());
+    }
+
+    #[test]
+    fn test_spawn_compute_task() {
+        let runtime = XetRuntime::new().unwrap();
+        let handle = runtime.spawn_compute_task(|| 42).unwrap();
+        assert_eq!(handle.join().unwrap(), 42);
+    }
+
+    #[test]
+    fn test_spawn_compute_task_fifo() {
+        let runtime = XetRuntime::new().unwrap();
+        let handle = runtime.spawn_compute_task_fifo(|| 42).unwrap();
+        assert_eq!(handle.join().unwrap(), 42);
+    }
+
+    #[test]
+    fn test_run_compute_task_from_async() {
+        let runtime = Arc::new(XetRuntime::new().unwrap());
+        let runtime_ = runtime.clone();
+        let result = runtime
+            .enter_runtime_async(async move { runtime_.run_compute_task_from_async(|| 42).await.unwrap() })
+            .unwrap();
+        assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn test_run_async_task() {
+        let runtime = XetRuntime::new().unwrap();
+        let result = runtime.run_async_task(async { 42 });
+        assert_eq!(result.unwrap(), 42);
+    }
+
+    #[test]
+    fn test_spawn_async_task() {
+        let runtime = Arc::new(XetRuntime::new().unwrap());
+        let runtime_ = runtime.clone();
+
+        runtime
+            .enter_runtime_async(async move {
+                let handle = runtime_.spawn_async_task(async { 42 });
+
+                let result = handle.await.unwrap();
+                assert_eq!(result, 42);
+            })
+            .unwrap();
+
+        // Now, make sure things can be passed around.
+        let handle = runtime.spawn_async_task(async { 42 });
+
+        runtime
+            .run_async_task(async move {
+                let result = handle.await.unwrap();
+                assert_eq!(result, 42);
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn test_par_for() {
+        let runtime = XetRuntime::new().unwrap();
+        let data = vec![1, 2, 3];
+        let result = runtime.par_for(data, |x| Result::Ok(x + 1)).unwrap();
+        assert_eq!(result, vec![2, 3, 4]);
+    }
+
+    #[test]
+    fn test_par_for_each() {
+        let runtime = XetRuntime::new().unwrap();
+        let data: Vec<_> = (0..500).collect();
+        let result = runtime.par_for_each(&data, |_| Result::Ok(()));
+        assert!(result.is_ok());
+
+        let result = runtime.par_for_each(&data, |x| {
+            if *x == 4 {
+                Err(XetRuntimeError::Other("I don't like the number 4".to_owned()))
+            } else {
+                Ok(())
+            }
+        });
+        assert!(!result.is_ok());
+
+        let data: Vec<_> = (0..500).map(AtomicUsize::new).collect();
+
+        runtime
+            .par_for_each(&data, |x| {
+                x.fetch_add(1, Ordering::Relaxed);
+                Result::Ok(())
+            })
+            .unwrap();
+
+        for (i, r) in data.iter().enumerate() {
+            assert_eq!(i + 1, r.load(Ordering::Relaxed));
+        }
+    }
+
+    #[test]
+    fn test_cancellation_request() {
+        let runtime = XetRuntime::new().unwrap();
+        runtime.request_task_cancellation();
+        assert!(runtime.cancelation_requested());
+    }
+
+    #[test]
+    fn test_check_for_cancellation() {
+        let runtime = XetRuntime::new().unwrap();
+        runtime.request_task_cancellation();
+        let result = runtime.check_for_cancellation();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_external_executor_count() {
+        let runtime = Arc::new(XetRuntime::new().unwrap());
+
+        assert_eq!(runtime.external_executor_count(), 0);
+
+        let r1 = runtime.clone();
+        runtime
+            .enter_runtime(move || {
+                assert_eq!(r1.external_executor_count(), 1);
+            })
+            .unwrap();
+
+        assert_eq!(runtime.external_executor_count(), 0);
+
+        let r2 = runtime.clone();
+        runtime
+            .enter_runtime_async(async move {
+                assert_eq!(r2.external_executor_count(), 1);
+            })
+            .unwrap();
+
+        assert_eq!(runtime.external_executor_count(), 0);
+    }
+
+    #[test]
+    fn test_compute_joinset() {
+        let runtime = XetRuntime::new().unwrap();
+        let mut joinset = runtime.compute_joinset();
+
+        // Test that it's repeatable too
+        for _iter in [0, 1] {
+            joinset.spawn(|| 42);
+            assert!(!joinset.is_empty());
+            assert_eq!(joinset.join_next().unwrap(), Some(42));
+            assert!(joinset.is_empty());
+            assert_eq!(joinset.join_next().unwrap(), None);
+            assert!(joinset.is_empty());
+            assert_eq!(joinset.join_next().unwrap(), None);
+        }
+    }
+
+    #[test]
+    fn test_async_joinset() {
+        let runtime = XetRuntime::new().unwrap();
+        let mut joinset = runtime.async_joinset();
+        joinset.spawn(async { 42 });
+        let result = runtime
+            .run_async_task(async move { (joinset.join_next().await.unwrap(), joinset.join_next().await.unwrap()) })
+            .unwrap();
+        assert_eq!(result, (Some(42), None));
+    }
+}

--- a/xet_runtime/src/runtime_executor.rs
+++ b/xet_runtime/src/runtime_executor.rs
@@ -3,8 +3,8 @@ use std::sync::atomic::Ordering::SeqCst;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 
+use error_printer::ErrorPrinter;
 use lazy_static::lazy_static;
-use tracing::debug;
 
 use crate::errors::{map_join_error, Result, RuntimeCancellation, XetRuntimeError};
 use crate::primatives::{AsyncJoinSet, ComputeJoinHandle, ComputeJoinSet};
@@ -184,10 +184,7 @@ impl XetRuntime {
 
         self.compute_threadpool.spawn(move || {
             let result = task();
-            let _ = tx.send(result).map_err(|e| {
-                debug!("Return result on join handle encountered error: {e:?}");
-                e
-            });
+            let _ = tx.send(result).debug_error("Return result on join handle encountered error.");
         });
 
         Ok(jh)
@@ -215,10 +212,7 @@ impl XetRuntime {
 
         self.compute_threadpool.spawn_fifo(move || {
             let result = task();
-            let _ = tx.send(result).map_err(|e| {
-                debug!("Return result on join handle encountered error: {e:?}");
-                e
-            });
+            let _ = tx.send(result).debug_error("Return result on join handle encountered error.");
         });
 
         Ok(jh)

--- a/xet_runtime/src/runtime_executor.rs
+++ b/xet_runtime/src/runtime_executor.rs
@@ -24,7 +24,7 @@ lazy_static! {
 
 /// Returns a reference to the global runtime object.
 pub fn xet_runtime() -> &'static XetRuntime {
-    &XET_RUNTIME.as_ref().expect("Error initializing Xet Runtime")
+    XET_RUNTIME.as_ref().expect("Error initializing Xet Runtime")
 }
 
 /// Returns a reference to the global runtime object, with error propegation.  This method

--- a/xet_runtime/src/runtime_executor.rs
+++ b/xet_runtime/src/runtime_executor.rs
@@ -354,6 +354,9 @@ fn get_async_thread_name() -> String {
 }
 
 mod tests {
+
+    // The rust nightly incorrectly thinks the use statement below is unused.
+    #[allow(unused_imports)]
     use super::*;
 
     #[test]


### PR DESCRIPTION
This PR introduces a new Xet Runtime class with both synchronous and async compute runtimes.  There are several design objectives:

1. Allow us to isolate the async part of our codebase to only the portions that really need it.  
2. Abstract away the specific async runtime (now tokio) to allow us to swap it out for lighter weight runtime down the road if desired.
3. Expose compute focused non-async primitives (e.g. par_for, JoinSet, JoinHandle) that we use frequently in the async world, but that could easily be done in the multithreaded sync world instead. 
4. Expose reliable ways to call into async routines from the non-async runtime. 
5. Lay the groundwork for better CTRL-C cancellations. 

Internally, the runtime maintains both a small tokio runtime and a small rayon threadpool for the parallel compute part. 

### Cancellation check
```rust
xet_runtime().check_runtime_cancellation()?; // Returns an error if cancellation is requested
```

### Background compute
```rust
let handle = xet_runtime().spawn_compute_task(|| ...)?;

let result = handle.join()?; // Wait for the result
```

### Run an async task from non-async code runtime.
```rust
let result = xet_runtime().run_async_task(async { ... })?;
```

### Run a long-running task on the compute threadpool from an async context
```rust
let result = xet_runtime().run_compute_task_from_async(|| ...).await?;
```

### Spawn a background async task
```rust
let handle = xet_runtime().spawn_async_task(async { ... });  // async or non-async
let result = handle.await?; // In async code 
let result = handle.join()?; // In non-async code
```

### par_for
```rust
let results: Vec<_> = xet_runtime().par_for(inputs, |x| { let v = ... ; Ok(v) })?; 
```

###  `par_for_each`
```rust
xet_runtime().par_for_each(inputs, |x| { do_something(); Ok(()) })?; 
```

### Compute JoinSet
```rust
let mut join_set = xet_runtime().compute_joinset();
join_set.spawn(|| 42);
join_set.spawn(|| 99);
while let Some(result) = join_set.join_next()? { ... } 
```

### Async JoinSet
```rust
let mut join_set = xet_runtime().async_joinset();
join_set.spawn(async { 42 });
join_set.spawn(async { 99 });
while let Some(result) = join_set.join_next().await? { ... }
```

### External Entry Points

To call in to the runtime from python or other places use enter_runtime or enter_runtime_async.  These are similar to the above but have specific error reporting and cancelation bookkeeping. 

```rust
let result = xet_runtime().enter_runtime(|| {...})?;
let result = xet_runtime().enter_runtime_async(async { ... } )?; 
```


