### PR TITLE
Update release.yml, fix GH publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,5 +194,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
       - name: Publish to GitHub Releases
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           gh release upload ${{github.event.release.tag_name}} wheels-*/*


### PR DESCRIPTION
Adds GH_TOKEN env variable to GitHub publish job.