### PR TITLE
Deadlock fix.

### DIFF
--- a/hf_xet/Cargo.lock
+++ b/hf_xet/Cargo.lock
@@ -225,11 +225,11 @@ dependencies = [
  "reqwest-middleware",
  "reqwest-retry",
  "tempfile",
+ "thiserror 2.0.11",
  "tokio",
  "tracing",
  "url",
  "utils",
- "thiserror",
 ]
 
 [[package]]
@@ -245,10 +245,10 @@ dependencies = [
  "merkledb",
  "merklehash",
  "rand 0.8.5",
+ "thiserror 2.0.11",
  "tokio",
  "tokio-util",
  "tracing",
- "thiserror",
 ]
 
 [[package]]
@@ -258,7 +258,7 @@ dependencies = [
  "merklehash",
  "serde",
  "serde_repr",
- "thiserror",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -301,9 +301,9 @@ dependencies = [
  "mockall",
  "once_cell",
  "rand 0.8.5",
+ "thiserror 2.0.11",
  "tracing",
  "utils",
- "thiserror",
 ]
 
 [[package]]
@@ -473,11 +473,11 @@ dependencies = [
  "sha2",
  "static_assertions",
  "tempfile",
+ "thiserror 2.0.11",
  "tokio",
  "toml",
  "tracing",
  "utils",
- "thiserror",
 ]
 
 [[package]]
@@ -1433,11 +1433,11 @@ dependencies = [
  "regex",
  "static_assertions",
  "tempdir",
+ "thiserror 2.0.11",
  "tokio",
  "tracing",
  "utils",
  "uuid",
- "thiserror",
 ]
 
 [[package]]
@@ -1475,9 +1475,9 @@ dependencies = [
  "rustc-hash",
  "serde",
  "tempfile",
+ "thiserror 2.0.11",
  "tracing",
  "walkdir",
- "thiserror",
 ]
 
 [[package]]
@@ -1869,7 +1869,7 @@ dependencies = [
  "memchr",
  "parking_lot 0.12.3",
  "protobuf",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2063,7 +2063,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2216,7 +2216,7 @@ dependencies = [
  "http 1.1.0",
  "reqwest 0.12.9",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
  "tower-service",
 ]
 
@@ -2717,7 +2717,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+dependencies = [
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -2725,6 +2734,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2975,9 +2995,9 @@ dependencies = [
  "merklehash",
  "parking_lot 0.11.2",
  "pin-project",
+ "thiserror 2.0.11",
  "tokio",
  "tracing",
- "thiserror",
 ]
 
 [[package]]
@@ -3390,23 +3410,6 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
-
-[[package]]
-name = "xet-error-impl"
-version = "1.0.50"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.87",
-]
-
-[[package]]
-name = "thiserror"
-version = "0.14.5"
-dependencies = [
- "lazy_static",
- "xet-error-impl",
-]
 
 [[package]]
 name = "yoke"

--- a/hf_xet/src/lib.rs
+++ b/hf_xet/src/lib.rs
@@ -145,7 +145,7 @@ impl PyPointerFile {
 }
 
 #[pymodule]
-pub fn hf_xet(py : Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
+pub fn hf_xet(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(upload_files, m)?)?;
     m.add_function(wrap_pyfunction!(download_files, m)?)?;
     m.add_class::<PyPointerFile>()?;

--- a/hf_xet/src/lib.rs
+++ b/hf_xet/src/lib.rs
@@ -151,6 +151,6 @@ pub fn hf_xet(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyPointerFile>()?;
 
     // Init the threadpool
-    init_threadpool(py)?;
+    runtime::init_threadpool(py)?;
     Ok(())
 }

--- a/hf_xet/src/lib.rs
+++ b/hf_xet/src/lib.rs
@@ -145,9 +145,12 @@ impl PyPointerFile {
 }
 
 #[pymodule]
-pub fn hf_xet(m: &Bound<'_, PyModule>) -> PyResult<()> {
+pub fn hf_xet(py : Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(upload_files, m)?)?;
     m.add_function(wrap_pyfunction!(download_files, m)?)?;
     m.add_class::<PyPointerFile>()?;
+
+    // Init the threadpool
+    init_threadpool(py)?;
     Ok(())
 }

--- a/hf_xet/src/log.rs
+++ b/hf_xet/src/log.rs
@@ -1,5 +1,5 @@
 use std::env;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use pyo3::Python;
 use tracing_subscriber::filter::FilterFn;
@@ -8,7 +8,7 @@ use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Layer};
 use utils::ThreadPool;
 
-use crate::log_buffer::{get_telemetry_task, LogBufferLayer, TELEMETRY_PRE_ALLOC_BYTES};
+use crate::log_buffer::{get_telemetry_task, LogBufferLayer, TelemetryTaskInfo, TELEMETRY_PRE_ALLOC_BYTES};
 
 /// Default log level for the library to use. Override using `RUST_LOG` env variable.
 #[cfg(not(debug_assertions))]
@@ -17,7 +17,17 @@ const DEFAULT_LOG_LEVEL: &str = "warn";
 #[cfg(debug_assertions)]
 const DEFAULT_LOG_LEVEL: &str = "info";
 
-pub fn initialize_logging(py: Python, runtime: Arc<ThreadPool>) {
+lazy_static::lazy_static! {
+    static ref GLOBAL_TELEMETRY_TASK_INFO : Mutex<(bool, Option<TelemetryTaskInfo>)> = Mutex::new((false, None));
+}
+
+pub fn get_or_init_global_logging(py: Python) -> Option<TelemetryTaskInfo> {
+    let mut telemetry_task_info_lg = GLOBAL_TELEMETRY_TASK_INFO.lock().unwrap();
+
+    if telemetry_task_info_lg.0 {
+        return telemetry_task_info_lg.1.clone();
+    }
+
     let fmt_layer = tracing_subscriber::fmt::layer()
         .with_line_number(true)
         .with_file(true)
@@ -30,10 +40,12 @@ pub fn initialize_logging(py: Python, runtime: Arc<ThreadPool>) {
 
     if env::var("HF_HUB_DISABLE_TELEMETRY").as_deref() == Ok("1") {
         tracing_subscriber::registry().with(fmt_layer).with(filter_layer).init();
+        *telemetry_task_info_lg = (true, None);
+        None
     } else {
         let telemetry_buffer_layer = LogBufferLayer::new(py, TELEMETRY_PRE_ALLOC_BYTES);
-        let telemetry_task =
-            get_telemetry_task(telemetry_buffer_layer.buffer.clone(), telemetry_buffer_layer.stats.clone());
+        let telemetry_task_info: TelemetryTaskInfo =
+            (telemetry_buffer_layer.buffer.clone(), telemetry_buffer_layer.stats.clone());
 
         let telemetry_filter_layer =
             telemetry_buffer_layer.with_filter(FilterFn::new(|meta| meta.target() == "client_telemetry"));
@@ -44,6 +56,18 @@ pub fn initialize_logging(py: Python, runtime: Arc<ThreadPool>) {
             .with(telemetry_filter_layer)
             .init();
 
+        *telemetry_task_info_lg = (true, Some(telemetry_task_info.clone()));
+        Some(telemetry_task_info)
+    }
+}
+
+pub fn initialize_runtime_logging(py: Python, runtime: Arc<ThreadPool>) {
+    // First get or init the global logging componenents.
+    let telemetry_task_info = get_or_init_global_logging(py);
+
+    // Spawn the telemetry logging.
+    if let Some(tti) = telemetry_task_info {
+        let telemetry_task = get_telemetry_task(tti);
         let _telemetry_task = runtime.spawn(telemetry_task);
     }
 }

--- a/hf_xet/src/log.rs
+++ b/hf_xet/src/log.rs
@@ -17,7 +17,7 @@ const DEFAULT_LOG_LEVEL: &str = "warn";
 #[cfg(debug_assertions)]
 const DEFAULT_LOG_LEVEL: &str = "info";
 
-pub fn init_global_logging(py: Python) -> Option<TelemetryTaskInfo> {
+fn init_global_logging(py: Python) -> Option<TelemetryTaskInfo> {
     let fmt_layer = tracing_subscriber::fmt::layer()
         .with_line_number(true)
         .with_file(true)

--- a/hf_xet/src/log.rs
+++ b/hf_xet/src/log.rs
@@ -1,5 +1,5 @@
 use std::env;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, OnceLock};
 
 use pyo3::Python;
 use tracing_subscriber::filter::FilterFn;
@@ -17,17 +17,7 @@ const DEFAULT_LOG_LEVEL: &str = "warn";
 #[cfg(debug_assertions)]
 const DEFAULT_LOG_LEVEL: &str = "info";
 
-lazy_static::lazy_static! {
-    static ref GLOBAL_TELEMETRY_TASK_INFO : Mutex<(bool, Option<TelemetryTaskInfo>)> = Mutex::new((false, None));
-}
-
-pub fn get_or_init_global_logging(py: Python) -> Option<TelemetryTaskInfo> {
-    let mut telemetry_task_info_lg = GLOBAL_TELEMETRY_TASK_INFO.lock().unwrap();
-
-    if telemetry_task_info_lg.0 {
-        return telemetry_task_info_lg.1.clone();
-    }
-
+pub fn init_global_logging(py: Python) -> Option<TelemetryTaskInfo> {
     let fmt_layer = tracing_subscriber::fmt::layer()
         .with_line_number(true)
         .with_file(true)
@@ -40,7 +30,6 @@ pub fn get_or_init_global_logging(py: Python) -> Option<TelemetryTaskInfo> {
 
     if env::var("HF_HUB_DISABLE_TELEMETRY").as_deref() == Ok("1") {
         tracing_subscriber::registry().with(fmt_layer).with(filter_layer).init();
-        *telemetry_task_info_lg = (true, None);
         None
     } else {
         let telemetry_buffer_layer = LogBufferLayer::new(py, TELEMETRY_PRE_ALLOC_BYTES);
@@ -56,18 +45,19 @@ pub fn get_or_init_global_logging(py: Python) -> Option<TelemetryTaskInfo> {
             .with(telemetry_filter_layer)
             .init();
 
-        *telemetry_task_info_lg = (true, Some(telemetry_task_info.clone()));
         Some(telemetry_task_info)
     }
 }
 
 pub fn initialize_runtime_logging(py: Python, runtime: Arc<ThreadPool>) {
+    static GLOBAL_TELEMETRY_TASK_INFO: OnceLock<Option<TelemetryTaskInfo>> = OnceLock::new();
+
     // First get or init the global logging componenents.
-    let telemetry_task_info = get_or_init_global_logging(py);
+    let telemetry_task_info = GLOBAL_TELEMETRY_TASK_INFO.get_or_init(move || init_global_logging(py));
 
     // Spawn the telemetry logging.
-    if let Some(tti) = telemetry_task_info {
-        let telemetry_task = get_telemetry_task(tti);
+    if let Some(ref tti) = telemetry_task_info {
+        let telemetry_task = get_telemetry_task(tti.clone());
         let _telemetry_task = runtime.spawn(telemetry_task);
     }
 }

--- a/hf_xet/src/log_buffer.rs
+++ b/hf_xet/src/log_buffer.rs
@@ -59,9 +59,9 @@ pub fn get_telemetry_endpoint() -> Option<String> {
     }))
 }
 
-pub type TelemetryTaskInfo = (Arc<Mutex<BipBuffer<u8>>>, Arc<LogBufferStats>); 
+pub type TelemetryTaskInfo = (Arc<Mutex<BipBuffer<u8>>>, Arc<LogBufferStats>);
 
-pub async fn get_telemetry_task(telemetry_task_info : TelemetryTaskInfo) {
+pub async fn get_telemetry_task(telemetry_task_info: TelemetryTaskInfo) {
     let (log_buffer, log_stats) = telemetry_task_info;
     let client = reqwest::Client::new();
     let telemetry_url = format!("{}/{}", get_telemetry_endpoint().unwrap_or_default(), TELEMETRY_SUFFIX);

--- a/hf_xet/src/log_buffer.rs
+++ b/hf_xet/src/log_buffer.rs
@@ -59,7 +59,10 @@ pub fn get_telemetry_endpoint() -> Option<String> {
     }))
 }
 
-pub async fn get_telemetry_task(log_buffer: Arc<Mutex<BipBuffer<u8>>>, log_stats: Arc<LogBufferStats>) {
+pub type TelemetryTaskInfo = (Arc<Mutex<BipBuffer<u8>>>, Arc<LogBufferStats>); 
+
+pub async fn get_telemetry_task(telemetry_task_info : TelemetryTaskInfo) {
+    let (log_buffer, log_stats) = telemetry_task_info;
     let client = reqwest::Client::new();
     let telemetry_url = format!("{}/{}", get_telemetry_endpoint().unwrap_or_default(), TELEMETRY_SUFFIX);
 

--- a/hf_xet/src/runtime.rs
+++ b/hf_xet/src/runtime.rs
@@ -100,16 +100,7 @@ fn signal_check_background_loop() {
     }
 }
 
-// This function initializes the runtime if not present, otherwise returns the existing one.
-fn get_threadpool(py: Python) -> PyResult<Arc<ThreadPool>> {
-    {
-        // First try a read lock to see if it's already initialized.
-        let guard = MULTITHREADED_RUNTIME.read().unwrap();
-        if let Some(ref existing) = *guard {
-            return Ok(existing.clone());
-        }
-    }
-
+pub fn init_threadpool(py: Python) -> PyResult<Arc<ThreadPool>> {
     // Need to initialize. Upgrade to write lock.
     let mut guard = MULTITHREADED_RUNTIME.write().unwrap();
 
@@ -121,9 +112,6 @@ fn get_threadpool(py: Python) -> PyResult<Arc<ThreadPool>> {
     // Create a new Tokio runtime.
     let runtime = Arc::new(ThreadPool::new().map_err(convert_multithreading_error)?);
 
-    // Initialize the logging
-    log::initialize_logging(py, runtime.clone());
-
     // Check the signal handler
     check_sigint_handler()?;
 
@@ -133,8 +121,36 @@ fn get_threadpool(py: Python) -> PyResult<Arc<ThreadPool>> {
     // Spawn a background non-tokio thread to check the sigint flag.
     std::thread::spawn(move || signal_check_background_loop());
 
-    // Return the handle to use to run tasks.
+    // Drop the guard and initialize the logging.
+    //
+    // We want to drop this first is that multiple threads entering this runtime
+    // may cause a deadlock if the thread that has the GIL tries to acquire the runtime,
+    // but then the logging expects the GIL in order to initialize it properly.
+    //
+    // In most cases, this will done on module initialization; however, after CTRL-C, the runtime is
+    // initialized lazily and so putting this here avoids the deadlock (and possibly some info! or other
+    // error statements may not be sent to python if the other thread continues ahead of the logging
+    // being initialized.)
+    drop(guard);
+
+    // Initialize the logging
+    log::initialize_logging(py, runtime.clone());
+
+    // Return the runtime
     Ok(runtime)
+}
+
+// This function initializes the runtime if not present, otherwise returns the existing one.
+fn get_threadpool(py: Python) -> PyResult<Arc<ThreadPool>> {
+    // First try a read lock to see if it's already initialized.
+    {
+        let guard = MULTITHREADED_RUNTIME.read().unwrap();
+        if let Some(ref existing) = *guard {
+            return Ok(existing.clone());
+        }
+    }
+    // Init and return
+    init_threadpool(py)
 }
 
 fn convert_multithreading_error(e: MultithreadedRuntimeError) -> PyErr {

--- a/hf_xet/src/runtime.rs
+++ b/hf_xet/src/runtime.rs
@@ -134,7 +134,7 @@ pub fn init_threadpool(py: Python) -> PyResult<Arc<ThreadPool>> {
     drop(guard);
 
     // Initialize the logging
-    log::initialize_logging(py, runtime.clone());
+    log::initialize_runtime_logging(py, runtime.clone());
 
     // Return the runtime
     Ok(runtime)


### PR DESCRIPTION
Fix for issue where: 
- multiple python threads call into download_files.  
- Thread 1 begins to initializes the runtime, including logging. 
- Thread 2 acquires the GIL but then blocks on the init lock on the runtime. 
- Thread 1 hits the logging section, which requires the GIL, and is blocked. 

Fix is to: 
- Initialize logging and runtime on module load.  
- Delay initializing logging until after runtime write lock is released for the case where CTRL-C forces the runtime to be re-initialized. 