### PR TITLE
in-memory MDBShardFile cache. 

### DIFF
--- a/data/src/remote_shard_interface.rs
+++ b/data/src/remote_shard_interface.rs
@@ -258,7 +258,7 @@ impl RemoteShardInterface {
         Ok(())
     }
 
-    pub fn merge_shards(&self) -> Result<JoinHandle<std::result::Result<Vec<MDBShardFile>, MDBShardError>>> {
+    pub fn merge_shards(&self) -> Result<JoinHandle<std::result::Result<Vec<Arc<MDBShardFile>>, MDBShardError>>> {
         let session_dir = self.shard_session_directory()?;
 
         let merged_shards_jh = self
@@ -268,7 +268,7 @@ impl RemoteShardInterface {
         Ok(merged_shards_jh)
     }
 
-    pub async fn upload_and_register_shards(&self, shards: Vec<MDBShardFile>) -> Result<()> {
+    pub async fn upload_and_register_shards(&self, shards: Vec<Arc<MDBShardFile>>) -> Result<()> {
         if shards.is_empty() {
             return Ok(());
         }


### PR DESCRIPTION
This implements a simple cache of Path -> MDBShardFile instances in order to speed up instantiation of a ShardFileManager across multiple calls to download_files or upload_files.  From the profiling work, this takes a significant amount of time.   Creating a MDBShardFile object requires loading the file header, and this ends up taking much of the time when done repeatedly. 

This PR changes the operative type used everywhere to Arc<MDBShardFile>, and keeps a global hashmap of PathBuf -> Arc<MDBShardFile> to avoid having to redo this step for all shards every time a new shard file manager is created.  

The full solution to this problem is a persistent index across shards, but this eliminates one of the major pain points, especially for downloads.  