### PR TITLE
Download benchmark results: set concurrent range gets to 8

### DIFF
--- a/cas_client/src/remote_client.rs
+++ b/cas_client/src/remote_client.rs
@@ -32,7 +32,7 @@ pub const PREFIX_DEFAULT: &str = "default";
 
 const NUM_RETRIES: usize = 5;
 const BASE_RETRY_DELAY_MS: u64 = 3000;
-const NUM_CONCURRENT_RANGE_GETS: usize = 4;
+const NUM_CONCURRENT_RANGE_GETS: usize = 8;
 
 type RangeDownloadSingleFlight = Arc<Group<(Vec<u8>, Vec<u32>), CasClientError>>;
 


### PR DESCRIPTION
From the results of the benchmarks, we should bump up the number of ranges downloaded at a time to a maximum of 8. With no change to the number of threads used.

---

details:
- the benchmark is not comprehensive over all data types. Only file tested was a 5 GB safetensors file with 75 terms and largely no dedupe. The environment used was a t3.2xl ec2 instance; fast link to s3.
- the benchmark showed that the current chunk cache is a significant bottleneck (causing download times to nearly triple ~15s -> ~40s). Cache changes will be addressed in later pull request/s.
- Changing the number of system threads used had largely no/minor impact on the download time.
- Changing the number of maximum buffered terms did have an impact.
  - with caching disabled 16 was marginally better than 8
  - with caching enabled 8 was marginally better than 16
  - in any case 4 (current) was too low
  - attempting to download all terms at once has a marginal benefit with caching disabled, while yielding worse performance with the current caching implementation likely stemming from lock contention.