### PR TITLE
Fragmentation Prevention

### DIFF
--- a/data/src/clean.rs
+++ b/data/src/clean.rs
@@ -550,7 +550,7 @@ impl Cleaner {
                 // This is new data.
                 let add_new_data;
 
-                if tracking_info.current_cas_block_hashes.get(&chunk.hash).is_some() && !forced_nodedupe {
+                if tracking_info.current_cas_block_hashes.contains_key(&chunk.hash) && !forced_nodedupe {
                     let idx = tracking_info.current_cas_block_hashes.get(&chunk.hash).unwrap();
                     let idx = *idx;
                     // This chunk will get the CAS hash updated when the local CAS block

--- a/data/src/clean.rs
+++ b/data/src/clean.rs
@@ -497,6 +497,7 @@ impl Cleaner {
 
             // check the fragmentation state and if it is pretty fragmented
             // we skip dedupe
+            let mut forced_nodedupe = false;
             if let Some((n_deduped, _)) = dedupe_query {
                 if let Some(chunks_per_range) = tracking_info.rolling_chunks_per_range() {
                     if chunks_per_range < MIN_N_CHUNKS_PER_RANGE {
@@ -507,6 +508,7 @@ impl Cleaner {
                         // the chunks per range and so we skip it.
                         if (n_deduped as f32) < chunks_per_range {
                             dedupe_query = None;
+                            forced_nodedupe = true;
                         }
                     }
                 }
@@ -548,7 +550,8 @@ impl Cleaner {
                 // This is new data.
                 let add_new_data;
 
-                if let Some(idx) = tracking_info.current_cas_block_hashes.get(&chunk.hash) {
+                if tracking_info.current_cas_block_hashes.get(&chunk.hash).is_some() && !forced_nodedupe {
+                    let idx = tracking_info.current_cas_block_hashes.get(&chunk.hash).unwrap();
                     let idx = *idx;
                     // This chunk will get the CAS hash updated when the local CAS block
                     // is full and registered.

--- a/data/src/clean.rs
+++ b/data/src/clean.rs
@@ -26,7 +26,9 @@ use utils::progress::ProgressUpdater;
 use utils::ThreadPool;
 
 use crate::chunking::{chunk_target_default, ChunkYieldType};
-use crate::constants::{MIN_SPACING_BETWEEN_GLOBAL_DEDUP_QUERIES, NRANGES_IN_STREAMING_FRAGMENTATION_ESTIMATOR, MIN_N_CHUNKS_PER_RANGE};
+use crate::constants::{
+    MIN_N_CHUNKS_PER_RANGE, MIN_SPACING_BETWEEN_GLOBAL_DEDUP_QUERIES, NRANGES_IN_STREAMING_FRAGMENTATION_ESTIMATOR,
+};
 use crate::data_processing::CASDataAggregator;
 use crate::errors::DataProcessingError::*;
 use crate::errors::Result;
@@ -58,19 +60,19 @@ struct DedupFileTrackingInfo {
     current_cas_block_hashes: HashMap<MerkleHash, usize>,
     cas_data: CASDataAggregator,
     /// This tracks the number of chunks in each of the last N ranges
-    rolling_last_nranges: VecDeque<usize>, 
+    rolling_last_nranges: VecDeque<usize>,
     /// This tracks the total number of chunks in the last N ranges
-    rolling_nranges_chunks: usize 
+    rolling_nranges_chunks: usize,
 }
 
 impl DedupFileTrackingInfo {
-    fn increment_last_range_in_fragmentation_estimate(&mut self, nchunks:usize) {
+    fn increment_last_range_in_fragmentation_estimate(&mut self, nchunks: usize) {
         if let Some(back) = self.rolling_last_nranges.back_mut() {
             *back += nchunks;
             self.rolling_nranges_chunks += nchunks;
         }
     }
-    fn add_range_to_fragmentation_estimate(&mut self, nchunks:usize) {
+    fn add_range_to_fragmentation_estimate(&mut self, nchunks: usize) {
         self.rolling_last_nranges.push_back(nchunks);
         self.rolling_nranges_chunks += nchunks;
         if self.rolling_last_nranges.len() > NRANGES_IN_STREAMING_FRAGMENTATION_ESTIMATOR {
@@ -79,7 +81,7 @@ impl DedupFileTrackingInfo {
     }
     /// Returns the average number of chunks per range
     /// None if there is is not enough data for an estimate
-    fn rolling_chunks_per_range(&self)->Option<f32> {
+    fn rolling_chunks_per_range(&self) -> Option<f32> {
         if self.rolling_last_nranges.len() < NRANGES_IN_STREAMING_FRAGMENTATION_ESTIMATOR {
             None
         } else {

--- a/data/src/constants.rs
+++ b/data/src/constants.rs
@@ -47,6 +47,10 @@ pub const FILE_RECONSTRUCTION_CACHE_SIZE: usize = 65536;
 pub const NRANGES_IN_STREAMING_FRAGMENTATION_ESTIMATOR: usize = 128;
 
 /// Minimum number of chunks per range. Used to control fragmentation
-/// This targets an average of 1MB per range
-pub const MIN_N_CHUNKS_PER_RANGE_LOW: f32 = 4.0;
-pub const MIN_N_CHUNKS_PER_RANGE_HIGH: f32 = 8.0;
+/// This targets an average of 1MB per range.
+/// The hysteresis factor multiplied by the target Chunks Per Range (CPR) controls
+/// the low end of of the hysteresis range. Basically, dedupe will stop
+/// when CPR drops below hysteresis * target_cpr, and will start again when
+/// CPR increases above target CPR.
+pub const MIN_N_CHUNKS_PER_RANGE_HYSTERESIS_FACTOR: f32 = 0.5;
+pub const DEFAULT_MIN_N_CHUNKS_PER_RANGE: f32 = 8.0;

--- a/data/src/constants.rs
+++ b/data/src/constants.rs
@@ -42,3 +42,10 @@ pub const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 /// Maximum number of entries in the file construction cache
 /// which stores File Hash -> reconstruction instructions
 pub const FILE_RECONSTRUCTION_CACHE_SIZE: usize = 65536;
+
+/// Number of ranges to use when estimating fragmentation
+pub const NRANGES_IN_STREAMING_FRAGMENTATION_ESTIMATOR: usize = 128;
+
+/// Minimum number of chunks per range. Used to control fragmentation
+/// This targets an average of 1MB per range
+pub const MIN_N_CHUNKS_PER_RANGE: f32 = 16.0;

--- a/data/src/constants.rs
+++ b/data/src/constants.rs
@@ -49,7 +49,7 @@ pub const NRANGES_IN_STREAMING_FRAGMENTATION_ESTIMATOR: usize = 128;
 /// Minimum number of chunks per range. Used to control fragmentation
 /// This targets an average of 1MB per range.
 /// The hysteresis factor multiplied by the target Chunks Per Range (CPR) controls
-/// the low end of of the hysteresis range. Basically, dedupe will stop
+/// the low end of the hysteresis range. Basically, dedupe will stop
 /// when CPR drops below hysteresis * target_cpr, and will start again when
 /// CPR increases above target CPR.
 pub const MIN_N_CHUNKS_PER_RANGE_HYSTERESIS_FACTOR: f32 = 0.5;

--- a/data/src/constants.rs
+++ b/data/src/constants.rs
@@ -44,8 +44,9 @@ pub const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const FILE_RECONSTRUCTION_CACHE_SIZE: usize = 65536;
 
 /// Number of ranges to use when estimating fragmentation
-pub const NRANGES_IN_STREAMING_FRAGMENTATION_ESTIMATOR: usize = 32;
+pub const NRANGES_IN_STREAMING_FRAGMENTATION_ESTIMATOR: usize = 128;
 
 /// Minimum number of chunks per range. Used to control fragmentation
 /// This targets an average of 1MB per range
-pub const MIN_N_CHUNKS_PER_RANGE: f32 = 16.0;
+pub const MIN_N_CHUNKS_PER_RANGE_LOW: f32 = 4.0;
+pub const MIN_N_CHUNKS_PER_RANGE_HIGH: f32 = 8.0;

--- a/data/src/constants.rs
+++ b/data/src/constants.rs
@@ -44,7 +44,7 @@ pub const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const FILE_RECONSTRUCTION_CACHE_SIZE: usize = 65536;
 
 /// Number of ranges to use when estimating fragmentation
-pub const NRANGES_IN_STREAMING_FRAGMENTATION_ESTIMATOR: usize = 128;
+pub const NRANGES_IN_STREAMING_FRAGMENTATION_ESTIMATOR: usize = 32;
 
 /// Minimum number of chunks per range. Used to control fragmentation
 /// This targets an average of 1MB per range


### PR DESCRIPTION
For https://linear.app/xet/issue/XET-246/fragmentation-prevention We use average chunks / range as a fragmentation estimator, targetting an average of 16 chunks per range which roughly equates to 1MB per range. This is computed over the last window of 32 ranges. If the average drops below the target, dedupe is disabled until the average is above the target again.

Running on first 1GB of a *highly* fragmented file (comprising of a few hundred KB of an existing file, followed by a hundred KB of zeros, repeat) we see the following:
 - Baseline: 1000000001 bytes -> 726845953 bytes, 2975 ranges, 336134 average bytes per range
 - 512KB target (anti-fragmentation goal of 8 chunk per range): 1000000001 bytes -> 873515521 bytes, 1465 ranges, 682594 average bytes per range
 - 1MB target (anti-fragmentation goal of 16 chunks per range): 1000000001 bytes -> 932235777 bytes, 829 ranges, 1206273 average bytes per range

This also includes a hysteresis implementation:
 - 512KB target (anti-fragmentation goal of 8 chunk per range): 1000000001 bytes -> 873515521 bytes, 1657 ranges, 603500 average bytes per range.


The hysteresis turned out to be pretty important for deduping a content defined chunked variant of Parquet:
Without hysteresis (only concern is how v2 dedupes against v1):
``` 
parquet file v1: 5728317968 bytes -> 5728137283 bytes
parquet file v2: 5726717793 bytes -> 4544391399 bytes (11.14 chunks per range)
```
With hysteresis
``` 
parquet file v1: 5728317968 bytes -> 5728137283 bytes
parquet file v2: 5726717793 bytes -> 3568275084 bytes (8.11 chunks per range)
```
So with the hysteresis implementation we are closer to the target chunk per range and we are able to still dedupe pretty well. As comparison, *without* any fragmentation prevention:
```
parquet file v1: 5728317968 bytes -> 5728137283 bytes
parquet file v2: 5726717793 bytes -> 3402767500 bytes (6.89 chunks per segment)
```