### PR TITLE
Fix ubuntu aarch64 build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ on:
   push:
     branches: 
       - main
-  pull_request:
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,11 @@ jobs:
         platform:
           - runner: ubuntu-22.04
             target: x86_64
+            manylinux: auto
             features: "--features openssl_vendored"
           - runner: ubuntu-22.04
             target: aarch64
+            manylinux: manylinux_2_28
             features: "--features openssl_vendored"
     steps:
       - uses: actions/checkout@v4
@@ -43,13 +45,13 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release ${{ matrix.platform.features }} --out dist
           sccache: 'true'
-          manylinux: manylinux_2_28
+          manylinux: ${{ matrix.platform.manylinux }}
           working-directory: hf_xet
           before-script-linux: |
             if command -v apt-get &> /dev/null; then
                 apt-get update && apt-get install libssl-dev libatomic-ops-dev -y
             elif command -v yum &> /dev/null; then
-                yum check-update && yum install openssl-devel devtoolset-10-libatomic-devel perl-IPC-Cmd -y
+                yum install openssl-devel devtoolset-10-libatomic-devel perl-IPC-Cmd -y
             else
                 echo "Neither apt-get nor yum is installed. Please install a package manager."
                 exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
             if command -v apt-get &> /dev/null; then
                 apt-get update && apt-get install libssl-dev libatomic-ops-dev -y
             elif command -v yum &> /dev/null; then
-                yum install openssl-devel devtoolset-10-libatomic-devel perl-IPC-Cmd -y
+                yum check-update && yum install openssl-devel devtoolset-10-libatomic-devel perl-IPC-Cmd -y
             else
                 echo "Neither apt-get nor yum is installed. Please install a package manager."
                 exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches: 
       - main
+  pull_request:
   workflow_dispatch:
     inputs:
       tag:
@@ -36,6 +37,12 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
+      - name: Upgrade GCC
+        if: ${{ matrix.platform.target }} == "aarch64"
+        run: |
+          sudo apt install gcc-10 g++-10
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10 --slave /usr/bin/gcov gcov /usr/bin/gcov-10
+          sudo update-alternatives --set gcc /usr/bin/gcc-10
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,19 +37,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
-      - name: Upgrade GCC
-        if: ${{ matrix.platform.target }} == "aarch64"
-        run: |
-          sudo apt install gcc-10 g++-10
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10 --slave /usr/bin/gcov gcov /usr/bin/gcov-10
-          sudo update-alternatives --set gcc /usr/bin/gcc-10
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
           args: --release ${{ matrix.platform.features }} --out dist
           sccache: 'true'
-          manylinux: auto
+          manylinux: manylinux_2_28
           working-directory: hf_xet
           before-script-linux: |
             if command -v apt-get &> /dev/null; then


### PR DESCRIPTION
Build on ubuntu-22.04, aarch64 has been failing since [this commit](https://github.com/huggingface/xet-core/commit/8f52fade9876710d1c2ecd771f407d640b1c4ea0), looks like jsonwebtoken introduced ring and the ARM assembler doesn't like it: [CI](https://github.com/huggingface/xet-core/actions/runs/12895273205/job/35955801283#step:4:812). A [comment](https://github.com/briansmith/ring/issues/1728#issuecomment-1758180655) under a ring repo related issue mentioned that "[manylinux_2_28](https://github.com/rust-cross/manylinux-cross#manylinux_2_28) based on GCC 7.5.0 works fine".