### PR TITLE
Added base64 util to DataHash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2005,6 +2005,7 @@ dependencies = [
 name = "merklehash"
 version = "0.14.5"
 dependencies = [
+ "base64 0.22.1",
  "blake3",
  "heed",
  "rand 0.8.5",

--- a/merklehash/Cargo.toml
+++ b/merklehash/Cargo.toml
@@ -11,6 +11,7 @@ blake3 = "1.5.1"
 safe-transmute = "0.11.2"
 serde = { version = "1.0.129", features = ["derive"] }
 heed = "0.11"
+base64 = "0.22.1"
 
 [features]
 strict = []

--- a/merklehash/src/data_hash.rs
+++ b/merklehash/src/data_hash.rs
@@ -149,6 +149,15 @@ impl DataHash {
         format!("{:016x}{:016x}{:016x}{:016x}", self.0[0], self.0[1], self.0[2], self.0[3])
     }
 
+    /// Gives a compact base64 representation of the hash that is more compact than hex and is
+    /// also url and file name safe.    
+    pub fn base64(&self) -> String {
+        // URL safe Base 64 encoding with ending characters removed.
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+        use base64::Engine as _;
+        URL_SAFE_NO_PAD.encode(&self.as_bytes())
+    }
+
     /// Parses a hexadecimal string as a DataHash, returning
     /// Err(DataHashHexParseError) on failure.
     pub fn from_hex(h: &str) -> Result<DataHash, DataHashHexParseError> {
@@ -166,6 +175,14 @@ impl DataHash {
         ret.0[2] = u64::from_str_radix(&h[32..48], 16)?;
         ret.0[3] = u64::from_str_radix(&h[48..64], 16)?;
         Ok(ret)
+    }
+
+    // Converts the hash from base64 (created by base64 above) to this.  Used for testing.
+    pub fn from_base64(b64: &str) -> Result<DataHash, DataHashBytesParseError> {
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+        use base64::Engine as _;
+        let bytes = URL_SAFE_NO_PAD.decode(b64.as_bytes()).map_err(|_| DataHashBytesParseError {})?;
+        DataHash::from_slice(&bytes)
     }
 
     /// Returns the datahash as a raw byte slice.
@@ -444,5 +461,15 @@ mod tests {
 
         // Verify that the outputs are different
         assert_ne!(output1, output2,);
+    }
+
+    // Test the base64 usage.
+    #[test]
+    fn test_base64() {
+        let hash = compute_data_hash(&[0, 1, 2, 3]);
+
+        let b64 = hash.base64();
+
+        assert_eq!(hash, DataHash::from_base64(&b64).unwrap());
     }
 }

--- a/merklehash/src/data_hash.rs
+++ b/merklehash/src/data_hash.rs
@@ -155,7 +155,7 @@ impl DataHash {
     /// Gives a compact base64 representation of the hash that is more compact than hex and is
     /// also url and file name safe.    
     pub fn base64(&self) -> String {
-        URL_SAFE_NO_PAD.encode(&self.as_bytes())
+        URL_SAFE_NO_PAD.encode(self.as_bytes())
     }
 
     /// Parses a hexadecimal string as a DataHash, returning

--- a/merklehash/src/data_hash.rs
+++ b/merklehash/src/data_hash.rs
@@ -7,6 +7,9 @@ use std::num::ParseIntError;
 use std::ops::{Deref, DerefMut};
 use std::{fmt, str};
 
+// URL safe Base 64 encoding with ending characters removed.
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
 use safe_transmute::transmute_to_bytes;
 use serde::{Deserialize, Serialize};
 
@@ -152,9 +155,6 @@ impl DataHash {
     /// Gives a compact base64 representation of the hash that is more compact than hex and is
     /// also url and file name safe.    
     pub fn base64(&self) -> String {
-        // URL safe Base 64 encoding with ending characters removed.
-        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-        use base64::Engine as _;
         URL_SAFE_NO_PAD.encode(&self.as_bytes())
     }
 
@@ -179,8 +179,6 @@ impl DataHash {
 
     // Converts the hash from base64 (created by base64 above) to this.  Used for testing.
     pub fn from_base64(b64: &str) -> Result<DataHash, DataHashBytesParseError> {
-        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-        use base64::Engine as _;
         let bytes = URL_SAFE_NO_PAD.decode(b64.as_bytes()).map_err(|_| DataHashBytesParseError {})?;
         DataHash::from_slice(&bytes)
     }


### PR DESCRIPTION
Adds a simple method to obtain the base64 of a hash to use for getting the a compact representation of the hash to use for ascii representations like filenames.  