### PR TITLE
chunk cache change hash to checksum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,11 +593,12 @@ name = "chunk_cache"
 version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
- "blake3",
  "cas_types",
  "clap 4.5.20",
+ "crc32fast",
  "error_printer",
  "file_utils",
+ "log",
  "merklehash",
  "mockall",
  "once_cell",
@@ -753,6 +754,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if 1.0.0",
 ]
 
 [[package]]

--- a/chunk_cache/Cargo.toml
+++ b/chunk_cache/Cargo.toml
@@ -10,13 +10,14 @@ thiserror = "2.0"
 error_printer = { path = "../error_printer" }
 file_utils = { path = "../file_utils" }
 utils = { path = "../utils" }
-blake3 = "1.5.4"
 base64 = "0.22.1"
 tracing = "0.1.40"
 rand = "0.8.5"
 mockall = "0.13.0"
 clap = { version = "4.5.20", optional = true, features = ["derive"] }
 once_cell = "1.20.2"
+crc32fast = "1.4.2"
+log = "0.4.22"
 
 [dev-dependencies]
 tokio = { version = "1.36", features = ["full"] }

--- a/chunk_cache_bench/Cargo.lock
+++ b/chunk_cache_bench/Cargo.lock
@@ -374,10 +374,11 @@ name = "chunk_cache"
 version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
- "blake3",
  "cas_types",
+ "crc32fast",
  "error_printer",
  "file_utils",
+ "log",
  "merklehash",
  "mockall",
  "once_cell",
@@ -1756,6 +1757,7 @@ dependencies = [
 name = "merklehash"
 version = "0.14.5"
 dependencies = [
+ "base64 0.22.1",
  "blake3",
  "heed",
  "rand 0.8.5",
@@ -3850,6 +3852,7 @@ dependencies = [
  "thiserror 2.0.11",
  "tokio",
  "tracing",
+ "xet_threadpool",
 ]
 
 [[package]]
@@ -4301,6 +4304,16 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "rustix",
+]
+
+[[package]]
+name = "xet_threadpool"
+version = "0.1.0"
+dependencies = [
+ "lazy_static",
+ "thiserror 2.0.11",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/hf_xet/Cargo.lock
+++ b/hf_xet/Cargo.lock
@@ -346,10 +346,11 @@ name = "chunk_cache"
 version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
- "blake3",
  "cas_types",
+ "crc32fast",
  "error_printer",
  "file_utils",
+ "log",
  "merklehash",
  "mockall",
  "once_cell",
@@ -446,6 +447,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1701,6 +1711,7 @@ dependencies = [
 name = "merklehash"
 version = "0.14.5"
 dependencies = [
+ "base64 0.22.1",
  "blake3",
  "heed",
  "rand 0.8.5",


### PR DESCRIPTION
fix XET-281

Calculating the hash of the cache file takes too long of a time relative to the target cache put performance in CPU constrained systems. We've already dropped the verification on gets, now dropping on writes and replacing with a CRC.

PS includes some good style updates.