### PR TITLE
check max chunk nums

### DIFF
--- a/cas_object/src/cas_chunk_format.rs
+++ b/cas_object/src/cas_chunk_format.rs
@@ -1,10 +1,10 @@
 use std::io::{Read, Write};
 use std::mem::size_of;
 
-use anyhow::anyhow;
-
 use crate::error::CasObjectError;
 use crate::CompressionScheme;
+use anyhow::anyhow;
+use merkledb::constants::MAXIMUM_CHUNK_SIZE;
 
 pub mod deserialize_async;
 
@@ -67,6 +67,18 @@ impl CASChunkHeader {
                 "chunk header version too high at {}, current version is {}",
                 self.version,
                 CURRENT_VERSION
+            )));
+        }
+        if self.get_compressed_length() as usize > MAXIMUM_CHUNK_SIZE {
+            return Err(CasObjectError::FormatError(anyhow!(
+                "chunk header compressed length too large at {}, maximum: {MAXIMUM_CHUNK_SIZE}",
+                self.get_compressed_length()
+            )));
+        }
+        if self.get_compressed_length() as usize > MAXIMUM_CHUNK_SIZE {
+            return Err(CasObjectError::FormatError(anyhow!(
+                "chunk header uncompressed length too large at {}, maximum: {MAXIMUM_CHUNK_SIZE}",
+                self.get_uncompressed_length()
             )));
         }
         Ok(())

--- a/cas_object/src/cas_chunk_format.rs
+++ b/cas_object/src/cas_chunk_format.rs
@@ -69,13 +69,13 @@ impl CASChunkHeader {
                 CURRENT_VERSION
             )));
         }
-        if self.get_compressed_length() as usize > MAXIMUM_CHUNK_SIZE {
+        if self.get_compressed_length() as usize > MAXIMUM_CHUNK_SIZE * 2 {
             return Err(CasObjectError::FormatError(anyhow!(
                 "chunk header compressed length too large at {}, maximum: {MAXIMUM_CHUNK_SIZE}",
                 self.get_compressed_length()
             )));
         }
-        if self.get_compressed_length() as usize > MAXIMUM_CHUNK_SIZE {
+        if self.get_compressed_length() as usize > MAXIMUM_CHUNK_SIZE * 2 {
             return Err(CasObjectError::FormatError(anyhow!(
                 "chunk header uncompressed length too large at {}, maximum: {MAXIMUM_CHUNK_SIZE}",
                 self.get_uncompressed_length()

--- a/cas_object/src/cas_chunk_format.rs
+++ b/cas_object/src/cas_chunk_format.rs
@@ -1,10 +1,11 @@
 use std::io::{Read, Write};
 use std::mem::size_of;
 
-use crate::error::CasObjectError;
-use crate::CompressionScheme;
 use anyhow::anyhow;
 use merkledb::constants::MAXIMUM_CHUNK_SIZE;
+
+use crate::error::CasObjectError;
+use crate::CompressionScheme;
 
 pub mod deserialize_async;
 

--- a/merkledb/src/constants.rs
+++ b/merkledb/src/constants.rs
@@ -10,6 +10,9 @@ pub const MINIMUM_CHUNK_DIVISOR: usize = 8;
 /// TARGET_CDC_CHUNK_SIZE * MAXIMUM_CHUNK_MULTIPLIER is the largest chunk size
 pub const MAXIMUM_CHUNK_MULTIPLIER: usize = 2;
 
+/// no chunk may be larger than MAXIMUM_CHUNK_SIZE bytes
+pub const MAXIMUM_CHUNK_SIZE: usize = TARGET_CDC_CHUNK_SIZE * MAXIMUM_CHUNK_MULTIPLIER;
+
 /// Produce a CAS block when accumulated chunks exceeds TARGET_CAS_BLOCK_SIZE,
 /// this ensures that block sizes are always less than IDEAL_CAS_BLOCK_SIZE.
 pub const TARGET_CAS_BLOCK_SIZE: usize = IDEAL_CAS_BLOCK_SIZE - TARGET_CDC_CHUNK_SIZE * MAXIMUM_CHUNK_MULTIPLIER;


### PR DESCRIPTION
FIX XET-201

- when validating a chunk header in a xorb ensure that the lengths that chunk specifies are less than the max size (*2 for some buffer in case the compression ends up increasing the stored size accidentally.)