### PR TITLE
cache gets verifies crc checksum on stored cache items

### DIFF
--- a/chunk_cache/src/disk.rs
+++ b/chunk_cache/src/disk.rs
@@ -11,7 +11,6 @@ use base64::Engine;
 use cas_types::{ChunkRange, Key};
 use error_printer::ErrorPrinter;
 use file_utils::SafeFileCreator;
-use log::info;
 use merklehash::MerkleHash;
 use tracing::{debug, warn};
 #[cfg(feature = "analysis")]

--- a/chunk_cache/src/disk.rs
+++ b/chunk_cache/src/disk.rs
@@ -253,10 +253,12 @@ impl DiskCache {
             };
 
             if !cache_item.is_verified() {
-                if crc32_from_reader(&mut file)? == cache_item.checksum {
+                let checksum = crc32_from_reader(&mut file)?;
+                if checksum == cache_item.checksum {
                     cache_item.verify();
                     file.rewind()?;
                 } else {
+                    warn!("computed checksum {checksum} mismatch on cache item {key}/{cache_item}");
                     self.remove_item(key, &cache_item)?;
                     continue;
                 }

--- a/chunk_cache/src/disk.rs
+++ b/chunk_cache/src/disk.rs
@@ -257,9 +257,7 @@ impl DiskCache {
                 if crc32_from_reader(&mut file)? == cache_item.checksum {
                     cache_item.verify();
                     file.rewind()?;
-                    info!("verified {key} {cache_item}");
                 } else {
-                    info!("failed to verify {key} {cache_item}");
                     self.remove_item(key, &cache_item)?;
                     continue;
                 }

--- a/chunk_cache/src/disk.rs
+++ b/chunk_cache/src/disk.rs
@@ -8,16 +8,17 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use base64::engine::general_purpose::URL_SAFE;
 use base64::engine::GeneralPurpose;
 use base64::Engine;
-use cache_file_header::CacheFileHeader;
-use cache_item::CacheItem;
 use cas_types::{ChunkRange, Key};
 use error_printer::ErrorPrinter;
 use file_utils::SafeFileCreator;
+use log::info;
 use merklehash::MerkleHash;
 use tracing::{debug, warn};
 #[cfg(feature = "analysis")]
 use utils::output_bytes;
 
+use crate::disk::cache_file_header::CacheFileHeader;
+use crate::disk::cache_item::{CacheItem, VerificationCell};
 use crate::error::ChunkCacheError;
 use crate::{CacheConfig, ChunkCache};
 
@@ -34,13 +35,13 @@ type OptionResult<T, E> = Result<Option<T>, E>;
 
 #[derive(Debug, Clone)]
 struct CacheState {
-    inner: HashMap<Key, Vec<CacheItem>>,
+    inner: HashMap<Key, Vec<VerificationCell<CacheItem>>>,
     num_items: usize,
     total_bytes: u64,
 }
 
 impl CacheState {
-    fn new(state: HashMap<Key, Vec<CacheItem>>, num_items: usize, total_bytes: u64) -> Self {
+    fn new(state: HashMap<Key, Vec<VerificationCell<CacheItem>>>, num_items: usize, total_bytes: u64) -> Self {
         Self {
             inner: state,
             num_items,
@@ -211,7 +212,7 @@ impl DiskCache {
 
                     total_bytes += cache_item.len;
                     num_items += 1;
-                    items.push(cache_item);
+                    items.push(VerificationCell::new_unverified(cache_item));
 
                     // if already filled capacity, stop iterating over cache items
                     if total_bytes >= max_num_bytes {
@@ -241,7 +242,7 @@ impl DiskCache {
 
             let path = self.item_path(key, &cache_item)?;
 
-            let mut file_buf = match File::open(&path) {
+            let mut file = match File::open(&path) {
                 Ok(file) => file,
                 Err(e) => match e.kind() {
                     ErrorKind::NotFound => {
@@ -252,11 +253,19 @@ impl DiskCache {
                 },
             };
 
-            // TODO: reintroduce checksum validation of cache file, but not for every get, memoize success status per
-            // cache item
+            if !cache_item.is_verified() {
+                if crc32_from_reader(&mut file)? == cache_item.checksum {
+                    cache_item.verify();
+                    file.rewind()?;
+                    info!("verified {key} {cache_item}");
+                } else {
+                    info!("failed to verify {key} {cache_item}");
+                    self.remove_item(key, &cache_item)?;
+                    continue;
+                }
+            }
 
-            file_buf.seek(SeekFrom::Start(0))?;
-            let Ok(header) = CacheFileHeader::deserialize(&mut file_buf)
+            let Ok(header) = CacheFileHeader::deserialize(&mut file)
                 .debug_error(format!("failed to deserialize cache file header on path: {path:?}"))
             else {
                 self.remove_item(key, &cache_item)?;
@@ -264,12 +273,12 @@ impl DiskCache {
             };
 
             let start = cache_item.range.start;
-            let result_buf = get_range_from_cache_file(&header, &mut file_buf, range, start)?;
+            let result_buf = get_range_from_cache_file(&header, &mut file, range, start)?;
             return Ok(Some(result_buf));
         }
     }
 
-    fn find_match(&self, key: &Key, range: &ChunkRange) -> OptionResult<CacheItem, ChunkCacheError> {
+    fn find_match(&self, key: &Key, range: &ChunkRange) -> OptionResult<VerificationCell<CacheItem>, ChunkCacheError> {
         let state = self.state.lock()?;
         let Some(items) = state.inner.get(key) else {
             return Ok(None);
@@ -293,7 +302,7 @@ impl DiskCache {
     ) -> Result<(), ChunkCacheError> {
         if range.start >= range.end
         || chunk_byte_indices.len() != (range.end - range.start + 1) as usize
-        // chunk_byte_indices is guarenteed to be more than 1 element at this point
+        // chunk_byte_indices is guaranteed to be more than 1 element at this point
         || chunk_byte_indices[0] != 0
         || *chunk_byte_indices.last().unwrap() as usize != data.len()
         || !strictly_increasing(chunk_byte_indices)
@@ -370,7 +379,7 @@ impl DiskCache {
         state.num_items += 1;
         state.total_bytes += cache_item.len;
         let item_set = state.inner.entry(key.clone()).or_default();
-        item_set.push(cache_item);
+        item_set.push(VerificationCell::new_verified(cache_item));
 
         // release lock
         drop(state);
@@ -397,7 +406,7 @@ impl DiskCache {
         range: &ChunkRange,
         chunk_byte_indices: &[u32],
         data: &[u8],
-        cache_item: &CacheItem,
+        cache_item: &VerificationCell<CacheItem>,
     ) -> Result<bool, ChunkCacheError> {
         // this is a redundant check
         if range.start < cache_item.range.start || range.end > cache_item.range.end {
@@ -506,7 +515,7 @@ impl DiskCache {
     }
 
     /// removes an item from both the in-memory state of the cache and the file system
-    fn remove_item(&self, key: &Key, cache_item: &CacheItem) -> Result<(), ChunkCacheError> {
+    fn remove_item(&self, key: &Key, cache_item: &VerificationCell<CacheItem>) -> Result<(), ChunkCacheError> {
         {
             let mut state = self.state.lock()?;
             if let Some(items) = state.inner.get_mut(key) {
@@ -537,6 +546,20 @@ impl DiskCache {
     fn item_path(&self, key: &Key, cache_item: &CacheItem) -> Result<PathBuf, ChunkCacheError> {
         Ok(self.cache_root.join(key_dir(key)).join(cache_item.file_name()?))
     }
+}
+
+fn crc32_from_reader(reader: &mut impl Read) -> Result<u32, ChunkCacheError> {
+    const CRC_BUFFER_SIZE: usize = 4096;
+    let mut buf = [0u8; CRC_BUFFER_SIZE];
+    let mut hasher = crc32fast::Hasher::new();
+    loop {
+        let num_read = reader.read(&mut buf)?;
+        if num_read == 0 {
+            break;
+        }
+        hasher.update(&buf[..num_read])
+    }
+    Ok(hasher.finalize())
 }
 
 #[inline]

--- a/chunk_cache/src/disk/cache_item.rs
+++ b/chunk_cache/src/disk/cache_item.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use std::fmt::{Debug, Formatter};
 use std::hash::{Hash, Hasher};
 use std::io::Cursor;
 use std::mem::size_of;
@@ -17,6 +17,21 @@ use crate::error::ChunkCacheError;
 pub(crate) struct VerificationCell<T> {
     inner: T,
     verification: Arc<AtomicBool>,
+}
+
+impl<T: std::fmt::Display> std::fmt::Display for VerificationCell<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} ({})",
+            self.inner,
+            if self.verification.load(std::sync::atomic::Ordering::Relaxed) {
+                "verified"
+            } else {
+                "unverified"
+            }
+        )
+    }
 }
 
 impl<T> AsRef<T> for VerificationCell<T> {

--- a/chunk_cache/src/disk/cache_item.rs
+++ b/chunk_cache/src/disk/cache_item.rs
@@ -1,6 +1,10 @@
-use std::cmp::Ordering;
+use std::fmt::Debug;
+use std::hash::{Hash, Hasher};
 use std::io::Cursor;
 use std::mem::size_of;
+use std::ops::Deref;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 
 use base64::Engine;
 use cas_types::ChunkRange;
@@ -8,6 +12,64 @@ use utils::serialization_utils::{read_u32, read_u64, write_u32, write_u64};
 
 use super::BASE64_ENGINE;
 use crate::error::ChunkCacheError;
+
+#[derive(Debug, Clone)]
+pub(crate) struct VerificationCell<T> {
+    inner: T,
+    verification: Arc<AtomicBool>,
+}
+
+impl<T> AsRef<T> for VerificationCell<T> {
+    fn as_ref(&self) -> &T {
+        &self.inner
+    }
+}
+
+impl<T> Deref for VerificationCell<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<T: Hash> Hash for VerificationCell<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.inner.hash(state)
+    }
+}
+
+impl<T: PartialEq> PartialEq for VerificationCell<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner.eq(other)
+    }
+}
+
+impl<T: Debug + Clone> VerificationCell<T> {
+    pub fn new_unverified(inner: T) -> Self {
+        Self::new(inner, false)
+    }
+
+    pub fn new_verified(inner: T) -> Self {
+        Self::new(inner, true)
+    }
+
+    #[inline]
+    fn new(inner: T, verified: bool) -> Self {
+        Self {
+            inner,
+            verification: Arc::new(AtomicBool::new(verified)),
+        }
+    }
+
+    pub fn verify(&self) {
+        self.verification.store(true, std::sync::atomic::Ordering::Release)
+    }
+
+    pub fn is_verified(&self) -> bool {
+        self.verification.load(std::sync::atomic::Ordering::Relaxed)
+    }
+}
 
 // range start, range end, length, and checksum
 const CACHE_ITEM_FILE_NAME_BUF_SIZE: usize = size_of::<u32>() * 2 + size_of::<u64>() + size_of::<u32>();
@@ -32,7 +94,7 @@ impl std::fmt::Display for CacheItem {
 // impl PartialOrd & Ord to sort by the range to enable binary search over
 // sorted CacheItems using the range field to match a range for search
 impl Ord for CacheItem {
-    fn cmp(&self, other: &Self) -> Ordering {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.range.cmp(&other.range)
     }
 }


### PR DESCRIPTION
FIX XET-142.

Previously we removed the chunk cache validation on the cache items on the get path since it turned out to be where all the time was spent on cache operations. This PR reintroduces checksum validation, now that we are using checksums rather than more expensive hashes.

Notably the verification is still rather expensive since it requires reading the entire file, whereas a simple cache get may only need to seek to 1 section of the file.

Verification is done only once on a best effort basis, i.e. it is not strictly enforced that the verification work is done only once, if 2 threads attempt to verify concurrently, double work is done. See VerificationCell.