### PR TITLE
Include s in repo type arg of xtool

### DIFF
--- a/data/src/bin/xtool.rs
+++ b/data/src/bin/xtool.rs
@@ -31,7 +31,7 @@ struct CliOverrides {
     /// HF Hub access token.
     #[clap(long)]
     token: Option<String>, // if not specified we use env:HF_TOKEN
-    /// Type of the associated repo: "model", "dataset", or "space"
+    /// Type of the associated repo: "models", "datasets", or "spaces"
     #[clap(long)]
     repo_type: String,
     /// A namespace and a repo name separated by a '/'.

--- a/data/src/migration_tool/hub_client.rs
+++ b/data/src/migration_tool/hub_client.rs
@@ -22,7 +22,7 @@ impl HubClient {
         let repo_type = self.repo_type.as_str();
         let repo_id = self.repo_id.as_str();
 
-        let url = format!("{endpoint}/api/{repo_type}s/{repo_id}/xet-{token_type}-token/main");
+        let url = format!("{endpoint}/api/{repo_type}/{repo_id}/xet-{token_type}-token/main");
 
         let response = self
             .client
@@ -80,7 +80,7 @@ mod tests {
         let hub_client = HubClient {
             endpoint: "https://xethub-poc.us.dev.moon.huggingface.tech".to_owned(),
             token: "[MASKED]".to_owned(),
-            repo_type: "dataset".to_owned(),
+            repo_type: "datasets".to_owned(),
             repo_id: "test/t2".to_owned(),
             client: build_http_client(&None)?,
         };

--- a/data/src/migration_tool/migrate.rs
+++ b/data/src/migration_tool/migrate.rs
@@ -19,7 +19,7 @@ use crate::{PointerFile, PointerFileTranslator};
 /// let file_paths = vec!["/path/to/file1".to_string(), "/path/to/file2".to_string()];
 /// let hub_endpoint = "https://huggingface.co";
 /// let hub_token = "your_token";
-/// let repo_type = "model";
+/// let repo_type = "models";
 /// let repo_id = "your_repo_id";
 /// let handle = tokio::runtime::Handle::current();
 /// migrate_with_external_runtime(file_paths, hub_endpoint, hub_token, repo_type, repo_id, handle)


### PR DESCRIPTION
Use the plural as default for `repo_type` arg for the xtool so that it is consistent with how the caller (repo scanner) parses the repo type as plural