### PR TITLE
Fix calling async from sync inside async runtime

### DIFF
--- a/data/src/migration_tool/hub_client.rs
+++ b/data/src/migration_tool/hub_client.rs
@@ -60,7 +60,7 @@ impl TokenRefresher for HubClientTokenRefresher {
         let token_type = self.token_type.clone();
         let ret = self
             .threadpool
-            .external_run_async_task(async move { client.refresh_jwt_token(&token_type).await })
+            .internal_run_async_task(async move { client.refresh_jwt_token(&token_type).await })
             .map_err(|e| AuthError::TokenRefreshFailure(e.to_string()))?
             .map_err(|e| AuthError::TokenRefreshFailure(e.to_string()))?;
         Ok(ret)

--- a/xet_threadpool/src/threadpool.rs
+++ b/xet_threadpool/src/threadpool.rs
@@ -50,6 +50,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 ///
 /// - `new_threadpool`: Creates a new Tokio runtime with the specified settings.
 use tokio;
+use tokio::runtime::Handle;
 use tokio::task::JoinHandle;
 use tracing::{debug, error};
 
@@ -174,6 +175,27 @@ impl ThreadPool {
 
         self.external_executor_count.fetch_sub(1, Ordering::SeqCst);
         ret
+    }
+
+    pub fn internal_run_async_task<F>(&self, future: F) -> Result<F::Output, MultithreadedRuntimeError>
+    where
+        F: std::future::Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        tokio::task::block_in_place(move || {
+            Handle::current().block_on(async { tokio::spawn(future).await }).map_err(|e| {
+                if e.is_panic() {
+                    // The task panic'd.  Pass this exception on.
+                    error!("Panic reported on xet worker task: {e:?}");
+                    MultithreadedRuntimeError::TaskPanic(e)
+                } else if e.is_cancelled() {
+                    // Likely caused by the runtime shutting down (e.g. with a keyboard CTRL-C).
+                    MultithreadedRuntimeError::TaskCanceled(format!("{e}"))
+                } else {
+                    MultithreadedRuntimeError::Other(format!("task join error: {e}"))
+                }
+            })
+        })
     }
 
     /// Spawn an async task to run in the background on the current pool of worker threads.

--- a/xet_threadpool/src/threadpool.rs
+++ b/xet_threadpool/src/threadpool.rs
@@ -177,6 +177,8 @@ impl ThreadPool {
         ret
     }
 
+    /// This function can be safely used by threads inside of tokio to call an async function
+    /// from a sync function.
     pub fn internal_run_async_task<F>(&self, future: F) -> Result<F::Output, MultithreadedRuntimeError>
     where
         F: std::future::Future + Send + 'static,


### PR DESCRIPTION
The "external_run_async_task" function, as documented in the comment, should only be used by threads outside of tokio, otherwise it can panic if `block_on` is called on a thread that is to drive async tasks. The `HubClientTokenRefresher::refresh` function, however, needs to call an async fn inside of tokio. This PR implements the correct routine to do that.