### PR TITLE
Shard query resilient to shard file deletion

### DIFF
--- a/mdb_shard/src/error.rs
+++ b/mdb_shard/src/error.rs
@@ -49,3 +49,26 @@ impl PartialEq for MDBShardError {
         }
     }
 }
+
+// Helper trait to swallow io::ErrorKind::NotFound errors. In the case of
+// a cache shard was registered but later deleted during the lifetime
+// of a shard file manager, dedup queries to this shard should not fail hard.
+pub trait CacheDeletionResilience<T> {
+    fn ok_for_io_error_not_found(self) -> Result<Option<T>>;
+}
+
+impl<T> CacheDeletionResilience<T> for Result<T> {
+    fn ok_for_io_error_not_found(self) -> Result<Option<T>> {
+        match self {
+            Ok(v) => Ok(Some(v)),
+            Err(MDBShardError::IOError(e)) => {
+                if e.kind() == io::ErrorKind::NotFound {
+                    Ok(None)
+                } else {
+                    Err(MDBShardError::IOError(e))
+                }
+            },
+            Err(other_err) => Err(other_err),
+        }
+    }
+}

--- a/mdb_shard/src/error.rs
+++ b/mdb_shard/src/error.rs
@@ -49,19 +49,3 @@ impl PartialEq for MDBShardError {
         }
     }
 }
-
-// Helper function to swallow io::ErrorKind::NotFound errors. In the case of
-// a cached shard was registered but later deleted during the lifetime
-// of a shard file manager, queries to this shard should not fail hard.
-pub fn not_found_as_none<T>(e: MDBShardError) -> Result<Option<T>> {
-    match e {
-        MDBShardError::IOError(e) => {
-            if e.kind() == io::ErrorKind::NotFound {
-                Ok(None)
-            } else {
-                Err(MDBShardError::IOError(e))
-            }
-        },
-        other_err => Err(other_err),
-    }
-}

--- a/mdb_shard/src/shard_file_handle.rs
+++ b/mdb_shard/src/shard_file_handle.rs
@@ -8,7 +8,7 @@ use merklehash::{compute_data_hash, HMACKey, HashedWrite, MerkleHash};
 use tracing::{debug, error, info, warn};
 
 use crate::cas_structs::CASChunkSequenceHeader;
-use crate::error::{CacheDeletionResilience, MDBShardError, Result};
+use crate::error::{not_found_as_none, MDBShardError, Result};
 use crate::file_structs::{FileDataSequenceEntry, MDBFileInfo};
 use crate::shard_file::current_timestamp;
 use crate::shard_format::MDBShardInfo;
@@ -234,7 +234,7 @@ impl MDBShardFile {
 
     #[inline]
     pub fn get_file_reconstruction_info(&self, file_hash: &MerkleHash) -> Result<Option<MDBFileInfo>> {
-        let reader = self.get_reader().ok_for_io_error_not_found()?;
+        let reader = self.get_reader().map(Some).or_else(not_found_as_none)?;
         let Some(mut reader) = reader else {
             return Ok(None);
         };
@@ -247,7 +247,7 @@ impl MDBShardFile {
         &self,
         query_hashes: &[MerkleHash],
     ) -> Result<Option<(usize, FileDataSequenceEntry)>> {
-        let reader = self.get_reader().ok_for_io_error_not_found()?;
+        let reader = self.get_reader().map(Some).or_else(not_found_as_none)?;
         let Some(mut reader) = reader else {
             return Ok(None);
         };
@@ -262,7 +262,7 @@ impl MDBShardFile {
         cas_block_index: u32,
         cas_chunk_offset: u32,
     ) -> Result<Option<(usize, FileDataSequenceEntry)>> {
-        let reader = self.get_reader().ok_for_io_error_not_found()?;
+        let reader = self.get_reader().map(Some).or_else(not_found_as_none)?;
         let Some(mut reader) = reader else {
             return Ok(None);
         };


### PR DESCRIPTION
Since [add a caching layer for shard file manager](https://github.com/huggingface/xet-core/pull/159), a shard file manager along with shards registered to it are kept in memory through out the entire life time of a running process. If the shard files on disk are (manually) deleted after one operation (e.g. upload_folder in a iPython session), the next operation will fail due to file not found I/O error. This PR turns this I/O error into a soft failure such that a query into a deleted shard returns `Ok(None)`. I don't think there's need to remove them from the in memory registry for the numbers being small.