### PR TITLE
Rename data processing class names to reflect functionality 

### DIFF
--- a/data/src/bin/example.rs
+++ b/data/src/bin/example.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, OnceLock};
 use anyhow::Result;
 use clap::{Args, Parser, Subcommand};
 use data::configurations::*;
-use data::{PointerFile, PointerFileTranslator};
+use data::{FileDownloader, FileUploadSession, PointerFile};
 use xet_threadpool::ThreadPool;
 
 #[derive(Parser)]
@@ -85,7 +85,7 @@ async fn clean(mut reader: impl Read, mut writer: impl Write) -> Result<()> {
 
     let mut read_buf = vec![0u8; READ_BLOCK_SIZE];
 
-    let translator = PointerFileTranslator::new(
+    let translator = FileUploadSession::new(
         TranslatorConfig::local_config(std::env::current_dir()?, true)?,
         get_threadpool(),
         None,
@@ -139,15 +139,10 @@ async fn smudge(mut reader: impl Read, writer: &mut Box<dyn Write + Send>) -> Re
         return Ok(());
     }
 
-    let translator = PointerFileTranslator::new(
-        TranslatorConfig::local_config(std::env::current_dir()?, true)?,
-        get_threadpool(),
-        None,
-        true,
-    )
-    .await?;
+    let downloader =
+        FileDownloader::new(TranslatorConfig::local_config(std::env::current_dir()?, true)?, get_threadpool()).await?;
 
-    translator.smudge_file_from_pointer(&pointer_file, writer, None, None).await?;
+    downloader.smudge_file_from_pointer(&pointer_file, writer, None, None).await?;
 
     Ok(())
 }

--- a/data/src/bin/example.rs
+++ b/data/src/bin/example.rs
@@ -85,13 +85,9 @@ async fn clean(mut reader: impl Read, mut writer: impl Write) -> Result<()> {
 
     let mut read_buf = vec![0u8; READ_BLOCK_SIZE];
 
-    let translator = FileUploadSession::new(
-        TranslatorConfig::local_config(std::env::current_dir()?, true)?,
-        get_threadpool(),
-        None,
-        false,
-    )
-    .await?;
+    let translator =
+        FileUploadSession::new(TranslatorConfig::local_config(std::env::current_dir()?, true)?, get_threadpool(), None)
+            .await?;
 
     let handle = translator.start_clean(1024, None).await?;
 

--- a/data/src/cas_interface.rs
+++ b/data/src/cas_interface.rs
@@ -1,9 +1,7 @@
 use std::sync::Arc;
 
 pub use cas_client::Client;
-use cas_client::{CacheConfig, LocalClient, RemoteClient};
-use cas_object::CompressionScheme;
-use utils::auth::AuthConfig;
+use cas_client::{LocalClient, RemoteClient};
 use xet_threadpool::ThreadPool;
 
 use crate::configurations::*;
@@ -11,33 +9,18 @@ use crate::errors::Result;
 
 pub(crate) fn create_cas_client(
     cas_storage_config: &StorageConfig,
-    _maybe_repo_info: &Option<RepoInfo>,
     threadpool: Arc<ThreadPool>,
     dry_run: bool,
 ) -> Result<Arc<dyn Client + Send + Sync>> {
     match cas_storage_config.endpoint {
-        Endpoint::Server(ref endpoint) => remote_client(
+        Endpoint::Server(ref endpoint) => Ok(Arc::new(RemoteClient::new(
+            threadpool,
             endpoint,
             cas_storage_config.compression,
-            &cas_storage_config.cache_config,
             &cas_storage_config.auth,
-            threadpool,
+            &cas_storage_config.cache_config,
             dry_run,
-        ),
+        ))),
         Endpoint::FileSystem(ref path) => Ok(Arc::new(LocalClient::new(path)?)),
     }
-}
-
-fn remote_client(
-    endpoint: &str,
-    compression: CompressionScheme,
-    cache_config: &Option<CacheConfig>,
-    auth: &Option<AuthConfig>,
-    threadpool: Arc<ThreadPool>,
-    dry_run: bool,
-) -> Result<Arc<dyn Client + Send + Sync>> {
-    // Raw remote client.
-    let remote_client = RemoteClient::new(threadpool, endpoint, compression, auth, cache_config, dry_run);
-
-    Ok(Arc::new(remote_client))
 }

--- a/data/src/chunking.rs
+++ b/data/src/chunking.rs
@@ -9,7 +9,7 @@ use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use xet_threadpool::ThreadPool;
 
-use super::clean::BufferItem;
+use super::file_cleaner::BufferItem;
 use crate::errors::{DataProcessingError, Result};
 
 pub type ChunkYieldType = (Chunk, Vec<u8>);

--- a/data/src/data_client.rs
+++ b/data/src/data_client.rs
@@ -19,7 +19,7 @@ use xet_threadpool::ThreadPool;
 
 use crate::configurations::*;
 use crate::errors::DataProcessingError;
-use crate::{errors, PointerFile, PointerFileTranslator};
+use crate::{errors, FileDownloader, FileUploadSession, PointerFile};
 
 // Concurrency in number of files
 lazy_static! {
@@ -133,7 +133,7 @@ pub async fn upload_async(
         token_refresher,
     )?;
 
-    let processor = Arc::new(PointerFileTranslator::new(config, threadpool, progress_updater, false).await?);
+    let processor = Arc::new(FileUploadSession::new(config, threadpool, progress_updater, false).await?);
 
     // for all files, clean them, producing pointer files.
     let pointers = tokio_par_for_each(file_paths, *MAX_CONCURRENT_UPLOADS, |f, _| async {
@@ -176,7 +176,7 @@ pub async fn download_async(
     };
     let pointer_files_plus = pointer_files.into_iter().zip(updaters).collect::<Vec<_>>();
 
-    let processor = &Arc::new(PointerFileTranslator::new(config, threadpool, None, true).await?);
+    let processor = &Arc::new(FileDownloader::new(config, threadpool).await?);
     let paths =
         tokio_par_for_each(pointer_files_plus, MAX_CONCURRENT_DOWNLOADS, |(pointer_file, updater), _| async move {
             let proc = processor.clone();
@@ -191,7 +191,7 @@ pub async fn download_async(
     Ok(paths)
 }
 
-pub async fn clean_file(processor: &PointerFileTranslator, f: String) -> errors::Result<(PointerFile, u64)> {
+pub async fn clean_file(processor: &FileUploadSession, f: String) -> errors::Result<(PointerFile, u64)> {
     let mut read_buf = vec![0u8; READ_BLOCK_SIZE];
     let path = PathBuf::from(f);
     let mut reader = BufReader::new(File::open(path.clone())?);
@@ -217,7 +217,7 @@ pub async fn clean_file(processor: &PointerFileTranslator, f: String) -> errors:
 }
 
 async fn smudge_file(
-    proc: &PointerFileTranslator,
+    downloader: &FileDownloader,
     pointer_file: &PointerFile,
     progress_updater: Option<Arc<dyn ProgressUpdater>>,
 ) -> errors::Result<String> {
@@ -226,7 +226,8 @@ async fn smudge_file(
         fs::create_dir_all(parent_dir)?;
     }
     let mut f: Box<dyn Write + Send> = Box::new(File::create(&path)?);
-    proc.smudge_file_from_pointer(pointer_file, &mut f, None, progress_updater)
+    downloader
+        .smudge_file_from_pointer(pointer_file, &mut f, None, progress_updater)
         .await?;
     Ok(pointer_file.path().to_string())
 }

--- a/data/src/data_client.rs
+++ b/data/src/data_client.rs
@@ -133,7 +133,7 @@ pub async fn upload_async(
         token_refresher,
     )?;
 
-    let processor = Arc::new(FileUploadSession::new(config, threadpool, progress_updater, false).await?);
+    let processor = Arc::new(FileUploadSession::new(config, threadpool, progress_updater).await?);
 
     // for all files, clean them, producing pointer files.
     let pointers = tokio_par_for_each(file_paths, *MAX_CONCURRENT_UPLOADS, |f, _| async {

--- a/data/src/file_cleaner.rs
+++ b/data/src/file_cleaner.rs
@@ -30,9 +30,9 @@ use crate::constants::{
     DEFAULT_MIN_N_CHUNKS_PER_RANGE, MIN_N_CHUNKS_PER_RANGE_HYSTERESIS_FACTOR, MIN_SPACING_BETWEEN_GLOBAL_DEDUP_QUERIES,
     NRANGES_IN_STREAMING_FRAGMENTATION_ESTIMATOR,
 };
-use crate::data_processing::CASDataAggregator;
 use crate::errors::DataProcessingError::*;
 use crate::errors::Result;
+use crate::file_upload_session::CASDataAggregator;
 use crate::metrics::FILTER_BYTES_CLEANED;
 use crate::parallel_xorb_uploader::XorbUpload;
 use crate::remote_shard_interface::RemoteShardInterface;
@@ -158,7 +158,8 @@ impl ShaGenerator {
     }
 }
 
-pub struct Cleaner {
+/// A class that encapsulates the clean and data task around a single file.
+pub struct SingleFileCleaner {
     // Configurations
     enable_global_dedup_queries: bool,
     cas_prefix: String,
@@ -192,7 +193,7 @@ pub struct Cleaner {
     threadpool: Arc<ThreadPool>,
 }
 
-impl Cleaner {
+impl SingleFileCleaner {
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn new(
         enable_global_dedup_queries: bool,
@@ -214,7 +215,7 @@ impl Cleaner {
 
         let chunker = chunk_target_default(data_c, chunk_p, threadpool.clone());
 
-        let cleaner = Arc::new(Cleaner {
+        let cleaner = Arc::new(SingleFileCleaner {
             enable_global_dedup_queries,
             cas_prefix,
             repo_salt,

--- a/data/src/file_downloader.rs
+++ b/data/src/file_downloader.rs
@@ -1,0 +1,66 @@
+use std::io::Write;
+use std::sync::Arc;
+
+use cas_client::Client;
+use cas_types::FileRange;
+use merklehash::MerkleHash;
+use reqwest_middleware::ClientWithMiddleware;
+use utils::progress::ProgressUpdater;
+use xet_threadpool::ThreadPool;
+
+use crate::cas_interface::create_cas_client;
+use crate::configurations::TranslatorConfig;
+use crate::errors::*;
+use crate::PointerFile;
+
+/// Manages the download of files based on a hash or pointer file.
+///
+/// This class handles the clean operations.  It's meant to be a single atomic session
+/// that succeeds or fails as a unit;  i.e. all files get uploaded on finalization, and all shards
+/// and xorbs needed to reconstruct those files are properly uploaded and registered.
+pub struct FileDownloader {
+    /* ----- Configurations ----- */
+    config: TranslatorConfig,
+    cas: Arc<dyn Client + Send + Sync>,
+    http_client: Arc<ClientWithMiddleware>,
+}
+
+/// Smudge operations
+impl FileDownloader {
+    pub async fn new(config: TranslatorConfig, threadpool: Arc<ThreadPool>) -> Result<Self> {
+        let cas = create_cas_client(&config.cas_storage_config, threadpool.clone(), false)?;
+
+        let http_client = Arc::new(cas_client::build_http_client(&None)?);
+
+        Ok(Self {
+            config,
+            cas,
+            http_client,
+        })
+    }
+
+    pub async fn smudge_file_from_pointer(
+        &self,
+        pointer: &PointerFile,
+        writer: &mut Box<dyn Write + Send>,
+        range: Option<FileRange>,
+        progress_updater: Option<Arc<dyn ProgressUpdater>>,
+    ) -> Result<()> {
+        self.smudge_file_from_hash(&pointer.hash()?, writer, range, progress_updater)
+            .await
+    }
+
+    pub async fn smudge_file_from_hash(
+        &self,
+        file_id: &MerkleHash,
+        writer: &mut Box<dyn Write + Send>,
+        range: Option<FileRange>,
+        progress_updater: Option<Arc<dyn ProgressUpdater>>,
+    ) -> Result<()> {
+        // Currently, this works by always directly querying the remote server.
+        self.cas
+            .get_file(self.http_client.clone(), file_id, range, writer, progress_updater)
+            .await?;
+        Ok(())
+    }
+}

--- a/data/src/file_upload_session.rs
+++ b/data/src/file_upload_session.rs
@@ -1,11 +1,9 @@
-use std::io::Write;
 use std::mem::take;
 use std::ops::DerefMut;
 use std::path::Path;
 use std::sync::Arc;
 
 use cas_client::Client;
-use cas_types::FileRange;
 use jsonwebtoken::{decode, DecodingKey, Validation};
 use lazy_static::lazy_static;
 use mdb_shard::file_structs::MDBFileInfo;
@@ -16,14 +14,13 @@ use utils::progress::ProgressUpdater;
 use xet_threadpool::ThreadPool;
 
 use crate::cas_interface::create_cas_client;
-use crate::clean::Cleaner;
 use crate::configurations::*;
 use crate::constants::MAX_CONCURRENT_XORB_UPLOADS;
 use crate::errors::*;
+use crate::file_cleaner::SingleFileCleaner;
 use crate::parallel_xorb_uploader::{ParallelXorbUploader, XorbUpload};
 use crate::remote_shard_interface::RemoteShardInterface;
 use crate::shard_interface::create_shard_manager;
-use crate::PointerFile;
 
 lazy_static! {
     pub static ref XORB_UPLOAD_RATE_LIMITER: Arc<Semaphore> = Arc::new(Semaphore::new(*MAX_CONCURRENT_XORB_UPLOADS));
@@ -57,8 +54,10 @@ impl CASDataAggregator {
 /// Manages the translation of files between the
 /// MerkleDB / pointer file format and the materialized version.
 ///
-/// This class handles the clean and smudge options.
-pub struct PointerFileTranslator {
+/// This class handles the clean operations.  It's meant to be a single atomic session
+/// that succeeds or fails as a unit;  i.e. all files get uploaded on finalization, and all shards
+/// and xorbs needed to reconstruct those files are properly uploaded and registered.
+pub struct FileUploadSession {
     /* ----- Configurations ----- */
     config: TranslatorConfig,
     dry_run: bool,
@@ -81,14 +80,14 @@ pub struct PointerFileTranslator {
 }
 
 // Constructors
-impl PointerFileTranslator {
+impl FileUploadSession {
     pub async fn new(
         config: TranslatorConfig,
         threadpool: Arc<ThreadPool>,
         upload_progress_updater: Option<Arc<dyn ProgressUpdater>>,
         download_only: bool,
-    ) -> Result<PointerFileTranslator> {
-        PointerFileTranslator::new_impl(config, threadpool, upload_progress_updater, download_only, false).await
+    ) -> Result<FileUploadSession> {
+        FileUploadSession::new_impl(config, threadpool, upload_progress_updater, download_only, false).await
     }
 
     pub async fn dry_run(
@@ -96,8 +95,8 @@ impl PointerFileTranslator {
         threadpool: Arc<ThreadPool>,
         upload_progress_updater: Option<Arc<dyn ProgressUpdater>>,
         download_only: bool,
-    ) -> Result<PointerFileTranslator> {
-        PointerFileTranslator::new_impl(config, threadpool, upload_progress_updater, download_only, true).await
+    ) -> Result<FileUploadSession> {
+        FileUploadSession::new_impl(config, threadpool, upload_progress_updater, download_only, true).await
     }
 
     async fn new_impl(
@@ -106,10 +105,10 @@ impl PointerFileTranslator {
         upload_progress_updater: Option<Arc<dyn ProgressUpdater>>,
         download_only: bool,
         dry_run: bool,
-    ) -> Result<PointerFileTranslator> {
+    ) -> Result<FileUploadSession> {
         let shard_manager = create_shard_manager(&config.shard_storage_config, download_only).await?;
 
-        let cas_client = create_cas_client(&config.cas_storage_config, &config.repo_info, threadpool.clone(), dry_run)?;
+        let cas_client = create_cas_client(&config.cas_storage_config, threadpool.clone(), dry_run)?;
 
         let remote_shards = {
             if let Some(dedup) = &config.dedup_config {
@@ -175,19 +174,19 @@ impl PointerFileTranslator {
 }
 
 /// Clean operations
-impl PointerFileTranslator {
+impl FileUploadSession {
     /// Start to clean one file. When cleaning multiple files, each file should
     /// be associated with one Cleaner. This allows to launch multiple clean task
     /// simultaneously.
     ///
     /// The caller is responsible for memory usage management, the parameter "buffer_size"
     /// indicates the maximum number of Vec<u8> in the internal buffer.
-    pub async fn start_clean(&self, buffer_size: usize, file_name: Option<&Path>) -> Result<Arc<Cleaner>> {
+    pub async fn start_clean(&self, buffer_size: usize, file_name: Option<&Path>) -> Result<Arc<SingleFileCleaner>> {
         let Some(ref dedup) = self.config.dedup_config else {
             return Err(DataProcessingError::DedupConfigError("empty dedup config".to_owned()));
         };
 
-        Cleaner::new(
+        SingleFileCleaner::new(
             matches!(dedup.global_dedup_policy, GlobalDedupPolicy::Always),
             self.config.cas_storage_config.prefix.clone(),
             dedup.repo_salt,
@@ -252,34 +251,6 @@ impl PointerFileTranslator {
     }
 }
 
-/// Smudge operations
-impl PointerFileTranslator {
-    pub async fn smudge_file_from_pointer(
-        &self,
-        pointer: &PointerFile,
-        writer: &mut Box<dyn Write + Send>,
-        range: Option<FileRange>,
-        progress_updater: Option<Arc<dyn ProgressUpdater>>,
-    ) -> Result<()> {
-        self.smudge_file_from_hash(&pointer.hash()?, writer, range, progress_updater)
-            .await
-    }
-
-    pub async fn smudge_file_from_hash(
-        &self,
-        file_id: &MerkleHash,
-        writer: &mut Box<dyn Write + Send>,
-        range: Option<FileRange>,
-        progress_updater: Option<Arc<dyn ProgressUpdater>>,
-    ) -> Result<()> {
-        let http_client = cas_client::build_http_client(&None)?;
-        self.cas
-            .get_file(Arc::new(http_client), file_id, range, writer, progress_updater)
-            .await?;
-        Ok(())
-    }
-}
-
 #[cfg(test)]
 mod tests {
 
@@ -290,7 +261,7 @@ mod tests {
 
     use xet_threadpool::ThreadPool;
 
-    use crate::{PointerFile, PointerFileTranslator};
+    use crate::{FileDownloader, FileUploadSession, PointerFile};
 
     /// Return a shared threadpool to be reused as needed.
     fn get_threadpool() -> Arc<ThreadPool> {
@@ -317,7 +288,7 @@ mod tests {
         );
 
         let translator =
-            PointerFileTranslator::new(TranslatorConfig::local_config(cas_path, true).unwrap(), runtime, None, false)
+            FileUploadSession::new(TranslatorConfig::local_config(cas_path, true).unwrap(), runtime, None, false)
                 .await
                 .unwrap();
 
@@ -356,10 +327,9 @@ mod tests {
             return;
         }
 
-        let translator =
-            PointerFileTranslator::new(TranslatorConfig::local_config(cas_path, true).unwrap(), runtime, None, true)
-                .await
-                .unwrap();
+        let translator = FileDownloader::new(TranslatorConfig::local_config(cas_path, true).unwrap(), runtime)
+            .await
+            .unwrap();
 
         translator
             .smudge_file_from_pointer(&pointer_file, &mut Box::new(writer), None, None)

--- a/data/src/file_upload_session.rs
+++ b/data/src/file_upload_session.rs
@@ -85,28 +85,25 @@ impl FileUploadSession {
         config: TranslatorConfig,
         threadpool: Arc<ThreadPool>,
         upload_progress_updater: Option<Arc<dyn ProgressUpdater>>,
-        download_only: bool,
     ) -> Result<FileUploadSession> {
-        FileUploadSession::new_impl(config, threadpool, upload_progress_updater, download_only, false).await
+        FileUploadSession::new_impl(config, threadpool, upload_progress_updater, false).await
     }
 
     pub async fn dry_run(
         config: TranslatorConfig,
         threadpool: Arc<ThreadPool>,
         upload_progress_updater: Option<Arc<dyn ProgressUpdater>>,
-        download_only: bool,
     ) -> Result<FileUploadSession> {
-        FileUploadSession::new_impl(config, threadpool, upload_progress_updater, download_only, true).await
+        FileUploadSession::new_impl(config, threadpool, upload_progress_updater, true).await
     }
 
     async fn new_impl(
         config: TranslatorConfig,
         threadpool: Arc<ThreadPool>,
         upload_progress_updater: Option<Arc<dyn ProgressUpdater>>,
-        download_only: bool,
         dry_run: bool,
     ) -> Result<FileUploadSession> {
-        let shard_manager = create_shard_manager(&config.shard_storage_config, download_only).await?;
+        let shard_manager = create_shard_manager(&config.shard_storage_config, false).await?;
 
         let cas_client = create_cas_client(&config.cas_storage_config, threadpool.clone(), dry_run)?;
 
@@ -119,7 +116,7 @@ impl FileUploadSession {
                     Some(cas_client.clone()),
                     dedup.repo_salt,
                     threadpool.clone(),
-                    download_only,
+                    false,
                 )
                 .await?
             } else {
@@ -287,10 +284,9 @@ mod tests {
                 .unwrap(),
         );
 
-        let translator =
-            FileUploadSession::new(TranslatorConfig::local_config(cas_path, true).unwrap(), runtime, None, false)
-                .await
-                .unwrap();
+        let translator = FileUploadSession::new(TranslatorConfig::local_config(cas_path, true).unwrap(), runtime, None)
+            .await
+            .unwrap();
 
         let handle = translator.start_clean(1024, None).await.unwrap();
 

--- a/data/src/lib.rs
+++ b/data/src/lib.rs
@@ -2,12 +2,13 @@
 
 mod cas_interface;
 mod chunking;
-mod clean;
 pub mod configurations;
 mod constants;
 pub mod data_client;
-mod data_processing;
 pub mod errors;
+mod file_cleaner;
+mod file_downloader;
+mod file_upload_session;
 mod metrics;
 pub mod migration_tool;
 mod parallel_xorb_uploader;
@@ -17,5 +18,6 @@ mod repo_salt;
 mod shard_interface;
 
 pub use cas_client::CacheConfig;
-pub use data_processing::PointerFileTranslator;
+pub use file_downloader::FileDownloader;
+pub use file_upload_session::FileUploadSession;
 pub use pointer_file::PointerFile;

--- a/data/src/migration_tool/migrate.rs
+++ b/data/src/migration_tool/migrate.rs
@@ -11,7 +11,7 @@ use xet_threadpool::ThreadPool;
 use super::hub_client::{HubClient, HubClientTokenRefresher};
 use crate::data_client::{clean_file, default_config, xorb_compression_for_repo_type};
 use crate::errors::DataProcessingError;
-use crate::{PointerFile, PointerFileTranslator};
+use crate::{FileUploadSession, PointerFile};
 
 /// Migrate files to the Hub with external async runtime.
 /// How to use:
@@ -72,9 +72,9 @@ pub async fn migrate_files_impl(
 
     let num_workers = if sequential { 1 } else { threadpool.num_worker_threads() };
     let processor = if dry_run {
-        Arc::new(PointerFileTranslator::dry_run(config, threadpool, None, false).await?)
+        Arc::new(FileUploadSession::dry_run(config, threadpool, None, false).await?)
     } else {
-        Arc::new(PointerFileTranslator::new(config, threadpool, None, false).await?)
+        Arc::new(FileUploadSession::new(config, threadpool, None, false).await?)
     };
 
     let clean_ret = tokio_par_for_each(file_paths, num_workers, |f, _| async {

--- a/data/src/migration_tool/migrate.rs
+++ b/data/src/migration_tool/migrate.rs
@@ -72,9 +72,9 @@ pub async fn migrate_files_impl(
 
     let num_workers = if sequential { 1 } else { threadpool.num_worker_threads() };
     let processor = if dry_run {
-        Arc::new(FileUploadSession::dry_run(config, threadpool, None, false).await?)
+        Arc::new(FileUploadSession::dry_run(config, threadpool, None).await?)
     } else {
-        Arc::new(FileUploadSession::new(config, threadpool, None, false).await?)
+        Arc::new(FileUploadSession::new(config, threadpool, None).await?)
     };
 
     let clean_ret = tokio_par_for_each(file_paths, num_workers, |f, _| async {

--- a/data/src/parallel_xorb_uploader.rs
+++ b/data/src/parallel_xorb_uploader.rs
@@ -12,9 +12,9 @@ use tokio::task::JoinSet;
 use utils::progress::ProgressUpdater;
 use xet_threadpool::ThreadPool;
 
-use crate::data_processing::CASDataAggregator;
 use crate::errors::DataProcessingError::*;
 use crate::errors::*;
+use crate::file_upload_session::CASDataAggregator;
 
 #[async_trait]
 pub(crate) trait XorbUpload {


### PR DESCRIPTION
Renamed the following to more clearly reflect the current functionality:
- PointerFileTranslator is split into FileUploadSession and FileDownloader
- Cleaner -> SingleFileCleaner

The mental model is that a call to download_files or upload_files defines a session, where a session may translate multiple files must fully complete, including completing any remote operations, before returning.  This renaming makes this it clearer where the functionality of different parts of this model live.  
