### PR TITLE
Fix validating v0 xorb bug

### DIFF
--- a/cas_object/src/cas_object_format.rs
+++ b/cas_object/src/cas_object_format.rs
@@ -1130,7 +1130,6 @@ impl CasObject {
 
         if self.info.num_chunks != self.info.chunk_boundary_offsets.len() as u32
             || self.info.num_chunks != self.info.chunk_hashes.len() as u32
-            || self.info.num_chunks != self.info.unpacked_chunk_offsets.len() as u32
         {
             return Err(CasObjectError::FormatError(anyhow!(
                 "Invalid CasObjectInfo, num chunks not matching boundaries or hashes."

--- a/cas_object/src/cas_object_format.rs
+++ b/cas_object/src/cas_object_format.rs
@@ -1130,6 +1130,8 @@ impl CasObject {
 
         if self.info.num_chunks != self.info.chunk_boundary_offsets.len() as u32
             || self.info.num_chunks != self.info.chunk_hashes.len() as u32
+            || (self.info.version == CAS_OBJECT_FORMAT_VERSION
+                && self.info.num_chunks != self.info.unpacked_chunk_offsets.len() as u32)
         {
             return Err(CasObjectError::FormatError(anyhow!(
                 "Invalid CasObjectInfo, num chunks not matching boundaries or hashes."


### PR DESCRIPTION
V0 xorbs doesn't have `unpacked_chunk_offsets`. The check should only be applied on v1 xorbs.