### PR TITLE
Fix parsing v0 xorb again

### DIFF
--- a/cas_object/src/cas_object_format.rs
+++ b/cas_object/src/cas_object_format.rs
@@ -1130,8 +1130,8 @@ impl CasObject {
 
         if self.info.num_chunks != self.info.chunk_boundary_offsets.len() as u32
             || self.info.num_chunks != self.info.chunk_hashes.len() as u32
-            || (self.info.version == CAS_OBJECT_FORMAT_VERSION
-                && self.info.num_chunks != self.info.unpacked_chunk_offsets.len() as u32)
+        // || (self.info.version == CAS_OBJECT_FORMAT_VERSION
+        //     && self.info.num_chunks != self.info.unpacked_chunk_offsets.len() as u32)
         {
             return Err(CasObjectError::FormatError(anyhow!(
                 "Invalid CasObjectInfo, num chunks not matching boundaries or hashes."


### PR DESCRIPTION
We parse V0 xorb as V1, so the version check won't work... Comment out the check for now