### PR TITLE
Adds support cache dir config via env variable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,6 +939,7 @@ dependencies = [
  "reqwest 0.11.27",
  "reqwest-middleware",
  "serde_json",
+ "serial_test",
  "sha2",
  "static_assertions",
  "tempfile",
@@ -3145,6 +3146,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea091f6cac2595aa38993f04f4ee692ed43757035c36e67c180b6828356385b1"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3158,6 +3168,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07779b9b918cc05650cb30f404d4d7835d26df37c235eded8a6832e2fb82cca"
 
 [[package]]
 name = "security-framework"
@@ -3255,6 +3271,31 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot 0.12.3",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -77,6 +77,7 @@ sha2 = { version = "0.10.8", features = ["asm"] }
 sha2 = { version = "0.10.8" }
 
 [dev-dependencies]
+serial_test = "3.2.0"
 
 [features]
 strict = []

--- a/data/src/data_client.rs
+++ b/data/src/data_client.rs
@@ -227,15 +227,18 @@ async fn smudge_file(
         .await?;
     Ok(pointer_file.path().to_string())
 }
+
 #[cfg(test)]
 mod tests {
     use std::env;
 
     use tempfile::tempdir;
+    use serial_test::serial;
 
     use super::*;
 
     #[test]
+    #[serial(default_config_env)]
     fn test_default_config_with_hf_home() {
         let temp_dir = tempdir().unwrap();
         env::set_var("HF_HOME", temp_dir.path().to_str().unwrap());
@@ -257,6 +260,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(default_config_env)]
     fn test_default_config_with_hf_xet_cache_and_hf_home() {
         let temp_dir_xet_cache = tempdir().unwrap();
         let temp_dir_hf_home = tempdir().unwrap();
@@ -299,6 +303,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(default_config_env)]
     fn test_default_config_with_hf_xet_cache() {
         let temp_dir = tempdir().unwrap();
         env::set_var("HF_XET_CACHE", temp_dir.path().to_str().unwrap());
@@ -320,6 +325,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(default_config_env)]
     fn test_default_config_without_env_vars() {
         let endpoint = "http://localhost:8080".to_string();
         let result = default_config(endpoint, None, None, None);

--- a/data/src/data_client.rs
+++ b/data/src/data_client.rs
@@ -229,10 +229,12 @@ async fn smudge_file(
 }
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::env;
+
     use tempfile::tempdir;
-    
+
+    use super::*;
+
     #[test]
     fn test_default_config_with_hf_home() {
         let temp_dir = tempdir().unwrap();
@@ -244,9 +246,12 @@ mod tests {
         assert!(result.is_ok());
         let (config, _tempdir) = result.unwrap();
         assert!(config.cas_storage_config.cache_config.is_some());
-        assert!(
-            config.cas_storage_config.cache_config.unwrap().cache_directory.starts_with(&temp_dir.path())
-        );
+        assert!(config
+            .cas_storage_config
+            .cache_config
+            .unwrap()
+            .cache_directory
+            .starts_with(&temp_dir.path()));
 
         env::remove_var("HF_HOME");
     }
@@ -264,13 +269,16 @@ mod tests {
         assert!(result.is_ok());
         let (config, _tempdir) = result.unwrap();
         assert!(config.cas_storage_config.cache_config.is_some());
-        assert!(
-            config.cas_storage_config.cache_config.unwrap().cache_directory.starts_with(&temp_dir_xet_cache.path())
-        );
+        assert!(config
+            .cas_storage_config
+            .cache_config
+            .unwrap()
+            .cache_directory
+            .starts_with(&temp_dir_xet_cache.path()));
 
         env::remove_var("HF_XET_CACHE");
         env::remove_var("HF_HOME");
-        
+
         let temp_dir = tempdir().unwrap();
         env::set_var("HF_HOME", temp_dir.path().to_str().unwrap());
 
@@ -280,9 +288,12 @@ mod tests {
         assert!(result.is_ok());
         let (config, _tempdir) = result.unwrap();
         assert!(config.cas_storage_config.cache_config.is_some());
-        assert!(
-            config.cas_storage_config.cache_config.unwrap().cache_directory.starts_with(&temp_dir.path())
-        );
+        assert!(config
+            .cas_storage_config
+            .cache_config
+            .unwrap()
+            .cache_directory
+            .starts_with(&temp_dir.path()));
 
         env::remove_var("HF_HOME");
     }
@@ -298,9 +309,12 @@ mod tests {
         assert!(result.is_ok());
         let (config, _tempdir) = result.unwrap();
         assert!(config.cas_storage_config.cache_config.is_some());
-        assert!(
-            config.cas_storage_config.cache_config.unwrap().cache_directory.starts_with(&temp_dir.path())
-        );
+        assert!(config
+            .cas_storage_config
+            .cache_config
+            .unwrap()
+            .cache_directory
+            .starts_with(&temp_dir.path()));
 
         env::remove_var("HF_XET_CACHE");
     }
@@ -310,13 +324,20 @@ mod tests {
         let endpoint = "http://localhost:8080".to_string();
         let result = default_config(endpoint, None, None, None);
 
-        let expected = home_dir().unwrap_or(std::env::current_dir().unwrap()).join(".cache").join("huggingface").join("xet");
+        let expected = home_dir()
+            .unwrap_or(std::env::current_dir().unwrap())
+            .join(".cache")
+            .join("huggingface")
+            .join("xet");
 
         assert!(result.is_ok());
         let (config, _tempdir) = result.unwrap();
         assert!(config.cas_storage_config.cache_config.is_some());
-        assert!(
-            config.cas_storage_config.cache_config.unwrap().cache_directory.starts_with(&expected)
-        );
+        assert!(config
+            .cas_storage_config
+            .cache_config
+            .unwrap()
+            .cache_directory
+            .starts_with(&expected));
     }
 }

--- a/data/src/data_client.rs
+++ b/data/src/data_client.rs
@@ -232,8 +232,8 @@ async fn smudge_file(
 mod tests {
     use std::env;
 
-    use tempfile::tempdir;
     use serial_test::serial;
+    use tempfile::tempdir;
 
     use super::*;
 

--- a/data/src/data_client.rs
+++ b/data/src/data_client.rs
@@ -41,11 +41,11 @@ pub fn default_config(
     // if HF_HOME is set use that instead of ~/.cache/huggingface
     // if HF_XET_CACHE is set use that instead of ~/.cache/huggingface/xet
     // HF_XET_CACHE takes precedence over HF_HOME
-    let cache_root_path = if env::var("HF_HOME").is_ok() {
+    let cache_root_path = if env::var("HF_XET_CACHE").is_ok() {
+        PathBuf::from(env::var("HF_XET_CACHE").unwrap())
+    } else if env::var("HF_HOME").is_ok() {
         let home = env::var("HF_HOME").unwrap();
         PathBuf::from(home).join("xet")
-    } else if env::var("HF_XET_CACHE").is_ok() {
-        PathBuf::from(env::var("HF_XET_CACHE").unwrap())
     } else {
         let home = home_dir().unwrap_or(current_dir()?);
         home.join(".cache").join("huggingface").join("xet")
@@ -226,4 +226,97 @@ async fn smudge_file(
         .smudge_file_from_pointer(pointer_file, &mut f, None, progress_updater)
         .await?;
     Ok(pointer_file.path().to_string())
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+    use tempfile::tempdir;
+    
+    #[test]
+    fn test_default_config_with_hf_home() {
+        let temp_dir = tempdir().unwrap();
+        env::set_var("HF_HOME", temp_dir.path().to_str().unwrap());
+
+        let endpoint = "http://localhost:8080".to_string();
+        let result = default_config(endpoint, None, None, None);
+
+        assert!(result.is_ok());
+        let (config, _tempdir) = result.unwrap();
+        assert!(config.cas_storage_config.cache_config.is_some());
+        assert!(
+            config.cas_storage_config.cache_config.unwrap().cache_directory.starts_with(&temp_dir.path())
+        );
+
+        env::remove_var("HF_HOME");
+    }
+
+    #[test]
+    fn test_default_config_with_hf_xet_cache_and_hf_home() {
+        let temp_dir_xet_cache = tempdir().unwrap();
+        let temp_dir_hf_home = tempdir().unwrap();
+        env::set_var("HF_XET_CACHE", temp_dir_xet_cache.path().to_str().unwrap());
+        env::set_var("HF_HOME", temp_dir_hf_home.path().to_str().unwrap());
+
+        let endpoint = "http://localhost:8080".to_string();
+        let result = default_config(endpoint, None, None, None);
+
+        assert!(result.is_ok());
+        let (config, _tempdir) = result.unwrap();
+        assert!(config.cas_storage_config.cache_config.is_some());
+        assert!(
+            config.cas_storage_config.cache_config.unwrap().cache_directory.starts_with(&temp_dir_xet_cache.path())
+        );
+
+        env::remove_var("HF_XET_CACHE");
+        env::remove_var("HF_HOME");
+        
+        let temp_dir = tempdir().unwrap();
+        env::set_var("HF_HOME", temp_dir.path().to_str().unwrap());
+
+        let endpoint = "http://localhost:8080".to_string();
+        let result = default_config(endpoint, None, None, None);
+
+        assert!(result.is_ok());
+        let (config, _tempdir) = result.unwrap();
+        assert!(config.cas_storage_config.cache_config.is_some());
+        assert!(
+            config.cas_storage_config.cache_config.unwrap().cache_directory.starts_with(&temp_dir.path())
+        );
+
+        env::remove_var("HF_HOME");
+    }
+
+    #[test]
+    fn test_default_config_with_hf_xet_cache() {
+        let temp_dir = tempdir().unwrap();
+        env::set_var("HF_XET_CACHE", temp_dir.path().to_str().unwrap());
+
+        let endpoint = "http://localhost:8080".to_string();
+        let result = default_config(endpoint, None, None, None);
+
+        assert!(result.is_ok());
+        let (config, _tempdir) = result.unwrap();
+        assert!(config.cas_storage_config.cache_config.is_some());
+        assert!(
+            config.cas_storage_config.cache_config.unwrap().cache_directory.starts_with(&temp_dir.path())
+        );
+
+        env::remove_var("HF_XET_CACHE");
+    }
+
+    #[test]
+    fn test_default_config_without_env_vars() {
+        let endpoint = "http://localhost:8080".to_string();
+        let result = default_config(endpoint, None, None, None);
+
+        let expected = home_dir().unwrap_or(std::env::current_dir().unwrap()).join(".cache").join("huggingface").join("xet");
+
+        assert!(result.is_ok());
+        let (config, _tempdir) = result.unwrap();
+        assert!(config.cas_storage_config.cache_config.is_some());
+        assert!(
+            config.cas_storage_config.cache_config.unwrap().cache_directory.starts_with(&expected)
+        );
+    }
 }


### PR DESCRIPTION
Now the code honors HF_HOME env variable, and makes xet cache be $HF_HOME/xet directory.

Also, new env variable HF_XET_CACHE is honored and will be used for xet cache.

Noet: HF_XET_CACHE takes precedence over HF_HOME.

cc: @bpronan @hanouticelina @Wauplin 