### PR TITLE
Releasing version 0.1.4

### DIFF
--- a/hf_xet/Cargo.toml
+++ b/hf_xet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hf_xet"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
Releasing hf_xet 0.1.4 to use latest xorb format, other fixes.