### PR TITLE
Enable unpacked_chunk_offsets check

### DIFF
--- a/cas_object/src/cas_object_format.rs
+++ b/cas_object/src/cas_object_format.rs
@@ -1140,8 +1140,8 @@ impl CasObject {
 
         if self.info.num_chunks != self.info.chunk_boundary_offsets.len() as u32
             || self.info.num_chunks != self.info.chunk_hashes.len() as u32
-        // || (self.info.version == CAS_OBJECT_FORMAT_VERSION
-        //     && self.info.num_chunks != self.info.unpacked_chunk_offsets.len() as u32)
+            || (self.info.boundaries_version == CAS_OBJECT_FORMAT_BOUNDARIES_VERSION
+                && self.info.num_chunks != self.info.unpacked_chunk_offsets.len() as u32)
         {
             return Err(CasObjectError::FormatError(anyhow!(
                 "Invalid CasObjectInfo, num chunks not matching boundaries or hashes."


### PR DESCRIPTION
We use `boundaries_version` to distinguish a V1 xorb from V1 view of a V0 xorb.