### PR TITLE
add utils over unpacked_chunk_offsets

### DIFF
--- a/cas_object/src/cas_chunk_format/deserialize_async.rs
+++ b/cas_object/src/cas_chunk_format/deserialize_async.rs
@@ -44,6 +44,7 @@ pub async fn deserialize_chunk_to_writer<R: AsyncRead + Unpin, W: Write>(
     Ok((header.get_compressed_length() as usize + CAS_CHUNK_HEADER_LENGTH, uncompressed_len as u32))
 }
 
+/// deserialize 1 chunk returning a Vec<u8>, the compressed length and the uncompressed length of the chunk
 pub async fn deserialize_chunk<R: AsyncRead + Unpin>(reader: &mut R) -> Result<(Vec<u8>, usize, u32), CasObjectError> {
     let mut buf = Vec::new();
     let (compressed_len, uncompressed_len) = deserialize_chunk_to_writer(reader, &mut buf).await?;

--- a/cas_object/src/cas_chunk_format/deserialize_async.rs
+++ b/cas_object/src/cas_chunk_format/deserialize_async.rs
@@ -44,6 +44,14 @@ pub async fn deserialize_chunk_to_writer<R: AsyncRead + Unpin, W: Write>(
     Ok((header.get_compressed_length() as usize + CAS_CHUNK_HEADER_LENGTH, uncompressed_len as u32))
 }
 
+pub async fn deserialize_chunk<R: AsyncRead + Unpin>(
+    reader: &mut R,
+) -> Result<(Vec<u8>, usize, u32), CasObjectError> {
+    let mut buf = Vec::new();
+    let (compressed_len, uncompressed_len) = deserialize_chunk_to_writer(reader, &mut buf).await?;
+    Ok((buf, compressed_len, uncompressed_len))
+}
+
 pub async fn deserialize_chunks_to_writer_from_async_read<R: AsyncRead + Unpin, W: Write>(
     reader: &mut R,
     writer: &mut W,

--- a/cas_object/src/cas_chunk_format/deserialize_async.rs
+++ b/cas_object/src/cas_chunk_format/deserialize_async.rs
@@ -44,9 +44,7 @@ pub async fn deserialize_chunk_to_writer<R: AsyncRead + Unpin, W: Write>(
     Ok((header.get_compressed_length() as usize + CAS_CHUNK_HEADER_LENGTH, uncompressed_len as u32))
 }
 
-pub async fn deserialize_chunk<R: AsyncRead + Unpin>(
-    reader: &mut R,
-) -> Result<(Vec<u8>, usize, u32), CasObjectError> {
+pub async fn deserialize_chunk<R: AsyncRead + Unpin>(reader: &mut R) -> Result<(Vec<u8>, usize, u32), CasObjectError> {
     let mut buf = Vec::new();
     let (compressed_len, uncompressed_len) = deserialize_chunk_to_writer(reader, &mut buf).await?;
     Ok((buf, compressed_len, uncompressed_len))

--- a/cas_object/src/cas_object_format.rs
+++ b/cas_object/src/cas_object_format.rs
@@ -1132,6 +1132,8 @@ impl CasObject {
         Ok((byte_offset_start, byte_offset_end))
     }
 
+    /// given a valid chunk_index, returns the uncompressed chunk length for the chunk
+    /// at the given index, chunk_index must be less than the number of chunks in the xorb
     pub fn chunk_length(&self, chunk_index: u32) -> Result<u32, CasObjectError> {
         self.validate_cas_object_info()?;
         let chunk_index = chunk_index as usize;
@@ -1146,6 +1148,9 @@ impl CasObject {
         Ok(cumulative_sum - before)
     }
 
+    /// given a valid start and end, returns the uncompressed end-exclusive range length
+    /// meaning the length of the chunk range [chunk_index_start, chunk_index_end)
+    /// the following condition must be valid: chunk_index_end < chunk_index_end <= num_chunks
     pub fn uncompressed_range_length(
         &self,
         chunk_index_start: u32,
@@ -1854,5 +1859,58 @@ mod tests {
         assert_eq!(ret.info.chunk_boundary_offsets, cas_info_v0.chunk_boundary_offsets);
         assert_eq!(ret.info.chunk_hashes, cas_info_v0.chunk_hashes);
         assert_eq!(ret.info._buffer, cas_info_v0._buffer);
+    }
+
+    #[test]
+    fn test_chunk_length() {
+        const NUM_CHUNKS: u32 = 8;
+        let (c, _, _, _) = build_cas_object(NUM_CHUNKS, ChunkSize::Random(512, 2048), CompressionScheme::LZ4);
+
+        let mut cumulative_sum = 0;
+        for i in 0..NUM_CHUNKS {
+            let chunk_length_result = c.chunk_length(i);
+            assert!(chunk_length_result.is_ok());
+            let chunk_length = chunk_length_result.unwrap();
+            assert_eq!(chunk_length, c.info.unpacked_chunk_offsets[i as usize] - cumulative_sum);
+            cumulative_sum += chunk_length;
+        }
+    }
+
+    #[test]
+    fn test_chunk_length_invalid() {
+        const NUM_CHUNKS: u32 = 8;
+        let (c, _, _, _) = build_cas_object(NUM_CHUNKS, ChunkSize::Random(512, 2048), CompressionScheme::LZ4);
+
+        assert!(c.chunk_length(NUM_CHUNKS).is_err());
+        assert!(c.chunk_length(NUM_CHUNKS + 1).is_err());
+    }
+
+    #[test]
+    fn test_uncompressed_range_length() {
+        const NUM_CHUNKS: u32 = 4;
+        const CHUNK_SIZE: u32 = 512;
+        let (c, _, _, _) = build_cas_object(NUM_CHUNKS, ChunkSize::Fixed(CHUNK_SIZE), CompressionScheme::LZ4);
+
+        for start in 0..(NUM_CHUNKS - 1) {
+            for end in (start + 1)..NUM_CHUNKS {
+                let uncompressed_range_length_result = c.uncompressed_range_length(start, end);
+                assert!(uncompressed_range_length_result.is_ok());
+                let length = uncompressed_range_length_result.unwrap();
+                assert_eq!(length, CHUNK_SIZE * (end - start));
+            }
+        }
+    }
+
+    #[test]
+    fn test_uncompressed_range_length_invalid() {
+        const NUM_CHUNKS: u32 = 4;
+        const CHUNK_SIZE: u32 = 512;
+        let (c, _, _, _) = build_cas_object(NUM_CHUNKS, ChunkSize::Fixed(CHUNK_SIZE), CompressionScheme::LZ4);
+
+        assert!(c.uncompressed_range_length(0, 0).is_err());
+        assert!(c.uncompressed_range_length(1, 0).is_err());
+        assert!(c.uncompressed_range_length(0, NUM_CHUNKS + 1).is_err());
+        assert!(c.uncompressed_range_length(NUM_CHUNKS, NUM_CHUNKS + 1).is_err());
+        assert!(c.uncompressed_range_length(NUM_CHUNKS + 2, NUM_CHUNKS + 1).is_err());
     }
 }

--- a/cas_object/src/cas_object_format.rs
+++ b/cas_object/src/cas_object_format.rs
@@ -1152,16 +1152,16 @@ impl CasObject {
         chunk_index_end: u32,
     ) -> Result<u32, CasObjectError> {
         self.validate_cas_object_info()?;
-        if chunk_index_start >= chunk_index_end || chunk_index_end >= self.info.num_chunks {
-            return Err(CasObjectError::InvalidRange);
+        if chunk_index_start >= chunk_index_end || chunk_index_end > self.info.num_chunks {
+            return Err(CasObjectError::InvalidArguments);
         }
 
         let before_start = match chunk_index_start {
             0 => 0,
             _ => self.info.chunk_boundary_offsets[chunk_index_start as usize - 1],
         };
-        let end = self.info.chunk_boundary_offsets[chunk_index_end as usize];
-        Ok(end - before_start)
+        let incl_end = self.info.chunk_boundary_offsets[chunk_index_end as usize - 1];
+        Ok(incl_end - before_start)
     }
 
     /// Helper method to verify that info object is complete

--- a/cas_object/src/cas_object_format.rs
+++ b/cas_object/src/cas_object_format.rs
@@ -1132,6 +1132,32 @@ impl CasObject {
         Ok((byte_offset_start, byte_offset_end))
     }
 
+    pub fn chunk_length(&self, chunk_index: u32) -> Result<u32, CasObjectError> {
+        self.validate_cas_object_info()?;
+        let chunk_index = chunk_index as usize;
+        if chunk_index >= self.info.unpacked_chunk_offsets.len() {}
+        let cumulative_sum = self.info.unpacked_chunk_offsets[chunk_index];
+        let before = match chunk_index {
+            0 => 0,
+            _ => self.info.chunk_boundary_offsets[chunk_index - 1],
+        };
+        Ok(cumulative_sum - before)
+    }
+
+    pub fn uncompressed_range_length(&self, chunk_index_start: u32, chunk_index_end: u32) -> Result<u32, CasObjectError> {
+        self.validate_cas_object_info()?;
+        if chunk_index_start >= chunk_index_end || chunk_index_end >= self.info.num_chunks {
+            return Err(CasObjectError::InvalidRange);
+        }
+
+        let before_start = match chunk_index_start {
+            0 => 0,
+            _ => self.info.chunk_boundary_offsets[chunk_index_start as usize - 1],
+        };
+        let end = self.info.chunk_boundary_offsets[chunk_index_end as usize];
+        Ok(end - before_start)
+    }
+
     /// Helper method to verify that info object is complete
     fn validate_cas_object_info(&self) -> Result<(), CasObjectError> {
         if self.info.num_chunks == 0 {

--- a/cas_object/src/cas_object_format.rs
+++ b/cas_object/src/cas_object_format.rs
@@ -1141,7 +1141,7 @@ impl CasObject {
         let cumulative_sum = self.info.unpacked_chunk_offsets[chunk_index];
         let before = match chunk_index {
             0 => 0,
-            _ => self.info.chunk_boundary_offsets[chunk_index - 1],
+            _ => self.info.unpacked_chunk_offsets[chunk_index - 1],
         };
         Ok(cumulative_sum - before)
     }
@@ -1158,9 +1158,9 @@ impl CasObject {
 
         let before_start = match chunk_index_start {
             0 => 0,
-            _ => self.info.chunk_boundary_offsets[chunk_index_start as usize - 1],
+            _ => self.info.unpacked_chunk_offsets[chunk_index_start as usize - 1],
         };
-        let incl_end = self.info.chunk_boundary_offsets[chunk_index_end as usize - 1];
+        let incl_end = self.info.unpacked_chunk_offsets[chunk_index_end as usize - 1];
         Ok(incl_end - before_start)
     }
 

--- a/cas_object/src/cas_object_format.rs
+++ b/cas_object/src/cas_object_format.rs
@@ -1135,7 +1135,9 @@ impl CasObject {
     pub fn chunk_length(&self, chunk_index: u32) -> Result<u32, CasObjectError> {
         self.validate_cas_object_info()?;
         let chunk_index = chunk_index as usize;
-        if chunk_index >= self.info.unpacked_chunk_offsets.len() {}
+        if chunk_index >= self.info.unpacked_chunk_offsets.len() {
+            return Err(CasObjectError::InvalidArguments);
+        }
         let cumulative_sum = self.info.unpacked_chunk_offsets[chunk_index];
         let before = match chunk_index {
             0 => 0,
@@ -1144,7 +1146,11 @@ impl CasObject {
         Ok(cumulative_sum - before)
     }
 
-    pub fn uncompressed_range_length(&self, chunk_index_start: u32, chunk_index_end: u32) -> Result<u32, CasObjectError> {
+    pub fn uncompressed_range_length(
+        &self,
+        chunk_index_start: u32,
+        chunk_index_end: u32,
+    ) -> Result<u32, CasObjectError> {
         self.validate_cas_object_info()?;
         if chunk_index_start >= chunk_index_end || chunk_index_end >= self.info.num_chunks {
             return Err(CasObjectError::InvalidRange);

--- a/hf_xet/Cargo.lock
+++ b/hf_xet/Cargo.lock
@@ -1165,7 +1165,7 @@ checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hf_xet"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "bipbuffer",
  "chrono",


### PR DESCRIPTION
Adding utility functions to use the unpacked_chunk_offsets field where we need to use them on the serverside. This branch will be used in the cas server code until ready to merge both.