### PR TITLE
CAS Data Aggregator

### DIFF
--- a/cas_client/src/interface.rs
+++ b/cas_client/src/interface.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use cas_types::{FileRange, QueryReconstructionResponse};
-use mdb_shard::cas_structs::MDBCASInfo;
 use mdb_shard::shard_file_reconstructor::FileReconstructor;
 use merklehash::MerkleHash;
 use reqwest_middleware::ClientWithMiddleware;

--- a/cas_client/src/interface.rs
+++ b/cas_client/src/interface.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use cas_types::{FileRange, QueryReconstructionResponse};
+use mdb_shard::cas_structs::MDBCASInfo;
 use mdb_shard::shard_file_reconstructor::FileReconstructor;
 use merklehash::MerkleHash;
 use reqwest_middleware::ClientWithMiddleware;

--- a/data/src/data_aggregator.rs
+++ b/data/src/data_aggregator.rs
@@ -39,8 +39,6 @@ impl CASDataAggregator {
 
         // Now that we have the CAS hash, fill in any blocks with the referencing xorb
         // hash as needed.
-
-        // Now register any new files as needed.
         for (fi, chunk_hash_indices) in self.pending_file_info.iter_mut() {
             for &i in chunk_hash_indices.iter() {
                 debug_assert_eq!(fi.segments[i].cas_hash, MerkleHash::default());

--- a/data/src/data_aggregator.rs
+++ b/data/src/data_aggregator.rs
@@ -1,0 +1,89 @@
+use mdb_shard::cas_structs::{CASChunkSequenceEntry, CASChunkSequenceHeader, MDBCASInfo};
+use mdb_shard::file_structs::MDBFileInfo;
+use merkledb::aggregate_hashes::cas_node_hash;
+use merklehash::MerkleHash;
+
+#[derive(Default, Debug)]
+pub(crate) struct CASDataAggregator {
+    /// Bytes of all chunks accumulated in one CAS block concatenated together.
+    pub data: Vec<u8>,
+    /// Metadata of all chunks accumulated in one CAS block. Each entry is
+    /// (chunk hash, chunk size).
+    pub chunks: Vec<(MerkleHash, usize)>,
+    // The file info of files that are still being processed.
+    // As we're building this up, we assume that all files that do not have a size in the header are
+    // not finished yet and thus cannot be uploaded.
+    //
+    // All the cases the default hash for a cas info entry will be filled in with the cas hash for
+    // an entry once the cas block is finalized and uploaded.  These correspond to the indices given
+    // alongwith the file info.
+    // This tuple contains the file info (which may be modified) and the divisions in the chunks corresponding
+    // to this file.
+    pub pending_file_info: Vec<(MDBFileInfo, Vec<usize>)>,
+}
+
+impl CASDataAggregator {
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty() && self.chunks.is_empty() && self.pending_file_info.is_empty()
+    }
+
+    pub fn size(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Finalize the result, returning the CAS info, xorb data, and the file info that's included in this.
+    pub fn finalize(mut self) -> (MDBCASInfo, Vec<u8>, Vec<MDBFileInfo>) {
+        // First, cut the xorb for this one.
+        let raw_bytes_len = self.data.len();
+        let cas_hash = cas_node_hash(&self.chunks[..]);
+
+        // Now that we have the CAS hash, fill in any blocks with the referencing xorb
+        // hash as needed.
+
+        // Now register any new files as needed.
+        for (fi, chunk_hash_indices) in self.pending_file_info.iter_mut() {
+            for &i in chunk_hash_indices.iter() {
+                debug_assert_eq!(fi.segments[i].cas_hash, MerkleHash::default());
+                fi.segments[i].cas_hash = cas_hash;
+            }
+        }
+
+        // Build the MDBCASInfo struct.
+        let metadata = CASChunkSequenceHeader::new(cas_hash, self.chunks.len(), raw_bytes_len);
+
+        let mut pos = 0;
+        let chunks: Vec<_> = self
+            .chunks
+            .iter()
+            .map(|(h, len)| {
+                let ret = CASChunkSequenceEntry::new(*h, *len, pos);
+                pos += *len;
+                ret
+            })
+            .collect();
+        let cas_info = MDBCASInfo { metadata, chunks };
+
+        (cas_info, self.data, self.pending_file_info.into_iter().map(|(fi, _)| fi).collect())
+    }
+
+    pub fn merge_in(&mut self, mut other: CASDataAggregator) {
+        let shift = self.chunks.len() as u32;
+        self.data.append(&mut other.data);
+        self.chunks.append(&mut other.chunks);
+
+        // Adjust the chunk indices and shifts for
+        for file_info in other.pending_file_info.iter_mut() {
+            for fi in file_info.0.segments.iter_mut() {
+                // To transfer the cas chunks from the other data aggregator to this one,
+                // shift chunk indices so the new index start and end values reflect the
+                // append opperation above.
+                if fi.cas_hash == MerkleHash::default() {
+                    fi.chunk_index_start += shift;
+                    fi.chunk_index_end += shift;
+                }
+            }
+        }
+
+        self.pending_file_info.append(&mut other.pending_file_info);
+    }
+}

--- a/data/src/file_cleaner.rs
+++ b/data/src/file_cleaner.rs
@@ -644,77 +644,57 @@ impl SingleFileCleaner {
     async fn summarize_dedup_info(&self) -> Result<(MerkleHash, u64)> {
         let mut tracking_info = self.tracking_info.lock().await;
 
+        let mut chunk_idx = 0;
+
         let file_hash = file_node_hash(&tracking_info.file_hashes, &self.repo_salt.unwrap_or_default())?;
 
-        // Always register a new file info to be uploaded. This is because each file is associated with a repo and
-        // the client doesn't know with which repo this file is associated given local information.
-        // TODO: server exposes a HEAD repo_id/file_id endpoint so client can check if this file exists.
+        // Create the verification.
+        let verification = tracking_info
+            .file_info
+            .iter()
+            .map(|entry| {
+                let n_chunks = (entry.chunk_index_end - entry.chunk_index_start) as usize;
+                let chunk_hashes: Vec<_> = tracking_info.file_hashes[chunk_idx..chunk_idx + n_chunks]
+                    .iter()
+                    .map(|(hash, _)| *hash)
+                    .collect();
+                let range_hash = range_hash_from_chunks(&chunk_hashes);
+                chunk_idx += n_chunks;
 
-        {
-            // Put an accumulated data into the struct-wide cas block for building a future chunk.
-            let mut cas_data_accumulator = self.global_cas_data.lock().await;
+                FileVerificationEntry::new(range_hash)
+            })
+            .collect();
 
-            let shift = cas_data_accumulator.chunks.len() as u32;
-            cas_data_accumulator.data.append(&mut tracking_info.cas_data.data);
-            cas_data_accumulator.chunks.append(&mut tracking_info.cas_data.chunks);
+        // Create the metadata extension
+        let metadata_ext = Some(FileMetadataExt::new(self.sha_generator.generate()?));
 
-            let segments: Vec<_> = tracking_info
-                .file_info
-                .iter()
-                .map(|fi| {
-                    // Transfering cas chunks from tracking_info.cas_data to cas_data_accumulator,
-                    // shift chunk indices.
-                    let s = if fi.cas_hash == MerkleHash::default() { shift } else { 0 };
+        let file_info = MDBFileInfo {
+            metadata: FileDataSequenceHeader::new(
+                file_hash,
+                tracking_info.file_info.len(),
+                true,
+                metadata_ext.is_some(),
+            ),
+            segments: take(&mut tracking_info.file_info),
+            verification,
+            metadata_ext,
+        };
 
-                    let mut new_fi = fi.clone();
-                    new_fi.chunk_index_start += s;
-                    new_fi.chunk_index_end += s;
+        let mut local_data_aggregator = take(&mut tracking_info.cas_data);
+        local_data_aggregator
+            .pending_file_info
+            .push((file_info, take(&mut tracking_info.current_cas_file_info_indices)));
 
-                    new_fi
-                })
-                .collect();
+        // Put an accumulated data into the struct-wide cas block for building a future chunk.
+        let mut global_cas_data = self.global_cas_data.lock().await;
+        global_cas_data.merge_in(local_data_aggregator);
 
-            let mut chunk_idx = 0;
-            let verification = segments
-                .iter()
-                .map(|entry| {
-                    let n_chunks = (entry.chunk_index_end - entry.chunk_index_start) as usize;
-                    let chunk_hashes: Vec<_> = tracking_info.file_hashes[chunk_idx..chunk_idx + n_chunks]
-                        .iter()
-                        .map(|(hash, _)| *hash)
-                        .collect();
-                    let range_hash = range_hash_from_chunks(&chunk_hashes);
-                    chunk_idx += n_chunks;
-
-                    FileVerificationEntry::new(range_hash)
-                })
-                .collect();
-
-            let metadata_ext = Some(FileMetadataExt::new(self.sha_generator.generate()?));
-
-            let new_file_info = MDBFileInfo {
-                metadata: FileDataSequenceHeader::new(
-                    file_hash,
-                    tracking_info.file_info.len(),
-                    true,
-                    metadata_ext.is_some(),
-                ),
-                segments,
-                verification,
-                metadata_ext,
-            };
-
-            cas_data_accumulator
-                .pending_file_info
-                .push((new_file_info, tracking_info.current_cas_file_info_indices.clone()));
-
-            if cas_data_accumulator.data.len() >= TARGET_CAS_BLOCK_SIZE {
-                let new_cas_data = take(cas_data_accumulator.deref_mut());
-                drop(cas_data_accumulator); // Release the lock.
-                self.xorb_uploader.register_new_cas_block(new_cas_data).await?;
-            } else {
-                drop(cas_data_accumulator);
-            }
+        if global_cas_data.data.len() >= TARGET_CAS_BLOCK_SIZE {
+            let new_cas_data = take(global_cas_data.deref_mut());
+            drop(global_cas_data); // Release the lock.
+            self.xorb_uploader.register_new_cas_block(new_cas_data).await?;
+        } else {
+            drop(global_cas_data);
         }
 
         let file_size = self.metrics.file_size.load(Ordering::Relaxed);

--- a/data/src/file_cleaner.rs
+++ b/data/src/file_cleaner.rs
@@ -30,9 +30,9 @@ use crate::constants::{
     DEFAULT_MIN_N_CHUNKS_PER_RANGE, MIN_N_CHUNKS_PER_RANGE_HYSTERESIS_FACTOR, MIN_SPACING_BETWEEN_GLOBAL_DEDUP_QUERIES,
     NRANGES_IN_STREAMING_FRAGMENTATION_ESTIMATOR,
 };
+use crate::data_aggregator::CASDataAggregator;
 use crate::errors::DataProcessingError::*;
 use crate::errors::Result;
-use crate::file_upload_session::CASDataAggregator;
 use crate::metrics::FILTER_BYTES_CLEANED;
 use crate::parallel_xorb_uploader::XorbUpload;
 use crate::remote_shard_interface::RemoteShardInterface;

--- a/data/src/lib.rs
+++ b/data/src/lib.rs
@@ -4,6 +4,7 @@ mod cas_interface;
 mod chunking;
 pub mod configurations;
 mod constants;
+mod data_aggregator;
 pub mod data_client;
 pub mod errors;
 mod file_cleaner;

--- a/data/src/parallel_xorb_uploader.rs
+++ b/data/src/parallel_xorb_uploader.rs
@@ -3,11 +3,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use cas_client::Client;
-use mdb_shard::cas_structs::{CASChunkSequenceEntry, CASChunkSequenceHeader, MDBCASInfo};
 use mdb_shard::ShardFileManager;
-use merkledb::aggregate_hashes::cas_node_hash;
 use merklehash::MerkleHash;
-use tokio::runtime::Handle;
 use tokio::sync::{Mutex, Semaphore};
 use tokio::task::JoinSet;
 use utils::progress::ProgressUpdater;

--- a/data/src/parallel_xorb_uploader.rs
+++ b/data/src/parallel_xorb_uploader.rs
@@ -7,14 +7,15 @@ use mdb_shard::cas_structs::{CASChunkSequenceEntry, CASChunkSequenceHeader, MDBC
 use mdb_shard::ShardFileManager;
 use merkledb::aggregate_hashes::cas_node_hash;
 use merklehash::MerkleHash;
+use tokio::runtime::Handle;
 use tokio::sync::{Mutex, Semaphore};
 use tokio::task::JoinSet;
 use utils::progress::ProgressUpdater;
 use xet_threadpool::ThreadPool;
 
+use crate::data_aggregator::CASDataAggregator;
 use crate::errors::DataProcessingError::*;
 use crate::errors::*;
-use crate::file_upload_session::CASDataAggregator;
 
 #[async_trait]
 pub(crate) trait XorbUpload {
@@ -103,9 +104,8 @@ impl XorbUpload for ParallelXorbUploader {
             }
             Ok(MerkleHash::default())
         } else {
-            let xorb_data_len = cas_data.data.len();
-
-            let cas_hash = cas_node_hash(&cas_data.chunks[..]);
+            let (cas_info, data, file_info) = cas_data.finalize();
+            let cas_hash = cas_info.metadata.cas_hash;
 
             // Rate limiting, the acquired permit is dropped after the task completes.
             // The chosen Semaphore is fair, meaning xorbs added first will be scheduled to upload first.
@@ -116,36 +116,32 @@ impl XorbUpload for ParallelXorbUploader {
                 .await
                 .map_err(|e| UploadTaskError(e.to_string()))?;
 
-            let item = (cas_hash, cas_data.data, cas_data.chunks);
             let shard_manager = self.shard_manager.clone();
-            let cas = self.cas.clone();
+            let client = self.cas.clone();
             let cas_prefix = self.cas_prefix.clone();
-
-            let mut upload_tasks = self.upload_tasks.lock().await;
             let upload_progress_updater = self.upload_progress_updater.clone();
-            upload_tasks.spawn_on(
+
+            self.upload_tasks.lock().await.spawn_on(
                 async move {
-                    let ret = upload_and_register_xorb(item, shard_manager, cas, cas_prefix).await;
-                    if ret.is_ok() {
-                        if let Some(updater) = upload_progress_updater {
-                            updater.update(xorb_data_len as u64);
-                        }
-                    }
+                    let n_bytes_transmitted = client
+                        .put(&cas_prefix, &cas_hash, data, cas_info.chunks_and_boundaries())
+                        .await?;
                     drop(permit);
-                    ret
+
+                    shard_manager.add_cas_block(cas_info).await?;
+
+                    if let Some(updater) = upload_progress_updater {
+                        updater.update(n_bytes_transmitted as u64);
+                    }
+                    Ok(n_bytes_transmitted)
                 },
                 &self.threadpool.handle(),
             );
 
-            // Now register any new files as needed.
-            for (mut fi, chunk_hash_indices) in cas_data.pending_file_info {
-                for i in chunk_hash_indices {
-                    debug_assert_eq!(fi.segments[i].cas_hash, MerkleHash::default());
-                    fi.segments[i].cas_hash = cas_hash;
-                }
-
+            for fi in file_info {
                 self.shard_manager.add_file_reconstruction_info(fi).await?;
             }
+
             Ok(cas_hash)
         }
     }
@@ -162,49 +158,4 @@ impl XorbUpload for ParallelXorbUploader {
 
         Ok(self.total_bytes_trans.load(Ordering::Relaxed))
     }
-}
-
-async fn upload_and_register_xorb(
-    item: XorbUploadValueType,
-    shard_manager: Arc<ShardFileManager>,
-    cas: Arc<dyn Client + Send + Sync>,
-    cas_prefix: String,
-) -> Result<usize> {
-    let (cas_hash, data, chunks) = item;
-
-    let raw_bytes_len = data.len();
-    // upload xorb
-    let nbytes_trans = {
-        let mut pos = 0;
-        let chunk_and_boundaries = chunks
-            .iter()
-            .map(|(hash, len)| {
-                pos += *len;
-                (*hash, pos as u32)
-            })
-            .collect();
-        cas.put(&cas_prefix, &cas_hash, data, chunk_and_boundaries).await?
-    };
-
-    // register for dedup
-    // This should happen after uploading xorb above succeeded so not to
-    // leave invalid information in the local shard to dedup other xorbs.
-    {
-        let metadata = CASChunkSequenceHeader::new(cas_hash, chunks.len(), raw_bytes_len);
-
-        let mut pos = 0;
-        let chunks: Vec<_> = chunks
-            .iter()
-            .map(|(h, len)| {
-                let result = CASChunkSequenceEntry::new(*h, *len, pos);
-                pos += *len;
-                result
-            })
-            .collect();
-        let cas_info = MDBCASInfo { metadata, chunks };
-
-        shard_manager.add_cas_block(cas_info).await?;
-    }
-
-    Ok(nbytes_trans)
 }

--- a/mdb_shard/src/cas_structs.rs
+++ b/mdb_shard/src/cas_structs.rs
@@ -187,7 +187,7 @@ impl MDBCASInfo {
     pub fn chunks_and_boundaries(&self) -> Vec<(MerkleHash, u32)> {
         self.chunks
             .iter()
-            .map(|entry| (entry.chunk_hash, entry.chunk_byte_range_start))
+            .map(|entry| (entry.chunk_hash, entry.chunk_byte_range_start + entry.unpacked_segment_bytes))
             .collect()
     }
 }

--- a/mdb_shard/src/cas_structs.rs
+++ b/mdb_shard/src/cas_structs.rs
@@ -183,6 +183,13 @@ impl MDBCASInfo {
 
         Ok(n_out_bytes)
     }
+
+    pub fn chunks_and_boundaries(&self) -> Vec<(MerkleHash, u32)> {
+        self.chunks
+            .iter()
+            .map(|entry| (entry.chunk_hash, entry.chunk_byte_range_start))
+            .collect()
+    }
 }
 
 pub struct MDBCASInfoView {


### PR DESCRIPTION
This PR simply consolidates the functionality around building the CAS data blocks to the CASDataAggregator class, which eliminates several places with cut and pasted code.  

This PR is one reviewable step in a larger revision that simplifies the file cleaning and upload code paths.