### PR TITLE
Make Disk Cache Configurable by environment variable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -917,6 +917,7 @@ dependencies = [
  "cas_object",
  "cas_types",
  "chrono",
+ "chunk_cache",
  "clap 3.2.25",
  "dirs",
  "error_printer",

--- a/chunk_cache/src/disk.rs
+++ b/chunk_cache/src/disk.rs
@@ -27,14 +27,7 @@ pub mod test_utils;
 
 // consistently use URL_SAFE (also file path safe) base64 codec
 pub(crate) const BASE64_ENGINE: GeneralPurpose = URL_SAFE;
-pub const DEFAULT_CAPACITY: u64 = {
-    let default = 10 << 30; // 10 GB
-    std::env::var("HF_XET_CACHE_SIZE_GB")
-        .ok()
-        .and_then(|s| s.parse::<u64>().ok())
-        .map(|size| size << 30) // Convert GB to bytes
-        .unwrap_or(default)
-};
+pub const DEFAULT_CAPACITY: u64 = 10 << 30; // 10 GB
 const PREFIX_DIR_NAME_LEN: usize = 2;
 
 type OptionResult<T, E> = Result<Option<T>, E>;
@@ -818,6 +811,11 @@ mod tests {
     use crate::{CacheConfig, ChunkCache};
 
     const RANDOM_SEED: u64 = 9089 << 20 | 120043;
+
+    #[test]
+    fn test_default_capacity() {
+        assert_eq!(DEFAULT_CAPACITY, 10 << 30, "DEFAULT_CAPACITY should be 10GB");
+    }
 
     #[test]
     fn test_get_cache_empty() {

--- a/chunk_cache/src/disk.rs
+++ b/chunk_cache/src/disk.rs
@@ -29,7 +29,7 @@ pub mod test_utils;
 pub(crate) const BASE64_ENGINE: GeneralPurpose = URL_SAFE;
 pub const DEFAULT_CAPACITY: u64 = {
     let default = 10 << 30; // 10 GB
-    std::env::var("XET_CACHE_SIZE")
+    std::env::var("HF_XET_CACHE_SIZE_GB")
         .ok()
         .and_then(|s| s.parse::<u64>().ok())
         .map(|size| size << 30) // Convert GB to bytes

--- a/chunk_cache/src/disk.rs
+++ b/chunk_cache/src/disk.rs
@@ -27,7 +27,14 @@ pub mod test_utils;
 
 // consistently use URL_SAFE (also file path safe) base64 codec
 pub(crate) const BASE64_ENGINE: GeneralPurpose = URL_SAFE;
-pub const DEFAULT_CAPACITY: u64 = 10 << 30; // 10 GB
+pub const DEFAULT_CAPACITY: u64 = {
+    let default = 10 << 30; // 10 GB
+    std::env::var("XET_CACHE_SIZE")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .map(|size| size << 30) // Convert GB to bytes
+        .unwrap_or(default)
+};
 const PREFIX_DIR_NAME_LEN: usize = 2;
 
 type OptionResult<T, E> = Result<Option<T>, E>;

--- a/chunk_cache/src/disk.rs
+++ b/chunk_cache/src/disk.rs
@@ -12,7 +12,7 @@ use cas_types::{ChunkRange, Key};
 use error_printer::ErrorPrinter;
 use file_utils::SafeFileCreator;
 use merklehash::MerkleHash;
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 #[cfg(feature = "analysis")]
 use utils::output_bytes;
 
@@ -147,6 +147,12 @@ impl DiskCache {
         let mut num_items = 0;
         let max_num_bytes = 2 * capacity;
 
+        // short circuit if no capacity to cache.
+        if capacity == 0 {
+            info!("cache capacity is 0, not loading any cache state");
+            return Ok(CacheState::new(state, 0, 0));
+        }
+
         let Some(cache_root_readdir) = read_dir(cache_root)? else {
             return Ok(CacheState::new(state, 0, 0));
         };
@@ -168,7 +174,7 @@ impl DiskCache {
                 continue;
             };
 
-            // loop throught key directories inside prefix directory
+            // loop through key directories inside prefix directory
             for key_dir in key_prefix_readdir {
                 let key_dir = match is_ok_dir(key_dir) {
                     Ok(Some(dirent)) => dirent,

--- a/chunk_cache/src/lib.rs
+++ b/chunk_cache/src/lib.rs
@@ -7,8 +7,7 @@ use std::path::PathBuf;
 pub use cache_manager::get_cache;
 use cas_types::{ChunkRange, Key};
 pub use disk::test_utils::*;
-pub use disk::DiskCache;
-pub use disk::DEFAULT_CAPACITY;
+pub use disk::{DiskCache, DEFAULT_CAPACITY};
 use error::ChunkCacheError;
 use mockall::automock;
 

--- a/chunk_cache/src/lib.rs
+++ b/chunk_cache/src/lib.rs
@@ -1,5 +1,5 @@
 mod cache_manager;
-mod disk;
+pub mod disk;
 pub mod error;
 
 use std::path::PathBuf;
@@ -8,10 +8,9 @@ pub use cache_manager::get_cache;
 use cas_types::{ChunkRange, Key};
 pub use disk::test_utils::*;
 pub use disk::DiskCache;
+pub use disk::DEFAULT_CAPACITY;
 use error::ChunkCacheError;
 use mockall::automock;
-
-use crate::disk::DEFAULT_CAPACITY;
 
 /// ChunkCache is a trait for storing and fetching Xorb ranges.
 /// implementors are expected to return bytes for a key and a given chunk range

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/bin/xtool.rs"
 cas_client = { path = "../cas_client" }
 cas_object = { path = "../cas_object" }
 cas_types = { path = "../cas_types" }
+chunk_cache = { path = "../chunk_cache" }
 merkledb = { path = "../merkledb" }
 merklehash = { path = "../merklehash" }
 mdb_shard = { path = "../mdb_shard" }

--- a/data/src/configurations.rs
+++ b/data/src/configurations.rs
@@ -3,11 +3,11 @@ use std::str::FromStr;
 
 use cas_client::CacheConfig;
 use cas_object::CompressionScheme;
+use chunk_cache::disk::DEFAULT_CAPACITY;
 use utils::auth::AuthConfig;
 
 use crate::errors::Result;
 use crate::repo_salt::RepoSalt;
-use chunk_cache::disk::DEFAULT_CAPACITY;
 
 #[derive(Debug)]
 pub enum Endpoint {

--- a/data/src/configurations.rs
+++ b/data/src/configurations.rs
@@ -7,6 +7,7 @@ use utils::auth::AuthConfig;
 
 use crate::errors::Result;
 use crate::repo_salt::RepoSalt;
+use chunk_cache::disk::DEFAULT_CAPACITY;
 
 #[derive(Debug)]
 pub enum Endpoint {
@@ -112,7 +113,7 @@ impl TranslatorConfig {
                 prefix: "default".into(),
                 cache_config: Some(CacheConfig {
                     cache_directory: path.join("cache"),
-                    cache_size: 10 * 1024 * 1024 * 1024, // 10 GiB
+                    cache_size: DEFAULT_CAPACITY,
                 }),
                 staging_directory: None,
             },

--- a/data/src/data_client.rs
+++ b/data/src/data_client.rs
@@ -251,10 +251,10 @@ mod tests {
     fn test_cache_size_env_var() {
         // Test with different cache sizes
         let test_cases = vec![
-            (Some("5"), 5 << 30),    // 5GB
-            (Some("20"), 20 << 30),  // 20GB
-            (Some("1"), 1 << 30),    // 1GB
-            (None, DEFAULT_CAPACITY), // Default when not set
+            (Some("5"), 5 << 30),                // 5GB
+            (Some("20"), 20 << 30),              // 20GB
+            (Some("1"), 1 << 30),                // 1GB
+            (None, DEFAULT_CAPACITY),            // Default when not set
             (Some("invalid"), DEFAULT_CAPACITY), // Default when invalid value
         ];
 
@@ -267,7 +267,9 @@ mod tests {
             }
 
             // Verify the configured cache size matches the expected size
-            assert_eq!(get_configured_cache_size(), expected_size,
+            assert_eq!(
+                get_configured_cache_size(),
+                expected_size,
                 "Cache size mismatch for env var value {:?}. Expected {}GB, got {}GB",
                 env_value,
                 expected_size >> 30,

--- a/data/src/data_client.rs
+++ b/data/src/data_client.rs
@@ -247,10 +247,11 @@ mod tests {
     use super::*;
 
     #[test]
-    #[serial]
+    #[serial(xet_cache_size)]
     fn test_cache_size_env_var() {
         // Test with different cache sizes
         let test_cases = vec![
+            (Some("0"), 0),                      // 0GB (disable chunk-cache)
             (Some("5"), 5 << 30),                // 5GB
             (Some("20"), 20 << 30),              // 20GB
             (Some("1"), 1 << 30),                // 1GB
@@ -275,7 +276,19 @@ mod tests {
                 expected_size >> 30,
                 get_configured_cache_size() >> 30
             );
-        }
+
+            let endpoint = "http://localhost:8080".to_string();
+            let result = default_config(endpoint, None, None, None);
+
+            assert!(result.is_ok());
+            let (config, _tempdir) = result.unwrap();
+            assert!(config.cas_storage_config.cache_config.is_some());
+            assert_eq!(config
+                .cas_storage_config
+                .cache_config
+                .unwrap()
+                .cache_size, expected_size);
+            }
     }
 
     #[test]

--- a/data/src/data_client.rs
+++ b/data/src/data_client.rs
@@ -283,12 +283,8 @@ mod tests {
             assert!(result.is_ok());
             let (config, _tempdir) = result.unwrap();
             assert!(config.cas_storage_config.cache_config.is_some());
-            assert_eq!(config
-                .cas_storage_config
-                .cache_config
-                .unwrap()
-                .cache_size, expected_size);
-            }
+            assert_eq!(config.cas_storage_config.cache_config.unwrap().cache_size, expected_size);
+        }
     }
 
     #[test]

--- a/data/src/data_client.rs
+++ b/data/src/data_client.rs
@@ -8,6 +8,7 @@ use std::{env, fs};
 
 use cas_client::CacheConfig;
 use cas_object::CompressionScheme;
+use chunk_cache::disk::DEFAULT_CAPACITY;
 use dirs::home_dir;
 use lazy_static::lazy_static;
 use merkledb::constants::IDEAL_CAS_BLOCK_SIZE;
@@ -84,7 +85,7 @@ pub fn default_config(
             prefix: "default".into(),
             cache_config: Some(CacheConfig {
                 cache_directory: cache_path.join("chunk-cache"),
-                cache_size: 10 * 1024 * 1024 * 1024, // 10 GiB
+                cache_size: DEFAULT_CAPACITY,
             }),
             staging_directory: None,
         },


### PR DESCRIPTION
Make the chunk cache configurable through environment variable, specifically HF_XET_CACHE_SIZE_GB. Defaults to 10GB. Setting it to 0 disables the chunk cache.