### PR TITLE
Restrict memory allocation size on Xorb deserialization

### DIFF
--- a/cas_client/src/remote_client.rs
+++ b/cas_client/src/remote_client.rs
@@ -24,6 +24,7 @@ use utils::singleflight::Group;
 use xet_threadpool::ThreadPool;
 
 use crate::error::Result;
+use crate::http_client::ResponseErrorLogger;
 use crate::interface::*;
 use crate::{http_client, CasClientError, Client};
 

--- a/cas_client/src/remote_client.rs
+++ b/cas_client/src/remote_client.rs
@@ -24,7 +24,6 @@ use utils::singleflight::Group;
 use xet_threadpool::ThreadPool;
 
 use crate::error::Result;
-use crate::http_client::ResponseErrorLogger;
 use crate::interface::*;
 use crate::{http_client, CasClientError, Client};
 

--- a/cas_object/src/cas_object_format.rs
+++ b/cas_object/src/cas_object_format.rs
@@ -5,6 +5,7 @@ use std::mem::{size_of, size_of_val};
 use anyhow::anyhow;
 use bytes::Buf;
 use futures::AsyncReadExt;
+use merkledb::constants::{IDEAL_CAS_BLOCK_SIZE, TARGET_CDC_CHUNK_SIZE};
 use merkledb::prelude::MerkleDBHighLevelMethodsV1;
 use merkledb::{Chunk, MerkleMemDB};
 use merklehash::{DataHash, MerkleHash};
@@ -29,6 +30,8 @@ pub(crate) const CAS_OBJECT_FORMAT_BOUNDARIES_VERSION_NO_UNPACKED_INFO: u8 = 0;
 pub(crate) const CAS_OBJECT_FORMAT_BOUNDARIES_VERSION: u8 = 1;
 const _CAS_OBJECT_INFO_DEFAULT_LENGTH_V0: u32 = 60;
 const CAS_OBJECT_INFO_DEFAULT_LENGTH: u32 = 92;
+
+const AVERAGE_NUM_CHUNKS_PER_XORB: usize = IDEAL_CAS_BLOCK_SIZE / TARGET_CDC_CHUNK_SIZE;
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize)]
 /// Info struct for [CasObject]. This is stored at the end of the XORB.
@@ -163,13 +166,13 @@ impl CasObjectInfoV0 {
         read_bytes(&mut num_chunks)?;
         let num_chunks = u32::from_le_bytes(num_chunks);
 
-        let mut chunk_boundary_offsets = Vec::with_capacity(num_chunks as usize);
+        let mut chunk_boundary_offsets = Vec::with_capacity((num_chunks as usize).min(AVERAGE_NUM_CHUNKS_PER_XORB));
         for _ in 0..num_chunks {
             let mut offset = [0u8; size_of::<u32>()];
             read_bytes(&mut offset)?;
             chunk_boundary_offsets.push(u32::from_le_bytes(offset));
         }
-        let mut chunk_hashes = Vec::with_capacity(num_chunks as usize);
+        let mut chunk_hashes = Vec::with_capacity((num_chunks as usize).min(AVERAGE_NUM_CHUNKS_PER_XORB));
         for _ in 0..num_chunks {
             let mut hash = [0u8; size_of::<MerkleHash>()];
             read_bytes(&mut hash)?;
@@ -226,13 +229,13 @@ impl CasObjectInfoV0 {
         read_bytes(reader, &mut total_bytes_read, &mut num_chunks).await?;
         let num_chunks = u32::from_le_bytes(num_chunks);
 
-        let mut chunk_boundary_offsets = Vec::with_capacity(num_chunks as usize);
+        let mut chunk_boundary_offsets = Vec::with_capacity((num_chunks as usize).min(AVERAGE_NUM_CHUNKS_PER_XORB));
         for _ in 0..num_chunks {
             let mut offset = [0u8; size_of::<u32>()];
             read_bytes(reader, &mut total_bytes_read, &mut offset).await?;
             chunk_boundary_offsets.push(u32::from_le_bytes(offset));
         }
-        let mut chunk_hashes = Vec::with_capacity(num_chunks as usize);
+        let mut chunk_hashes = Vec::with_capacity((num_chunks as usize).min(AVERAGE_NUM_CHUNKS_PER_XORB));
         for _ in 0..num_chunks {
             let mut hash = [0u8; size_of::<MerkleHash>()];
             read_bytes(reader, &mut total_bytes_read, &mut hash).await?;
@@ -495,9 +498,9 @@ impl CasObjectInfoV1 {
         let num_chunks_2 = read_u32(r)?;
 
         // Read in the hashes.
-        s.chunk_hashes.resize(num_chunks_2 as usize, MerkleHash::default());
-        for s in s.chunk_hashes.iter_mut() {
-            *s = read_hash(r)?;
+        s.chunk_hashes.reserve((num_chunks_2 as usize).min(AVERAGE_NUM_CHUNKS_PER_XORB));
+        for _ in 0..num_chunks_2 {
+            s.chunk_hashes.push(read_hash(r)?);
         }
 
         //////////////////////////////////////////////////////////////////////////////////////////////
@@ -527,11 +530,17 @@ impl CasObjectInfoV1 {
             )));
         }
 
-        s.chunk_boundary_offsets.resize(num_chunks_3 as usize, 0);
-        read_u32s(r, &mut s.chunk_boundary_offsets)?;
+        s.chunk_boundary_offsets
+            .reserve((num_chunks_3 as usize).min(AVERAGE_NUM_CHUNKS_PER_XORB));
+        for _ in 0..num_chunks_3 {
+            s.chunk_boundary_offsets.push(read_u32(r)?);
+        }
 
-        s.unpacked_chunk_offsets.resize(num_chunks_3 as usize, 0);
-        read_u32s(r, &mut s.unpacked_chunk_offsets)?;
+        s.unpacked_chunk_offsets
+            .reserve((num_chunks_3 as usize).min(AVERAGE_NUM_CHUNKS_PER_XORB));
+        for _ in 0..num_chunks_3 {
+            s.unpacked_chunk_offsets.push(read_u32(r)?);
+        }
 
         // Now the final parts here.
         s.num_chunks = read_u32(r)?;
@@ -601,9 +610,9 @@ impl CasObjectInfoV1 {
         let num_chunks_2 = read_u32_async(r).await?;
 
         // Read in the hashes.
-        s.chunk_hashes.resize(num_chunks_2 as usize, MerkleHash::default());
-        for s in s.chunk_hashes.iter_mut() {
-            *s = read_hash_async(r).await?;
+        s.chunk_hashes.reserve((num_chunks_2 as usize).min(AVERAGE_NUM_CHUNKS_PER_XORB));
+        for _ in 0..num_chunks_2 {
+            s.chunk_hashes.push(read_hash_async(r).await?);
         }
 
         //////////////////////////////////////////////////////////////////////////////////////////////
@@ -633,11 +642,17 @@ impl CasObjectInfoV1 {
             )));
         }
 
-        s.chunk_boundary_offsets.resize(num_chunks_3 as usize, 0);
-        read_u32s_async(r, &mut s.chunk_boundary_offsets).await?;
+        s.chunk_boundary_offsets
+            .reserve((num_chunks_3 as usize).min(AVERAGE_NUM_CHUNKS_PER_XORB));
+        for _ in 0..num_chunks_3 {
+            s.chunk_boundary_offsets.push(read_u32_async(r).await?);
+        }
 
-        s.unpacked_chunk_offsets.resize(num_chunks_3 as usize, 0);
-        read_u32s_async(r, &mut s.unpacked_chunk_offsets).await?;
+        s.unpacked_chunk_offsets
+            .reserve((num_chunks_3 as usize).min(AVERAGE_NUM_CHUNKS_PER_XORB));
+        for _ in 0..num_chunks_3 {
+            s.unpacked_chunk_offsets.push(read_u32_async(r).await?);
+        }
 
         s.num_chunks = read_u32_async(r).await?;
 

--- a/cas_object/src/validate_xorb_stream.rs
+++ b/cas_object/src/validate_xorb_stream.rs
@@ -89,6 +89,8 @@ async fn _validate_cas_object_from_async_read<R: AsyncRead + Unpin>(
         let chunk_header = parse_chunk_header(buf8).log_error(format!("failed to parse chunk header {buf8:?}"))?;
 
         let chunk_compressed_len = chunk_header.get_compressed_length() as usize;
+        // compressed length is validated above in chunk header parsing that it
+        // will not exceed maximum chunk size * 2.
         let mut compressed_chunk_data = vec![0u8; chunk_compressed_len];
         reader.read_exact(&mut compressed_chunk_data).await.log_error(format!(
             "failed to read {} bytes chunk data at index {}",


### PR DESCRIPTION
Limit the initial variable length array allocation size and increment the array size as needed. This is to prevent allocating giant array based on the size declared in an uploaded xorb. This will pair up with [another PR](https://github.com/huggingface-internal/xetcas/pull/268) that limits the total read size of a reader to effectively limit total memory usage.