### PR TITLE
optionally deserialize only boundaries section of xorb metadata

### DIFF
--- a/cas_object/src/cas_object_format.rs
+++ b/cas_object/src/cas_object_format.rs
@@ -854,6 +854,10 @@ impl CasObjectInfoV1 {
             + self.chunk_hashes.len() * size_of::<MerkleHash>()) as u32
             + self.boundary_section_offset_from_end;
     }
+
+    pub fn has_chunk_hashes(&self) -> bool {
+        !self.chunk_hashes.is_empty()
+    }
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize)]
@@ -2059,6 +2063,8 @@ mod tests {
 
             // check that the hashes are not filled in
             assert!(boundaries_footer.chunk_hashes.is_empty());
+            assert!(!boundaries_footer.has_chunk_hashes());
+            assert!(original.has_chunk_hashes());
         }
     }
 }

--- a/cas_object/src/cas_object_format.rs
+++ b/cas_object/src/cas_object_format.rs
@@ -648,8 +648,6 @@ impl CasObjectInfoV1 {
             )));
         }
 
-        // set the version and ident field since this is a valid CasObjectInfoV1
-        s.hashes_version = 0;
         debug_assert!(s.chunk_hashes.is_empty());
 
         Ok((s, r.reader_bytes() as u32))
@@ -2062,7 +2060,6 @@ mod tests {
             assert_eq!(boundaries_footer.unpacked_chunk_offsets, original.unpacked_chunk_offsets);
 
             // check that the hashes are not filled in
-            assert!(boundaries_footer.chunk_hashes.is_empty());
             assert!(!boundaries_footer.has_chunk_hashes());
             assert!(original.has_chunk_hashes());
         }

--- a/cas_object/src/cas_object_format.rs
+++ b/cas_object/src/cas_object_format.rs
@@ -41,9 +41,9 @@ fn prealloc_num_chunks(declared_size: usize) -> usize {
     declared_size.min(AVERAGE_NUM_CHUNKS_PER_XORB * 9 / 8)
 }
 
-#[deprecated]
 #[derive(Clone, PartialEq, Eq, Debug, Serialize)]
 /// Info struct for [CasObject]. This is stored at the end of the XORB.
+/// DO NOT USE in any new code
 pub struct CasObjectInfoV0 {
     /// CAS identifier: "XETBLOB"
     pub ident: CasObjectIdent,
@@ -159,7 +159,6 @@ impl CasObjectInfoV0 {
         Ok((s, total_bytes_read + bytes_read_v0))
     }
 
-    #[deprecated]
     pub fn deserialize_v0<R: Read>(reader: &mut R) -> Result<(Self, u32), CasObjectError> {
         let mut total_bytes_read: u32 = 0;
 
@@ -212,7 +211,6 @@ impl CasObjectInfoV0 {
     /// assumes that the ident and version have already been read and verified.
     ///
     /// verifies that the length of the footer data matches the length field at the very end of the buffer
-    #[deprecated]
     pub async fn deserialize_async<R: futures::io::AsyncRead + Unpin>(
         reader: &mut R,
         version: u8,
@@ -1956,6 +1954,7 @@ mod tests {
 
         let mut buf = Cursor::new(buf);
         buf.seek(SeekFrom::End(0)).unwrap();
+        #[allow(deprecated)]
         let info_length = cas_info_v0.serialize(&mut buf).unwrap() as u32;
         write_u32(&mut buf, info_length).unwrap();
 
@@ -2039,7 +2038,7 @@ mod tests {
                 &raw_chunk_boundaries,
                 Some(COMPRESSION_SCHEME)
             )
-                .is_ok());
+            .is_ok());
             let original = c.info;
 
             writer.seek(SeekFrom::Start(0)).unwrap();
@@ -2061,6 +2060,5 @@ mod tests {
             // check that the hashes are not filled in
             assert!(boundaries_footer.chunk_hashes.is_empty());
         }
-
     }
 }

--- a/cas_object/src/validate_xorb_stream.rs
+++ b/cas_object/src/validate_xorb_stream.rs
@@ -287,6 +287,7 @@ mod tests {
 
         let mut buf = Cursor::new(buf);
         buf.seek(std::io::SeekFrom::End(0)).unwrap();
+        #[allow(deprecated)]
         let info_length = cas_info_v0.serialize(&mut buf).unwrap() as u32;
         write_u32(&mut buf, info_length).unwrap();
 


### PR DESCRIPTION
This PR will enable the CAS server to only download the boundaries section of xorb footers to reduce data required to be transmitted and cached.