### PR TITLE
xet_threadpool is wasm compilable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,9 +313,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.86"
+version = "0.1.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
+checksum = "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3770,9 +3770,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "9975ea0f48b5aa3972bf2d888c238182458437cc2a19374b81b25cdf1023fb3a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4027,6 +4027,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 name = "utils"
 version = "0.14.5"
 dependencies = [
+ "async-trait",
  "bytes",
  "futures",
  "merklehash",
@@ -4491,7 +4492,6 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 name = "xet_threadpool"
 version = "0.1.0"
 dependencies = [
- "lazy_static",
  "thiserror 2.0.11",
  "tokio",
  "tracing",

--- a/chunk_cache_bench/Cargo.lock
+++ b/chunk_cache_bench/Cargo.lock
@@ -142,9 +142,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-trait"
-version = "0.1.83"
+version = "0.1.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+checksum = "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1677,9 +1677,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libm"
@@ -3592,9 +3592,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.41.0"
+version = "1.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
+checksum = "9975ea0f48b5aa3972bf2d888c238182458437cc2a19374b81b25cdf1023fb3a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3610,9 +3610,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3896,6 +3896,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 name = "utils"
 version = "0.14.5"
 dependencies = [
+ "async-trait",
  "bytes",
  "futures",
  "merklehash",
@@ -4383,7 +4384,6 @@ dependencies = [
 name = "xet_threadpool"
 version = "0.1.0"
 dependencies = [
- "lazy_static",
  "thiserror 2.0.11",
  "tokio",
  "tracing",

--- a/hf_xet/Cargo.lock
+++ b/hf_xet/Cargo.lock
@@ -145,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.83"
+version = "0.1.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+checksum = "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1181,6 +1181,7 @@ checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 name = "hf_xet"
 version = "0.1.4"
 dependencies = [
+ "async-trait",
  "bipbuffer",
  "chrono",
  "ctrlc",
@@ -1685,9 +1686,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.164"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libredox"
@@ -3394,9 +3395,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.41.1"
+version = "1.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
+checksum = "9975ea0f48b5aa3972bf2d888c238182458437cc2a19374b81b25cdf1023fb3a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3412,9 +3413,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3617,6 +3618,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 name = "utils"
 version = "0.14.5"
 dependencies = [
+ "async-trait",
  "bytes",
  "futures",
  "merklehash",
@@ -4073,7 +4075,6 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 name = "xet_threadpool"
 version = "0.1.0"
 dependencies = [
- "lazy_static",
  "thiserror 2.0.11",
  "tokio",
  "tracing",

--- a/hf_xet/Cargo.toml
+++ b/hf_xet/Cargo.toml
@@ -40,6 +40,7 @@ pprof = { version = "0.14", features = [
     "prost",
     "protobuf-codec",
 ], optional = true }
+async-trait = "0.1.87"
 
 # Unix-specific dependencies
 [target.'cfg(unix)'.dependencies]

--- a/hf_xet/src/token_refresh.rs
+++ b/hf_xet/src/token_refresh.rs
@@ -1,5 +1,6 @@
 use std::fmt::{Debug, Formatter};
 
+use async_trait::async_trait;
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::PyAnyMethods;
 use pyo3::{Py, PyAny, PyErr, PyResult, Python};
@@ -48,9 +49,9 @@ impl WrappedTokenRefresher {
     }
 }
 
+#[async_trait]
 impl TokenRefresher for WrappedTokenRefresher {
-    fn refresh(&self) -> Result<TokenInfo, AuthError> {
-        info!("refreshing token");
+    async fn refresh(&self) -> Result<TokenInfo, AuthError> {
         Python::with_gil(|py| {
             let f = self.py_func.bind(py);
             if !f.is_callable() {

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -21,6 +21,7 @@ pin-project = "1.0.12"
 # consistenthash
 tracing = "0.1.31"
 bytes = "1.8.0"
+async-trait = "0.1.87"
 
 
 [dev-dependencies]

--- a/utils/src/errors.rs
+++ b/utils/src/errors.rs
@@ -45,6 +45,12 @@ pub enum AuthError {
     TokenRefreshFailure(String),
 }
 
+impl AuthError {
+    pub fn token_refresh_failure(err: impl ToString) -> Self {
+        Self::TokenRefreshFailure(err.to_string())
+    }
+}
+
 impl<E: Send + std::fmt::Debug + Sync> Clone for SingleflightError<E> {
     fn clone(&self) -> Self {
         match self {

--- a/xet_threadpool/Cargo.toml
+++ b/xet_threadpool/Cargo.toml
@@ -4,7 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tokio = { version = "1.41", features = ["full"] }
+tokio = { version = "1.44", features = ["sync", "macros", "io-util", "rt", "time"] }
 thiserror = "2.0"
 tracing = "0.1.31"
-lazy_static = "1"
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+tokio = { version = "1.44", features = ["rt-multi-thread"] }


### PR DESCRIPTION
Small step towards wasm-uploads, makes xet_threadpool work in singlethreaded wasm context (alledgedly, more testing to come)

- no impact on threadpool outside wasm/e.g. hf-xet
- required that I remove the use of `tokio::task::block_in_place` which is not available in tokio single thread/current_thread mode which is required in the WASM usage of tokio
  - this was used downstream of token refreshes, i.e. call async token refreshing function in hub_client from a sync `refresh` trait function. Ended up making the `TokenRefresher` trait an `async_trait` hence the various extra changes
- formatting fixes renamed imports for tokio::runtime::* imports.