### PR TITLE
make utils wasm compat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,6 @@ dependencies = [
  "lz4_flex",
  "merkledb",
  "merklehash",
- "parutils",
  "rand 0.8.5",
  "serde",
  "thiserror 2.0.11",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2179,6 +2179,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minicov"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27fe9f1cc3c22e1687f9446c2083c4c5fc7f0bcf1c7a86bdbded14985895b4b"
+dependencies = [
+ "cc",
+ "walkdir",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4036,6 +4046,7 @@ dependencies = [
  "thiserror 2.0.11",
  "tokio",
  "tracing",
+ "wasm-bindgen-test",
  "xet_threadpool",
 ]
 
@@ -4181,6 +4192,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c8d5e33ca3b6d9fa3b4676d774c5778031d27a578c2b007f905acf816152c3"
+dependencies = [
+ "js-sys",
+ "minicov",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17d5042cc5fa009658f9a7333ef24291b1291a25b6382dd68862a7f3b969f69b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2179,16 +2179,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "minicov"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27fe9f1cc3c22e1687f9446c2083c4c5fc7f0bcf1c7a86bdbded14985895b4b"
-dependencies = [
- "cc",
- "walkdir",
-]
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4046,7 +4036,6 @@ dependencies = [
  "thiserror 2.0.11",
  "tokio",
  "tracing",
- "wasm-bindgen-test",
  "xet_threadpool",
 ]
 
@@ -4192,30 +4181,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-bindgen-test"
-version = "0.3.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c8d5e33ca3b6d9fa3b4676d774c5778031d27a578c2b007f905acf816152c3"
-dependencies = [
- "js-sys",
- "minicov",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-bindgen-test-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-test-macro"
-version = "0.3.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17d5042cc5fa009658f9a7333ef24291b1291a25b6382dd68862a7f3b969f69b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
 ]
 
 [[package]]

--- a/cas_object/Cargo.toml
+++ b/cas_object/Cargo.toml
@@ -19,7 +19,6 @@ error_printer = { path = "../error_printer" }
 merkledb = { path = "../merkledb" }
 merklehash = { path = "../merklehash" }
 utils = { path = "../utils" }
-parutils = { path = "../parutils" }
 anyhow = "1.0.88"
 tracing = "0.1.40"
 lz4_flex = "0.11.3"

--- a/hf_xet/Cargo.lock
+++ b/hf_xet/Cargo.lock
@@ -324,7 +324,6 @@ dependencies = [
  "lz4_flex",
  "merkledb",
  "merklehash",
- "parutils",
  "rand 0.8.5",
  "serde",
  "thiserror 2.0.11",

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -26,8 +26,5 @@ async-trait = "0.1.87"
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 tempfile = "3.14.0"
 
-[target.'cfg(target_family = "wasm")'.dev-dependencies]
-wasm-bindgen-test = "0.3.50"
-
 [features]
 strict = []

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -26,5 +26,8 @@ async-trait = "0.1.87"
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 tempfile = "3.14.0"
 
+[target.'cfg(target_family = "wasm")'.dev-dependencies]
+wasm-bindgen-test = "0.3.50"
+
 [features]
 strict = []

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -13,8 +13,8 @@ xet_threadpool = { path = "../xet_threadpool" }
 thiserror = "2.0"
 futures = "0.3.28"
 
-# singleflight & threadpool
-tokio = { version = "1.41", features = ["full"] }
+# singleflight
+tokio = { version = "1.41", features = ["sync", "rt", "macros", "time", "io-util"] }
 parking_lot = "0.11"
 pin-project = "1.0.12"
 
@@ -23,9 +23,7 @@ tracing = "0.1.31"
 bytes = "1.8.0"
 async-trait = "0.1.87"
 
-
-[dev-dependencies]
-tokio = { version = "1.36", features = ["full"] }
+[target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 tempfile = "3.14.0"
 
 [features]

--- a/utils/src/async_read.rs
+++ b/utils/src/async_read.rs
@@ -37,7 +37,6 @@ mod tests {
     use bytes::Bytes;
     use futures::io::Cursor;
     use futures::{AsyncReadExt, TryStreamExt};
-    use tempfile::tempfile;
 
     use super::*;
 
@@ -60,6 +59,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(target_family = "wasm"))]
     #[tokio::test]
     async fn test_copy_reader_to_file() {
         let readers: Vec<Box<dyn AsyncRead + Unpin>> = vec![
@@ -71,7 +71,7 @@ mod tests {
         ];
 
         for mut reader in readers {
-            let mut writer = tempfile().unwrap();
+            let mut writer = tempfile::tempfile().unwrap();
             let mut copy_reader = CopyReader::new(&mut reader, &mut writer);
             let mut buf = Vec::new();
             assert!(copy_reader.read_to_end(&mut buf).await.is_ok());

--- a/utils/src/async_read.rs
+++ b/utils/src/async_read.rs
@@ -32,6 +32,7 @@ impl<'r, 'w, R: AsyncRead + Unpin, W: Write> CopyReader<'r, 'w, R, W> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(target_family = "wasm"))]
     use std::io::{Read, Seek, SeekFrom};
 
     use bytes::Bytes;

--- a/utils/src/output_bytes.rs
+++ b/utils/src/output_bytes.rs
@@ -4,6 +4,7 @@
 /// * `v` - the size in bytes
 pub fn output_bytes(v: usize) -> String {
     let map = vec![
+        #[cfg(not(target_family = "wasm"))]
         (1_099_511_627_776, "TiB"),
         (1_073_741_824, "GiB"),
         (1_048_576, "MiB"),
@@ -45,8 +46,11 @@ mod tests {
         assert_eq!("1 GiB", output_bytes(1_073_741_824));
         assert_eq!("1.00 GiB", output_bytes(1_073_741_825));
         assert_eq!("999.99 GiB", output_bytes(1_073_731_086_581));
+        #[cfg(not(target_family = "wasm"))]
         assert_eq!("1 TiB", output_bytes(1_099_511_627_776));
+        #[cfg(not(target_family = "wasm"))]
         assert_eq!("1.00 TiB", output_bytes(1_099_511_627_777));
+        #[cfg(not(target_family = "wasm"))]
         assert_eq!("1234.57 TiB", output_bytes(1_357_424_070_303_416));
     }
 }

--- a/utils/src/output_bytes.rs
+++ b/utils/src/output_bytes.rs
@@ -45,6 +45,7 @@ mod tests {
         assert_eq!("999.99 MiB", output_bytes(1_048_565_514));
         assert_eq!("1 GiB", output_bytes(1_073_741_824));
         assert_eq!("1.00 GiB", output_bytes(1_073_741_825));
+        #[cfg(not(target_family = "wasm"))]
         assert_eq!("999.99 GiB", output_bytes(1_073_731_086_581));
         #[cfg(not(target_family = "wasm"))]
         assert_eq!("1 TiB", output_bytes(1_099_511_627_776));


### PR DESCRIPTION
This PR ensures that the utils crate (singleflight, serialization_utils) compiles for WASM, should be rebased/merge-main after the xet_threadpool change #204  is in main.