### PR TITLE
concurrent limited join set

### DIFF
--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -8,6 +8,7 @@ pub mod singleflight;
 mod async_read;
 mod output_bytes;
 pub mod progress;
+pub mod limited_joinset;
 
 pub use async_read::CopyReader;
 pub use output_bytes::output_bytes;

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -6,9 +6,9 @@ pub mod serialization_utils;
 pub mod singleflight;
 
 mod async_read;
+pub mod limited_joinset;
 mod output_bytes;
 pub mod progress;
-pub mod limited_joinset;
 
 pub use async_read::CopyReader;
 pub use output_bytes::output_bytes;

--- a/utils/src/limited_joinset.rs
+++ b/utils/src/limited_joinset.rs
@@ -1,15 +1,16 @@
 use std::future::Future;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
 use tokio::sync::Semaphore;
 use tokio::task::{AbortHandle, JoinError, JoinSet as TokioJoinSet};
 
-pub struct JoinSet<T> {
+pub struct LimitedJoinSet<T> {
     inner: TokioJoinSet<T>,
     semaphore: Arc<Semaphore>,
 }
 
-impl<T: Send + 'static> JoinSet<T> {
+impl<T: 'static> LimitedJoinSet<T> {
     pub fn new(max_concurrent: usize) -> Self {
         Self {
             inner: TokioJoinSet::new(),
@@ -19,7 +20,9 @@ impl<T: Send + 'static> JoinSet<T> {
 
     pub fn spawn<F>(&mut self, task: F) -> AbortHandle
     where
-        F: Future<Output = T> + Unpin + Send + 'static,
+        F: Future<Output = T>,
+        F: Send + 'static,
+        T: Send,
     {
         let semaphore = self.semaphore.clone();
         self.inner.spawn(async move {
@@ -36,11 +39,50 @@ impl<T: Send + 'static> JoinSet<T> {
         self.inner.join_next().await
     }
 
+    pub async fn join_all(self) -> Vec<T> {
+        self.inner.join_all().await
+    }
+
+    pub fn poll_join_next(&mut self, cx: &mut Context<'_>) -> Poll<Option<Result<T, JoinError>>> {
+        self.inner.poll_join_next(cx)
+    }
+
     pub fn len(&self) -> usize {
         self.inner.len()
     }
 
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_joinset() {
+        let mut join_set = LimitedJoinSet::new(3);
+
+        for i in 0..4 {
+            join_set.spawn(async move {
+                tokio::time::sleep(Duration::from_millis(10 - i)).await;
+                i
+            });
+        }
+
+        let mut outs = Vec::new();
+        while let Ok(Some(value)) = join_set.join_next().await {
+            outs.push(value);
+        }
+
+        // expect that the task returning 3 was spawned after at least 1 other task finished
+        for (i, out) in outs.into_iter().enumerate() {
+            if out == 3 {
+                assert!(i > 0);
+            }
+        }
     }
 }

--- a/utils/src/limited_joinset.rs
+++ b/utils/src/limited_joinset.rs
@@ -1,11 +1,10 @@
-use std::collections::VecDeque;
 use std::future::Future;
-use std::num::NonZeroUsize;
 use std::sync::Arc;
+
 use tokio::sync::Semaphore;
 use tokio::task::{AbortHandle, JoinError, JoinSet as TokioJoinSet};
 
-struct JoinSet<T> {
+pub struct JoinSet<T> {
     inner: TokioJoinSet<T>,
     semaphore: Arc<Semaphore>,
 }

--- a/utils/src/limited_joinset.rs
+++ b/utils/src/limited_joinset.rs
@@ -74,11 +74,12 @@ mod tests {
         }
 
         let mut outs = Vec::new();
-        while let Ok(Some(value)) = join_set.join_next().await {
+        while let Some(Ok(value)) = join_set.join_next().await {
             outs.push(value);
         }
 
         // expect that the task returning 3 was spawned after at least 1 other task finished
+        assert_eq!(outs.len(), 4);
         for (i, out) in outs.into_iter().enumerate() {
             if out == 3 {
                 assert!(i > 0);

--- a/utils/src/limited_joinset.rs
+++ b/utils/src/limited_joinset.rs
@@ -1,0 +1,105 @@
+use futures::Stream;
+use std::collections::VecDeque;
+use std::future::Future;
+use std::num::NonZeroUsize;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::task::{JoinError, JoinSet as TokioJoinSet};
+
+struct JoinSet<T> {
+    inner: TokioJoinSet<T>,
+    max_concurrent: NonZeroUsize,
+    tasks_queue: VecDeque<Box<dyn Future<Output = T> + Send + 'static>>,
+    reaped: VecDeque<Result<T, JoinError>>,
+}
+
+impl<T> JoinSet<T> {
+    pub fn new(max_concurrent: NonZeroUsize) -> Self {
+        Self {
+            inner: TokioJoinSet::new(),
+            max_concurrent,
+            tasks_queue: VecDeque::new(),
+            reaped: VecDeque::new(),
+        }
+    }
+
+    pub fn spawn<F>(&mut self, task: F)
+    where
+        F: Future<Output = T>,
+        F: Send + 'static,
+        T: Send,
+    {
+        self.try_reap();
+        if self.inner.len() < self.max_concurrent.get() {
+            self.inner.spawn(task);
+            return;
+        }
+        self.tasks_queue.push_back(Box::new(task));
+    }
+
+    pub fn try_join_next(&mut self) -> Option<Result<T, JoinError>> {
+        self.try_reap();
+        self.reaped.pop_front()
+    }
+
+    pub async fn join_next(&mut self) -> Option<Result<T, JoinError>> {
+        if let Some(ready) = self.try_join_next() {
+            // ready value
+            Some(ready)
+        } else {
+            // none-ready to be reaped, return the next in the inner joinset
+            // or a none value if it is empty
+            self.inner.join_next().await
+        }
+    }
+
+    pub fn try_reap(&mut self) {
+        // try to retrieve any ready tasks and put them in the reaped queue
+        while let Some(reaped_value) = self.inner.try_join_next() {
+            self.reaped.push_back(reaped_value);
+        }
+        // refill inner join set
+        while self.inner.len() < self.max_concurrent.get() {
+            if let Some(task) = self.tasks_queue.pop_front() {
+                self.inner.spawn(task);
+            } else {
+                break;
+            }
+        }
+    }
+
+    pub fn from_iter<F>(max_concurrent: NonZeroUsize, it: impl Iterator<Item = F>) -> Self
+    where
+        F: Future<Output = T>,
+        F: Send + 'static,
+        T: Send,
+    {
+        let mut res = Self::new(max_concurrent);
+        for f in it {
+            res.spawn(f);
+        }
+        res
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.len() + self.tasks_queue.len() + self.reaped.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty() && self.reaped.is_empty()
+    }
+}
+
+impl<T> Stream for JoinSet<T> {
+    type Item = Result<T, JoinError>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if self.len() == 0 {
+            return Poll::Ready(None);
+        }
+        if let Some(result) = self.as_ref().try_join_next() {
+            return Poll::Ready(Some(result));
+        }
+        Poll::Pending
+    }
+}


### PR DESCRIPTION
An idea to be primarily used on the cas server.

A join set that only has at most X tasks running at once. In CAS server (and possibly in the client) we use a standard tokio JoinSet when spawning a number of tasks for 1 operation e.g. shard verification, fetch_info generation. In order to not cause too large a cpu spike/steal work from other requests being handled, we will use this limiting join set to ensure only some tasks are ever actually running at once. (tasks will be in the task pool but will only have work on them after the semaphore is acquired).