### PR TITLE
opt-test profile for builds with debug assertions for regular use

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
     "cas_object",
     "cas_types",
     "chunk_cache",
-    "xet_threadpool"
+    "xet_threadpool",
 ]
 
 exclude = ["hf_xet", "chunk_cache_bench"]
@@ -28,5 +28,5 @@ debug = 1
 
 [profile.opt-test]
 inherits = "dev"
-opt-level = 1
+opt-level = 3
 debug = 1


### PR DESCRIPTION
This PR ups the optimization level for the opt-test profile to 3 to better enable this mode to be used for non-release but production testing.  In this mode, debug_assertions are enabled, which can catch errors early on or ensure integrity checks are enabled.   Otherwise, it behaves just like release mode. 