### PR TITLE
Macro for declaring configurable constants. 

### DIFF
--- a/data/src/remote_shard_interface.rs
+++ b/data/src/remote_shard_interface.rs
@@ -113,7 +113,7 @@ impl RemoteShardInterface {
 
         let merged_shards_jh = self
             .threadpool
-            .spawn(async move { consolidate_shards_in_directory(&session_dir, MDB_SHARD_MIN_TARGET_SIZE) });
+            .spawn(async move { consolidate_shards_in_directory(&session_dir, *MDB_SHARD_MIN_TARGET_SIZE) });
 
         Ok(merged_shards_jh)
     }

--- a/mdb_shard/src/constants.rs
+++ b/mdb_shard/src/constants.rs
@@ -1,6 +1,6 @@
-use utils::{configurable_globals, release_fixed};
+use utils::configurable_constants;
 
-configurable_globals! {
+configurable_constants! {
 
     /// The target shard size; shards.
     MDB_SHARD_TARGET_SIZE : u64 = 64 * 1024 * 1024;

--- a/mdb_shard/src/constants.rs
+++ b/mdb_shard/src/constants.rs
@@ -1,13 +1,27 @@
-pub const MDB_SHARD_TARGET_SIZE: u64 = 64 * 1024 * 1024;
-pub const MDB_SHARD_MIN_TARGET_SIZE: u64 = 48 * 1024 * 1024;
+use utils::{configurable_globals, release_fixed};
 
-pub const MDB_SHARD_GLOBAL_DEDUP_CHUNK_MODULUS: u64 = 1024;
+configurable_globals! {
 
-/// The amount of time a shard should be expired by before it's deleted, in seconds.  
-/// By default set to 7 days.
-pub const MDB_SHARD_EXPIRATION_BUFFER_SECS: u64 = 7 * 24 * 3600;
+    /// The target shard size; shards.
+    MDB_SHARD_TARGET_SIZE : u64 = 64 * 1024 * 1024;
+
+    /// Minimum shard size; shards are aggregated until they are at least this.
+    MDB_SHARD_MIN_TARGET_SIZE: u64 = 64 * 1024 * 1024;
+
+    // The global dedup chunk modulus; a chunk is considered global dedup
+    // eligible if the hash modulus this value is zero.
+    MDB_SHARD_GLOBAL_DEDUP_CHUNK_MODULUS : u64 = release_fixed(1024);
+
+    /// The amount of time a shard should be expired by before it's deleted, in seconds.
+    /// By default set to 7 days.
+    MDB_SHARD_EXPIRATION_BUFFER_SECS : u64 = 7 * 24 * 3600;
+
+    /// The maximum size of the chunk index table that's stored in memory.  After this,
+    /// no new chunks are loaded for deduplication.
+    CHUNK_INDEX_TABLE_MAX_SIZE : usize = 64 * 1024 * 1024;
+}
 
 // How the MDB_SHARD_GLOBAL_DEDUP_CHUNK_MODULUS is used.
 pub fn hash_is_global_dedup_eligible(h: &merklehash::MerkleHash) -> bool {
-    (*h) % MDB_SHARD_GLOBAL_DEDUP_CHUNK_MODULUS == 0
+    (*h) % *MDB_SHARD_GLOBAL_DEDUP_CHUNK_MODULUS == 0
 }

--- a/utils/src/constant_declarations.rs
+++ b/utils/src/constant_declarations.rs
@@ -1,0 +1,107 @@
+/// A small marker struct so you can write `release_fixed(1234)`.
+/// In debug builds, we allow env override; in release, we ignore env.
+pub enum GlobalConfigMode<T> {
+    Fixed(T),
+    ReleaseFixed(T),
+    EnvConfigurable(T),
+}
+
+#[allow(dead_code)]
+pub fn release_fixed<T>(t: T) -> GlobalConfigMode<T> {
+    GlobalConfigMode::ReleaseFixed(t)
+}
+
+#[allow(dead_code)]
+pub fn fixed<T>(t: T) -> GlobalConfigMode<T> {
+    GlobalConfigMode::Fixed(t)
+}
+
+#[allow(dead_code)]
+pub fn env_configurable<T>(t: T) -> GlobalConfigMode<T> {
+    GlobalConfigMode::EnvConfigurable(t)
+}
+
+// Make env_configurable the default
+impl<T> From<T> for GlobalConfigMode<T> {
+    fn from(value: T) -> Self {
+        GlobalConfigMode::EnvConfigurable(value)
+    }
+}
+
+#[macro_export]
+macro_rules! configurable_constants {
+    ($(
+        $(#[$meta:meta])*
+        $name:ident : $type:ty = $value:expr;
+    )+) => {
+        $(
+            #[allow(unused_imports)]
+            use utils::constant_declarations::*;
+            lazy_static::lazy_static! {
+                $(#[$meta])*
+                pub static ref $name: $type = {
+                    let v : GlobalConfigMode<$type> = ($value).into();
+                    let try_load_from_env = |v_| {
+                        std::env::var(concat!("XET_",stringify!($name)))
+                            .ok()
+                            .and_then(|s| s.parse::<$type>().ok())
+                            .unwrap_or(v_)
+                    };
+
+                    match (v, cfg!(debug_assertions)) {
+                        (GlobalConfigMode::Fixed(v), _) => v,
+                        (GlobalConfigMode::ReleaseFixed(v), false) => v,
+                        (GlobalConfigMode::ReleaseFixed(v), true) => try_load_from_env(v),
+                        (GlobalConfigMode::EnvConfigurable(v), _) => try_load_from_env(v),
+                    }
+                };
+            }
+        )+
+    }
+}
+
+/// A macro for **tests** that sets `XET_<GLOBAL_NAME>` to `$value` **before**
+/// the global is initialized, and then checks that the global actually picks up
+/// that value. If the global was already accessed (thus initialized), or if it
+/// doesn't match after being set, this macro panics.
+///
+/// Typically you would document *the macro itself* here, rather than placing
+/// doc comments above each call to `test_set_global!`, because it doesn't
+/// define a new item.
+///
+/// # Example
+/// ```rust
+/// configurable_globals! {
+///    /// Target chunk size
+///    CHUNK_TARGET_SIZE : u64 = 1024;
+///
+///    /// Max Chunk size, only adjustable in testing mode.
+///    MAX_CHUNK_SIZE : u64 = release_fixed(4096);
+/// }
+///
+/// #[test]
+/// fn test_chunk_size() {
+///     // Must be called before the first use of CHUNK_TARGET_SIZE:
+///     test_set_global!(CHUNK_TARGET_SIZE, 2048);
+///     assert_eq!(*CHUNK_TARGET_SIZE, 2048);
+/// }
+/// ```
+#[macro_export]
+macro_rules! test_set_global {
+    ($global_name:ident, $value:expr) => {{
+        let env_var_name = concat!("XET_", stringify!($global_name));
+        ::std::env::set_var(env_var_name, $value.to_string());
+
+        // Force lazy_static to be read now:
+        let actual_value = *$global_name;
+
+        if actual_value != $value {
+            panic!(
+                "test_set_global! failed: wanted {} to be {}, but got {}",
+                stringify!($global_name),
+                $value,
+                actual_value
+            );
+        }
+    }};
+}

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -11,3 +11,6 @@ pub mod progress;
 
 pub use async_read::CopyReader;
 pub use output_bytes::output_bytes;
+
+pub mod globals;
+pub use globals::release_fixed;

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -12,5 +12,4 @@ pub mod progress;
 pub use async_read::CopyReader;
 pub use output_bytes::output_bytes;
 
-pub mod globals;
-pub use globals::release_fixed;
+pub mod constant_declarations;


### PR DESCRIPTION
Currently, we use a lot of const expressions in which a corresponding environment variable can be used to override the default value.  This PR introduces a macro to standardize this usage.

Example:
```
use utils::configurable_constants;

configurable_constants! {

    /// The target shard size; shards.
    MDB_SHARD_TARGET_SIZE : u64 = 64 * 1024 * 1024;

    /// Minimum shard size; shards are aggregated until they are at least this.
    MDB_SHARD_MIN_TARGET_SIZE: u64 = 64 * 1024 * 1024;

    /// The global dedup chunk modulus; a chunk is considered global dedup
    /// eligible if the hash modulus this value is zero.  Can only be changed for testing.
    MDB_SHARD_GLOBAL_DEDUP_CHUNK_MODULUS : u64 = release_fixed(1024);
}
```

In this example, on initialization, the code would attempt to read from XET_ MDB_SHARD_TARGET_SIZE, using the value given above if that doesn't work.   

For MDB_SHARD_GLOBAL_DEDUP_CHUNK_MODULUS, which is denoted by release_fixed, it would attempt to load the value  from the corresponding environment variable only when debug_assertions are enabled, allowing that value to be changed in tests but not in release mode.  Similarly, fixed(...) denotes that a value is never changed. 

Additionally, the macro `test_set_global!(VAR, VALUE);` can be called at the beginning of a test to ensure that the global referenced by that value is set to a specific value for that test.  



