### PR TITLE
Implement memory control for upload pipeline.

### DIFF
--- a/data/src/constants.rs
+++ b/data/src/constants.rs
@@ -1,5 +1,6 @@
 utils::configurable_constants! {
 
+
     // Approximately 4 MB min spacing between global dedup queries.  Calculated by 4MB / TARGET_CHUNK_SIZE
     ref MIN_SPACING_BETWEEN_GLOBAL_DEDUP_QUERIES: usize = 256;
 
@@ -29,4 +30,19 @@ utils::configurable_constants! {
     /// The maximum number of simultaneous xorb upload streams.
     /// The default value is 8 and can be overwritten by environment variable "XET_CONCURRENT_XORB_UPLOADS".
     ref MAX_CONCURRENT_XORB_UPLOADS: usize = 8;
+
+    /// The amount of data to process at once while chunking through files and incoming data
+    ref DATA_INGESTION_BUFFER_SIZE : usize = 16 * 1024 * 1024;
+
+    /// This is the target memory usage of chunks within an upload session.  This should be enough to
+    /// ensure that buffers are filled while uploading new xorbs, assuming that up to MAX_XORB_BYTES
+    /// are tied up in an intermediate xorb.
+    ///
+    /// As soon as new xorbs get queued in the
+    /// MAX_CONCURRENT_XORB_UPLOADS path, the memory is put to that process and those chunks are released.
+    ///
+    /// This is tracked on a per-session basis to avoid a potential deadlock where all chunk permits
+    /// are tied up in a multiplicity of intermediate xorb buffers.
+    ref CHUNK_MEMORY_USAGE_PER_UPLOAD_SESSION: usize = 512 * 1024 * 1024;
+
 }

--- a/data/src/constants.rs
+++ b/data/src/constants.rs
@@ -10,9 +10,6 @@ utils::configurable_constants! {
     /// The current version
     ref CURRENT_VERSION: String = release_fixed( env!("CARGO_PKG_VERSION").to_owned());
 
-    /// Number of ranges to use when estimating fragmentation
-    ref NRANGES_IN_STREAMING_FRAGMENTATION_ESTIMATOR: usize = 128;
-
     /// Minimum number of chunks per range. Used to control fragmentation
     /// This targets an average of 1MB per range.
     /// The hysteresis factor multiplied by the target Chunks Per Range (CPR) controls
@@ -43,7 +40,7 @@ utils::configurable_constants! {
     ref CHUNK_MEMORY_USAGE_PER_UPLOAD_SESSION: usize = 512 * 1024 * 1024;
 
     /// The amount of data to process at once while chunking through files and incoming data
-    ref DATA_INGESTION_BUFFER_SIZE : usize = 8 * 1024 * 1024;
+    ref DATA_INGESTION_BUFFER_SIZE : usize = 4 * 1024 * 1024;
 
     /// The maximum number of files to ingest at once on the upload path
     ref MAX_CONCURRENT_FILE_INGESTION: usize = 8;

--- a/data/src/data_client.rs
+++ b/data/src/data_client.rs
@@ -16,14 +16,12 @@ use utils::progress::ProgressUpdater;
 use xet_threadpool::ThreadPool;
 
 use crate::configurations::*;
-use crate::constants::{MAX_CONCURRENT_DOWNLOADS, MAX_CONCURRENT_FILE_INGESTION};
+use crate::constants::{DATA_INGESTION_BUFFER_SIZE, MAX_CONCURRENT_DOWNLOADS, MAX_CONCURRENT_FILE_INGESTION};
 use crate::errors::DataProcessingError;
 use crate::repo_salt::RepoSalt;
 use crate::{errors, FileDownloader, FileUploadSession, PointerFile};
 
 const DEFAULT_CAS_ENDPOINT: &str = "http://localhost:8080";
-
-const READ_BLOCK_SIZE: usize = 1024 * 1024;
 
 pub fn default_config(
     endpoint: String,
@@ -174,7 +172,7 @@ pub async fn clean_file(
     processor: Arc<FileUploadSession>,
     filename: impl AsRef<Path>,
 ) -> errors::Result<(PointerFile, DeduplicationMetrics)> {
-    let mut read_buf = vec![0u8; READ_BLOCK_SIZE];
+    let mut read_buf = vec![0u8; *DATA_INGESTION_BUFFER_SIZE];
     let mut reader = File::open(&filename)?;
 
     let mut handle = processor.start_clean(filename.as_ref().to_string_lossy().into());

--- a/data/src/errors.rs
+++ b/data/src/errors.rs
@@ -72,6 +72,9 @@ pub enum DataProcessingError {
 
     #[error("AuthError: {0}")]
     AuthError(#[from] AuthError),
+
+    #[error("Closed Semaphore: {0}")]
+    ClosedSemaphoreError(#[from] tokio::sync::AcquireError),
 }
 
 pub type Result<T> = std::result::Result<T, DataProcessingError>;

--- a/data/src/file_cleaner.rs
+++ b/data/src/file_cleaner.rs
@@ -63,7 +63,7 @@ impl SingleFileCleaner {
         // and thus any remaining permits are released right after the chunking is finished.
         let mut chunk_block_permit = self
             .session
-            .chunk_memory_limit
+            .chunk_memory_limiter
             .clone()
             .acquire_many_owned((data.len() + MAXIMUM_CHUNK_SIZE) as u32)
             .await?;

--- a/data/src/file_upload_session.rs
+++ b/data/src/file_upload_session.rs
@@ -47,7 +47,7 @@ pub struct FileUploadSession {
     pub(crate) config: Arc<TranslatorConfig>,
 
     /// The amount of memory allowed for use by the chunks.
-    pub(crate) chunk_memory_limit: Arc<Semaphore>,
+    pub(crate) chunk_memory_limiter: Arc<Semaphore>,
 
     /// Deduplicated data shared across files.
     current_session_data: Mutex<DataAggregator>,
@@ -119,7 +119,7 @@ impl FileUploadSession {
             config,
             current_session_data: Mutex::new(DataAggregator::default()),
             deduplication_metrics: Mutex::new(DeduplicationMetrics::default()),
-            chunk_memory_limit: Arc::new(Semaphore::new(*CHUNK_MEMORY_USAGE_PER_UPLOAD_SESSION)),
+            chunk_memory_limiter: Arc::new(Semaphore::new(*CHUNK_MEMORY_USAGE_PER_UPLOAD_SESSION)),
         }))
     }
 

--- a/data/src/sha256.rs
+++ b/data/src/sha256.rs
@@ -37,10 +37,10 @@ impl ShaGenerator {
 
     // For testing purposes
     pub fn update_with_bytes(&mut self, new_bytes: &[u8]) {
-        let new_chunk = Chunk {
-            hash: MerkleHash::default(), // not used
-            data: Arc::from(Vec::from(new_bytes)),
-        };
+        let new_chunk = Chunk::new(
+            MerkleHash::default(), // not used
+            Vec::from(new_bytes),
+        );
 
         self.update(Arc::new([new_chunk]));
     }

--- a/data/tests/test_clean_smudge.rs
+++ b/data/tests/test_clean_smudge.rs
@@ -16,7 +16,7 @@ use tokio::task::JoinSet;
 use utils::test_set_globals;
 use xet_threadpool::ThreadPool;
 
-// Runt this test suite with small chunks and xorbs so that we can make sure that all the different edge
+// Run this test suite with small chunks and xorbs so that we can make sure that all the different edge
 // cases are hit.
 test_set_globals! {
     TARGET_CHUNK_SIZE = 8 * 1024;

--- a/deduplication/src/constants.rs
+++ b/deduplication/src/constants.rs
@@ -3,9 +3,14 @@ utils::configurable_constants! {
     /// This will target 1024 chunks per Xorb / CAS block
     ref TARGET_CHUNK_SIZE: usize = release_fixed(64 * 1024);
 
-    /// TARGET_CDC_CHUNK_SIZE / MINIMUM_CHUNK_DIVISOR is the smallest chunk size
+    /// TARGET_CHUNK_SIZE / MINIMUM_CHUNK_DIVISOR is the smallest chunk size
     ref MINIMUM_CHUNK_DIVISOR: usize = release_fixed(8);
 
-    /// TARGET_CDC_CHUNK_SIZE * MAXIMUM_CHUNK_MULTIPLIER is the largest chunk size
+    /// TARGET_CHUNK_SIZE * MAXIMUM_CHUNK_MULTIPLIER is the largest chunk size
     ref MAXIMUM_CHUNK_MULTIPLIER: usize = release_fixed(2);
+}
+
+lazy_static::lazy_static! {
+    static ref MAX_CHUNK_SIZE : usize = (*TARGET_CHUNK_SIZE) * (*MAXIMUM_CHUNK_MULTIPLIER);
+    static ref MIN_CHUNK_SIZE : usize = (*TARGET_CHUNK_SIZE) / (*MINIMUM_CHUNK_DIVISOR);
 }

--- a/deduplication/src/lib.rs
+++ b/deduplication/src/lib.rs
@@ -7,7 +7,7 @@ mod file_deduplication;
 mod interface;
 mod raw_xorb_data;
 
-pub use chunking::{Chunk, Chunker};
+pub use chunking::{Chunk, ChunkPermitType, Chunker};
 pub use data_aggregator::DataAggregator;
 pub use dedup_metrics::DeduplicationMetrics;
 pub use file_deduplication::FileDeduper;

--- a/deduplication/src/raw_xorb_data.rs
+++ b/deduplication/src/raw_xorb_data.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use cas_object::constants::{MAX_XORB_BYTES, MAX_XORB_CHUNKS};
 use mdb_shard::cas_structs::{CASChunkSequenceEntry, CASChunkSequenceHeader, MDBCASInfo};
 use merkledb::aggregate_hashes::cas_node_hash;
@@ -12,7 +10,7 @@ use crate::Chunk;
 #[derive(Default, Debug)]
 pub struct RawXorbData {
     /// The data for the xorb info.
-    pub data: Vec<Arc<[u8]>>,
+    pub data: Vec<Chunk>,
 
     /// The cas info associated with the current xorb.
     pub cas_info: MDBCASInfo,
@@ -30,7 +28,7 @@ impl RawXorbData {
         let mut pos = 0;
         for c in chunks {
             chunk_seq_entries.push(CASChunkSequenceEntry::new(c.hash, c.data.len(), pos));
-            data.push(c.data.clone());
+            data.push(c.clone());
             pos += c.data.len();
         }
         let num_bytes = pos;
@@ -58,7 +56,7 @@ impl RawXorbData {
     pub fn num_bytes(&self) -> usize {
         let n = self.cas_info.metadata.num_bytes_in_cas as usize;
 
-        debug_assert_eq!(n, self.data.iter().map(|c| c.len()).sum::<usize>());
+        debug_assert_eq!(n, self.data.iter().map(|c| c.data.len()).sum::<usize>());
 
         n
     }
@@ -69,7 +67,7 @@ impl RawXorbData {
         let mut new_vec = Vec::with_capacity(self.num_bytes());
 
         for ch in self.data.iter() {
-            new_vec.extend_from_slice(ch);
+            new_vec.extend_from_slice(&ch.data);
         }
 
         new_vec


### PR DESCRIPTION
In the large update PR, the memory usage was unbounded as it was possible to load everything into chunks before the xorb upload begins.  This implements a simple strategy to ensure that more data is not ingested while the upload is unable to keep up.   By default, it limits memory usage by chunks to 512 MB per upload session, which does not include the additional potential global usage of MAX_PARALLEL_XORB_UPLOAD * MAX_XORB_BYTES or the local buffer used to read in the files.  

Memory usage is limited using a global semaphore combined with acquire_many_permits, where each permit effectively represents a byte.  Permits for a block of chunks that run through the processing end-to-end are acquired at once to ensure that parallel calls to add_data do not cause a deadlock.