### PR TITLE
Fix hf xet download speed

### DIFF
--- a/cas_client/src/interface.rs
+++ b/cas_client/src/interface.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::io::Write;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -57,15 +56,15 @@ pub trait ReconstructionClient {
         &self,
         hash: &MerkleHash,
         byte_range: Option<FileRange>,
-        writer: &mut Box<dyn Write + Send>,
+        path: &PathBuf,
         progress_updater: Option<Arc<dyn ProgressUpdater>>,
     ) -> Result<u64>;
 
-    async fn batch_get_file(&self, files: HashMap<MerkleHash, &mut Box<dyn Write + Send>>) -> Result<u64> {
+    async fn batch_get_file(&self, files: HashMap<MerkleHash, &PathBuf>) -> Result<u64> {
         let mut n_bytes = 0;
         // Provide the basic naive implementation as a default.
-        for (h, w) in files {
-            n_bytes += self.get_file(&h, None, w, None).await?;
+        for (h, f) in files {
+            n_bytes += self.get_file(&h, None, f, None).await?;
         }
         Ok(n_bytes)
     }

--- a/cas_client/src/interface.rs
+++ b/cas_client/src/interface.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -56,11 +56,11 @@ pub trait ReconstructionClient {
         &self,
         hash: &MerkleHash,
         byte_range: Option<FileRange>,
-        path: &PathBuf,
+        path: &Path,
         progress_updater: Option<Arc<dyn ProgressUpdater>>,
     ) -> Result<u64>;
 
-    async fn batch_get_file(&self, files: HashMap<MerkleHash, &PathBuf>) -> Result<u64> {
+    async fn batch_get_file(&self, files: HashMap<MerkleHash, &Path>) -> Result<u64> {
         let mut n_bytes = 0;
         // Provide the basic naive implementation as a default.
         for (h, f) in files {

--- a/cas_client/src/local_client.rs
+++ b/cas_client/src/local_client.rs
@@ -401,7 +401,7 @@ impl ReconstructionClient for LocalClient {
         &self,
         hash: &MerkleHash,
         byte_range: Option<FileRange>,
-        path: &PathBuf,
+        path: &Path,
         _progress_updater: Option<Arc<dyn ProgressUpdater>>,
     ) -> Result<u64> {
         let Some((file_info, _)) = self

--- a/cas_client/src/remote_client.rs
+++ b/cas_client/src/remote_client.rs
@@ -314,12 +314,6 @@ impl RemoteClient {
         if let Some(byte_range) = &byte_range {
             let mut current_offset = 0;
             for (idx, (term_range, &length)) in file_range_per_term.iter_mut().zip(term_lengths.iter()).enumerate() {
-                // FIXME I don't understand why the current logic does not take the start range into account
-                // term_range.start = if byte_range.start < current_offset + length && byte_range.start >=
-                // current_offset {     byte_range.start - current_offset
-                // } else {
-                //     0
-                // };
                 // Adjust the end based on whether the byte_range.end is within the current term.
                 term_range.end = if byte_range.end > current_offset && byte_range.end <= current_offset + length {
                     byte_range.end - current_offset

--- a/cas_client/src/remote_client.rs
+++ b/cas_client/src/remote_client.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::io::{Cursor, SeekFrom, Write};
 use std::path::PathBuf;
 use std::sync::Arc;
+
 use anyhow::anyhow;
 use async_trait::async_trait;
 use cas_object::{CasObject, CompressionScheme};
@@ -311,14 +312,10 @@ impl RemoteClient {
         }
         if let Some(byte_range) = &byte_range {
             let mut current_offset = 0;
-            for (idx, (term_range, &length)) in file_range_per_term
-                .iter_mut()
-                .zip(term_lengths.iter())
-                .enumerate()
-            {
+            for (idx, (term_range, &length)) in file_range_per_term.iter_mut().zip(term_lengths.iter()).enumerate() {
                 // FIXME I don't understand why the current logic does not take the start range into account
-                // term_range.start = if byte_range.start < current_offset + length && byte_range.start >= current_offset {
-                //     byte_range.start - current_offset
+                // term_range.start = if byte_range.start < current_offset + length && byte_range.start >=
+                // current_offset {     byte_range.start - current_offset
                 // } else {
                 //     0
                 // };

--- a/data/src/bin/example.rs
+++ b/data/src/bin/example.rs
@@ -1,6 +1,6 @@
 use std::fs::File;
 use std::io::{BufReader, Read, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 
 use anyhow::Result;
@@ -120,7 +120,7 @@ async fn smudge_file(arg: &SmudgeArg) -> Result<()> {
     Ok(())
 }
 
-async fn smudge(mut reader: impl Read, path: &PathBuf) -> Result<()> {
+async fn smudge(mut reader: impl Read, path: &Path) -> Result<()> {
     let mut input = String::new();
     reader.read_to_string(&mut input)?;
 
@@ -134,7 +134,7 @@ async fn smudge(mut reader: impl Read, path: &PathBuf) -> Result<()> {
     let downloader =
         FileDownloader::new(TranslatorConfig::local_config(std::env::current_dir()?)?, get_threadpool()).await?;
 
-    downloader.smudge_file_from_pointer(&pointer_file, &path, None, None).await?;
+    downloader.smudge_file_from_pointer(&pointer_file, path, None, None).await?;
 
     Ok(())
 }

--- a/data/src/constants.rs
+++ b/data/src/constants.rs
@@ -21,7 +21,7 @@ utils::configurable_constants! {
     ref MAX_CONCURRENT_FILE_INGESTION: usize = 8;
 
     /// The maximum number of files to download at one time.
-    ref MAX_CONCURRENT_DOWNLOADS : usize = 8;
+    ref MAX_CONCURRENT_DOWNLOADS : usize = 16;
 
     /// The maximum block size from a file to process at once.
     ref INGESTION_BLOCK_SIZE : usize = 8 * 1024 * 1024;

--- a/data/src/data_client.rs
+++ b/data/src/data_client.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::env::current_dir;
 use std::fs::File;
-use std::io::{Read, Write};
+use std::io::{Read};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -200,9 +200,8 @@ async fn smudge_file(
     if let Some(parent_dir) = path.parent() {
         std::fs::create_dir_all(parent_dir)?;
     }
-    let mut f: Box<dyn Write + Send> = Box::new(File::create(&path)?);
     downloader
-        .smudge_file_from_pointer(pointer_file, &mut f, None, progress_updater)
+        .smudge_file_from_pointer(pointer_file, &path, None, progress_updater)
         .await?;
     Ok(pointer_file.path().to_string())
 }

--- a/data/src/data_client.rs
+++ b/data/src/data_client.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::env::current_dir;
 use std::fs::File;
-use std::io::{Read};
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 

--- a/data/src/file_downloader.rs
+++ b/data/src/file_downloader.rs
@@ -1,4 +1,4 @@
-use std::io::Write;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use cas_client::Client;
@@ -34,23 +34,23 @@ impl FileDownloader {
     pub async fn smudge_file_from_pointer(
         &self,
         pointer: &PointerFile,
-        writer: &mut Box<dyn Write + Send>,
+        path: &PathBuf,
         range: Option<FileRange>,
         progress_updater: Option<Arc<dyn ProgressUpdater>>,
     ) -> Result<u64> {
-        self.smudge_file_from_hash(&pointer.hash()?, writer, range, progress_updater)
+        self.smudge_file_from_hash(&pointer.hash()?, path, range, progress_updater)
             .await
     }
 
     pub async fn smudge_file_from_hash(
         &self,
         file_id: &MerkleHash,
-        writer: &mut Box<dyn Write + Send>,
+        path: &PathBuf,
         range: Option<FileRange>,
         progress_updater: Option<Arc<dyn ProgressUpdater>>,
     ) -> Result<u64> {
         // Currently, this works by always directly querying the remote server.
-        let n_bytes = self.client.get_file(file_id, range, writer, progress_updater).await?;
+        let n_bytes = self.client.get_file(file_id, range, path, progress_updater).await?;
 
         prometheus_metrics::FILTER_BYTES_SMUDGED.inc_by(n_bytes);
 

--- a/data/src/file_downloader.rs
+++ b/data/src/file_downloader.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::Path;
 use std::sync::Arc;
 
 use cas_client::Client;
@@ -34,7 +34,7 @@ impl FileDownloader {
     pub async fn smudge_file_from_pointer(
         &self,
         pointer: &PointerFile,
-        path: &PathBuf,
+        path: &Path,
         range: Option<FileRange>,
         progress_updater: Option<Arc<dyn ProgressUpdater>>,
     ) -> Result<u64> {
@@ -45,7 +45,7 @@ impl FileDownloader {
     pub async fn smudge_file_from_hash(
         &self,
         file_id: &MerkleHash,
-        path: &PathBuf,
+        path: &Path,
         range: Option<FileRange>,
         progress_updater: Option<Arc<dyn ProgressUpdater>>,
     ) -> Result<u64> {

--- a/data/src/file_upload_session.rs
+++ b/data/src/file_upload_session.rs
@@ -350,14 +350,6 @@ mod tests {
     /// * `output_path`: path to write the hydrated/original file
     async fn test_smudge_file(runtime: Arc<ThreadPool>, cas_path: &Path, pointer_path: &Path, output_path: &Path) {
         let mut reader = File::open(pointer_path).unwrap();
-        let writer: Box<dyn Write + Send + 'static> = Box::new(
-            OpenOptions::new()
-                .create(true)
-                .write(true)
-                .truncate(true)
-                .open(output_path)
-                .unwrap(),
-        );
 
         let mut input = String::new();
         reader.read_to_string(&mut input).unwrap();
@@ -373,7 +365,7 @@ mod tests {
             .unwrap();
 
         translator
-            .smudge_file_from_pointer(&pointer_file, &mut (Box::new(writer) as Box<dyn Write + Send>), None, None)
+            .smudge_file_from_pointer(&pointer_file, &output_path.to_path_buf(), None, None)
             .await
             .unwrap();
     }

--- a/data/tests/test_clean_smudge.rs
+++ b/data/tests/test_clean_smudge.rs
@@ -140,15 +140,12 @@ async fn hydrate_directory(cas_dir: &Path, ptr_dir: &Path, out_dir: &Path) {
 
         let out_filename = out_dir.join(entry.file_name());
 
-        // Create an output file for writing
-        let mut file_out: Box<dyn Write + Send> = Box::new(File::create(&out_filename).unwrap());
-
         // Pointer file.
         let pf = PointerFile::init_from_path(entry.path());
         assert!(pf.is_valid());
 
         downloader
-            .smudge_file_from_pointer(&pf, &mut file_out, None, None)
+            .smudge_file_from_pointer(&pf, &out_filename, None, None)
             .await
             .unwrap();
     }

--- a/hf_xet/Cargo.lock
+++ b/hf_xet/Cargo.lock
@@ -322,8 +322,10 @@ dependencies = [
  "futures",
  "half",
  "lz4_flex",
+ "mdb_shard",
  "merkledb",
  "merklehash",
+ "more-asserts",
  "parutils",
  "rand 0.8.5",
  "serde",
@@ -629,6 +631,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,10 +661,11 @@ dependencies = [
  "cas_types",
  "chrono",
  "clap 3.2.25",
+ "countio",
+ "deduplication",
  "dirs",
  "error_printer",
  "file_utils",
- "gearhash",
  "glob",
  "hashers",
  "http 0.2.12",
@@ -661,6 +674,7 @@ dependencies = [
  "mdb_shard",
  "merkledb",
  "merklehash",
+ "more-asserts",
  "openssl",
  "parutils",
  "prometheus",
@@ -689,6 +703,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "uuid",
+]
+
+[[package]]
+name = "deduplication"
+version = "0.14.5"
+dependencies = [
+ "async-trait",
+ "gearhash",
+ "lazy_static",
+ "mdb_shard",
+ "merkledb",
+ "merklehash",
+ "more-asserts",
+ "utils",
 ]
 
 [[package]]
@@ -1763,6 +1791,7 @@ version = "0.14.5"
 dependencies = [
  "anyhow",
  "async-trait",
+ "blake3",
  "clap 3.2.25",
  "futures-io",
  "futures-util",
@@ -1895,6 +1924,12 @@ dependencies = [
  "quote",
  "syn 2.0.87",
 ]
+
+[[package]]
+name = "more-asserts"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 
 [[package]]
 name = "native-tls"
@@ -2147,6 +2182,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45ca20c77d80be666aef2b45486da86238fabe33e38306bd3118fe4af33fa880"
+dependencies = [
+ "paste-impl",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "paste-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6"
+dependencies = [
+ "proc-macro-hack",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2295,6 +2349,12 @@ dependencies = [
  "quote",
  "version_check",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -3620,9 +3680,12 @@ version = "0.14.5"
 dependencies = [
  "async-trait",
  "bytes",
+ "ctor",
  "futures",
+ "lazy_static",
  "merklehash",
  "parking_lot 0.11.2",
+ "paste",
  "pin-project",
  "thiserror 2.0.11",
  "tokio",

--- a/hf_xet/src/token_refresh.rs
+++ b/hf_xet/src/token_refresh.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::PyAnyMethods;
 use pyo3::{Py, PyAny, PyErr, PyResult, Python};
-use tracing::{error};
+use tracing::error;
 use utils::auth::{TokenInfo, TokenRefresher};
 use utils::errors::AuthError;
 

--- a/hf_xet/src/token_refresh.rs
+++ b/hf_xet/src/token_refresh.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::PyAnyMethods;
 use pyo3::{Py, PyAny, PyErr, PyResult, Python};
-use tracing::{error, info};
+use tracing::{error};
 use utils::auth::{TokenInfo, TokenRefresher};
 use utils::errors::AuthError;
 


### PR DESCRIPTION
Check #221 for implem.

Fix `hf_xet` download logic to write file chunk in parallel rather than iterating.
While this fix improves performances on SSD, it will degrade performances on HDD.

For reviewers:
- Please check `remote_client.rs:317` as I am unsure of Xet logic at this point. Commented code is what I would have expected but it was not implemented previously and breaks the tests. I you can enlighten me...
- I increased `NUM_CONCURRENT_RANGE_GETS`, but it should maybe depend on the underlying hardware not to hog desktop machines.
- Seek in file is slow, we can probably use a `write_at` from `std::os::unix::fs::FileExt` to get a bit more perf, but that would be a unix-only option

## Performance comparison
`hf_xet_fixed` is current PR.

![xet_gcp_aws_tools](https://github.com/user-attachments/assets/d1ad2dd1-ee0e-4e56-a72b-91e0d12bafa6)
![xet_tool_boxplot](https://github.com/user-attachments/assets/3cf529bf-a710-4cc0-98af-0602f21b5726)

