### PR TITLE
Env to write reconstruction terms in parallel

### DIFF
--- a/cas_client/src/interface.rs
+++ b/cas_client/src/interface.rs
@@ -176,7 +176,7 @@ pub mod buffer {
 
     impl BufferProvider {
         pub fn get_writer_at(&self, _start: u64) -> Result<Box<dyn Write + Send>> {
-            Ok(Box::new(self.buf.clone())) // TODO: fix tests once we start writing in parallel
+            Ok(Box::new(self.buf.clone()))
         }
     }
 

--- a/cas_client/src/interface.rs
+++ b/cas_client/src/interface.rs
@@ -175,18 +175,22 @@ pub mod buffer {
     }
 
     impl BufferProvider {
-        pub fn get_writer_at(&self, _start: u64) -> Result<Box<dyn Write + Send>> {
-            Ok(Box::new(self.buf.clone()))
+        pub fn get_writer_at(&self, start: u64) -> Result<Box<dyn Write + Send>> {
+            let mut buffer = self.buf.clone();
+            buffer.idx = start;
+            Ok(Box::new(buffer))
         }
     }
 
     #[derive(Debug, Default, Clone)]
+    /// Thread-safe in-memory buffer that implements [Write](Write) trait at some position
+    /// within an underlying buffer and allows access to inner buffer.
     /// Thread-safe in-memory buffer that implements [Write](Write) trait and allows
     /// access to inner buffer
     pub struct ThreadSafeBuffer {
+        idx: u64,
         inner: Arc<Mutex<Cursor<Vec<u8>>>>,
     }
-
     impl ThreadSafeBuffer {
         pub fn value(&self) -> Vec<u8> {
             self.inner.lock().unwrap().get_ref().clone()
@@ -195,7 +199,11 @@ pub mod buffer {
 
     impl Write for ThreadSafeBuffer {
         fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-            self.inner.lock().map_err(|e| std::io::Error::other(format!("{e}")))?.write(buf)
+            let mut guard = self.inner.lock().map_err(|e| std::io::Error::other(format!("{e}")))?;
+            guard.set_position(self.idx);
+            let num_written = guard.write(buf)?;
+            self.idx = guard.position();
+            Ok(num_written)
         }
 
         fn flush(&mut self) -> std::io::Result<()> {

--- a/cas_client/src/interface.rs
+++ b/cas_client/src/interface.rs
@@ -58,11 +58,11 @@ pub trait ReconstructionClient {
         &self,
         hash: &MerkleHash,
         byte_range: Option<FileRange>,
-        writer: &WriteProvider,
+        output_provider: &OutputProvider,
         progress_updater: Option<Arc<dyn ProgressUpdater>>,
     ) -> Result<u64>;
 
-    async fn batch_get_file(&self, files: HashMap<MerkleHash, &WriteProvider>) -> Result<u64> {
+    async fn batch_get_file(&self, files: HashMap<MerkleHash, &OutputProvider>) -> Result<u64> {
         let mut n_bytes = 0;
         // Provide the basic naive implementation as a default.
         for (h, w) in files {
@@ -74,19 +74,19 @@ pub trait ReconstructionClient {
 
 /// Enum of different output formats to write reconstructed files.
 #[derive(Debug, Clone)]
-pub enum WriteProvider {
+pub enum OutputProvider {
     File(FileProvider),
     #[cfg(test)]
     Buffer(buffer::BufferProvider),
 }
 
-impl WriteProvider {
+impl OutputProvider {
     /// Create a new writer to start writing at the indicated start location.
     pub(crate) fn get_writer_at(&self, start: u64) -> Result<Box<dyn Write + Send>> {
         match self {
-            WriteProvider::File(fp) => fp.get_writer_at(start),
+            OutputProvider::File(fp) => fp.get_writer_at(start),
             #[cfg(test)]
-            WriteProvider::Buffer(bp) => bp.get_writer_at(start),
+            OutputProvider::Buffer(bp) => bp.get_writer_at(start),
         }
     }
 }

--- a/cas_client/src/lib.rs
+++ b/cas_client/src/lib.rs
@@ -3,7 +3,7 @@
 pub use chunk_cache::CacheConfig;
 pub use http_client::{build_auth_http_client, build_http_client};
 use interface::RegistrationClient;
-pub use interface::{Client, FileProvider, ReconstructionClient, UploadClient, WriteProvider};
+pub use interface::{Client, FileProvider, OutputProvider, ReconstructionClient, UploadClient};
 pub use local_client::LocalClient;
 pub use remote_client::RemoteClient;
 

--- a/cas_client/src/lib.rs
+++ b/cas_client/src/lib.rs
@@ -3,7 +3,7 @@
 pub use chunk_cache::CacheConfig;
 pub use http_client::{build_auth_http_client, build_http_client};
 use interface::RegistrationClient;
-pub use interface::{Client, FileWriteProvider, ReconstructionClient, UploadClient, WriteProvider};
+pub use interface::{Client, FileProvider, ReconstructionClient, UploadClient, WriteProvider};
 pub use local_client::LocalClient;
 pub use remote_client::RemoteClient;
 

--- a/cas_client/src/lib.rs
+++ b/cas_client/src/lib.rs
@@ -3,7 +3,7 @@
 pub use chunk_cache::CacheConfig;
 pub use http_client::{build_auth_http_client, build_http_client};
 use interface::RegistrationClient;
-pub use interface::{Client, ReconstructionClient, UploadClient};
+pub use interface::{Client, FileWriteProvider, ReconstructionClient, UploadClient, WriteProvider};
 pub use local_client::LocalClient;
 pub use remote_client::RemoteClient;
 

--- a/cas_client/src/local_client.rs
+++ b/cas_client/src/local_client.rs
@@ -20,7 +20,7 @@ use tracing::{debug, error, info, warn};
 use utils::progress::ProgressUpdater;
 
 use crate::error::{CasClientError, Result};
-use crate::interface::{ShardDedupProber, UploadClient, WriteProvider};
+use crate::interface::{OutputProvider, ShardDedupProber, UploadClient};
 use crate::{Client, ReconstructionClient, RegistrationClient, ShardClientInterface};
 
 pub struct LocalClient {
@@ -399,7 +399,7 @@ impl ReconstructionClient for LocalClient {
         &self,
         hash: &MerkleHash,
         byte_range: Option<FileRange>,
-        writer: &WriteProvider,
+        output_provider: &OutputProvider,
         _progress_updater: Option<Arc<dyn ProgressUpdater>>,
     ) -> Result<u64> {
         let Some((file_info, _)) = self
@@ -410,7 +410,7 @@ impl ReconstructionClient for LocalClient {
         else {
             return Err(CasClientError::FileNotFound(*hash));
         };
-        let mut writer = writer.get_writer_at(0)?;
+        let mut writer = output_provider.get_writer_at(0)?;
 
         // This is just used for testing, so inefficient is fine.
         let mut file_vec = Vec::new();

--- a/cas_client/src/local_client.rs
+++ b/cas_client/src/local_client.rs
@@ -20,7 +20,7 @@ use tracing::{debug, error, info, warn};
 use utils::progress::ProgressUpdater;
 
 use crate::error::{CasClientError, Result};
-use crate::interface::{ShardDedupProber, UploadClient};
+use crate::interface::{ShardDedupProber, UploadClient, WriteProvider};
 use crate::{Client, ReconstructionClient, RegistrationClient, ShardClientInterface};
 
 pub struct LocalClient {
@@ -399,7 +399,7 @@ impl ReconstructionClient for LocalClient {
         &self,
         hash: &MerkleHash,
         byte_range: Option<FileRange>,
-        writer: &mut Box<dyn Write + Send>,
+        writer: &WriteProvider,
         _progress_updater: Option<Arc<dyn ProgressUpdater>>,
     ) -> Result<u64> {
         let Some((file_info, _)) = self
@@ -410,6 +410,7 @@ impl ReconstructionClient for LocalClient {
         else {
             return Err(CasClientError::FileNotFound(*hash));
         };
+        let mut writer = writer.get_writer_at(0)?;
 
         // This is just used for testing, so inefficient is fine.
         let mut file_vec = Vec::new();
@@ -444,7 +445,6 @@ fn map_heed_db_error(e: heed::Error) -> CasClientError {
 
 #[cfg(test)]
 mod tests {
-
     use cas_object::test_utils::*;
     use cas_object::CompressionScheme::LZ4;
     use mdb_shard::utils::parse_shard_filename;

--- a/cas_client/src/remote_client.rs
+++ b/cas_client/src/remote_client.rs
@@ -47,6 +47,10 @@ const NUM_RETRIES: usize = 5;
 const BASE_RETRY_DELAY_MS: u64 = 3000;
 const NUM_CONCURRENT_RANGE_GETS: usize = 16;
 
+/// Env to switch to writing terms sequentially to disk. Benchmarks have shown that on
+/// SSD machines, writing in parallel seems to far outperform sequential term writes.
+/// However, this is not likely the case for writing to HDD and may in fact be worse,
+/// so for those machines, setting this env may help download perf.
 const ENV_RECONSTRUCT_WRITE_SEQUENTIALLY: &str = "HF_XET_RECONSTRUCT_WRITE_SEQUENTIALLY";
 
 type RangeDownloadSingleFlight = Arc<Group<(Vec<u8>, Vec<u32>), CasClientError>>;

--- a/cas_client/src/remote_client.rs
+++ b/cas_client/src/remote_client.rs
@@ -45,9 +45,9 @@ pub const PREFIX_DEFAULT: &str = "default";
 
 const NUM_RETRIES: usize = 5;
 const BASE_RETRY_DELAY_MS: u64 = 3000;
-const NUM_CONCURRENT_RANGE_GETS: usize = 8;
+const NUM_CONCURRENT_RANGE_GETS: usize = 16;
 
-const ENV_RECONSTRUCT_WRITE_PARALLEL: &str = "HF_XET_RECONSTRUCT_WRITE_PARALLEL";
+const ENV_RECONSTRUCT_WRITE_SEQUENTIALLY: &str = "HF_XET_RECONSTRUCT_WRITE_SEQUENTIALLY";
 
 type RangeDownloadSingleFlight = Arc<Group<(Vec<u8>, Vec<u32>), CasClientError>>;
 
@@ -156,10 +156,10 @@ impl ReconstructionClient for RemoteClient {
         let terms = manifest.terms;
         let fetch_info = Arc::new(manifest.fetch_info);
 
-        // If the user has set the `ENV_RECONSTRUCT_WRITE_PARALLEL` env variable, then we should
-        // write the file to the output in parallel instead of sequentially.
-        if env::var(ENV_RECONSTRUCT_WRITE_PARALLEL).is_ok() {
-            self.reconstruct_file_to_writer_parallel(
+        // If the user has set the `ENV_RECONSTRUCT_WRITE_SEQUENTIALLY` env variable, then we should
+        // write the file to the output sequentially instead of in parallel.
+        if env::var(ENV_RECONSTRUCT_WRITE_SEQUENTIALLY).is_ok() {
+            self.reconstruct_file_to_writer(
                 terms,
                 fetch_info,
                 manifest.offset_into_first_range,
@@ -169,7 +169,7 @@ impl ReconstructionClient for RemoteClient {
             )
             .await
         } else {
-            self.reconstruct_file_to_writer(
+            self.reconstruct_file_to_writer_parallel(
                 terms,
                 fetch_info,
                 manifest.offset_into_first_range,
@@ -197,11 +197,11 @@ impl ReconstructionClient for RemoteClient {
         let mut ret_size = 0;
         for (hash, terms) in manifest.files {
             let w = files.get(&(hash.into())).unwrap();
-            ret_size += if env::var(ENV_RECONSTRUCT_WRITE_PARALLEL).is_ok() {
-                self.reconstruct_file_to_writer_parallel(terms, fetch_info.clone(), 0, None, w, None)
+            ret_size += if env::var(ENV_RECONSTRUCT_WRITE_SEQUENTIALLY).is_ok() {
+                self.reconstruct_file_to_writer(terms, fetch_info.clone(), 0, None, w, None)
                     .await?
             } else {
-                self.reconstruct_file_to_writer(terms, fetch_info.clone(), 0, None, w, None)
+                self.reconstruct_file_to_writer_parallel(terms, fetch_info.clone(), 0, None, w, None)
                     .await?
             }
         }
@@ -398,7 +398,7 @@ impl RemoteClient {
         // offset for the output.
         let mut bytes_written = 0;
         let mut remaining = total_len;
-        let terms = terms.into_iter().enumerate().map(|(idx, term)| {
+        let term_tasks = terms.into_iter().enumerate().map(|(idx, term)| {
             let start = if idx == 0 { offset_into_first_range as usize } else { 0 };
             let end = min(start as u64 + remaining, term.unpacked_length as u64) as usize;
             let file_offset = bytes_written;
@@ -413,8 +413,8 @@ impl RemoteClient {
 
         // Spawn the tasks
         let mut handles = FuturesUnordered::new();
-        terms.for_each(|term| {
-            let handle = self.threadpool.spawn(term);
+        term_tasks.for_each(|task| {
+            let handle = self.threadpool.spawn(task);
             handles.push(handle);
         });
 

--- a/cas_client/src/remote_client.rs
+++ b/cas_client/src/remote_client.rs
@@ -1,6 +1,7 @@
 use std::cmp::{max, min};
 use std::collections::{HashMap, HashSet};
 use std::io::{Cursor, Write};
+use std::ops::Range;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -14,6 +15,7 @@ use cas_types::{
 use chunk_cache::{CacheConfig, ChunkCache};
 use error_printer::ErrorPrinter;
 use file_utils::SafeFileCreator;
+use futures::stream::FuturesUnordered;
 use futures::{StreamExt, TryStreamExt};
 use http::header::RANGE;
 use mdb_shard::file_structs::{FileDataSequenceEntry, FileDataSequenceHeader, MDBFileInfo};
@@ -22,6 +24,7 @@ use mdb_shard::utils::shard_file_name;
 use merklehash::{HashedWrite, MerkleHash};
 use reqwest::{StatusCode, Url};
 use reqwest_middleware::ClientWithMiddleware;
+use tokio::sync::Semaphore;
 use tracing::{debug, error, trace};
 use utils::auth::AuthConfig;
 use utils::progress::ProgressUpdater;
@@ -178,7 +181,7 @@ impl ReconstructionClient for RemoteClient {
         for (hash, terms) in manifest.files {
             let w = files.get(&(hash.into())).unwrap();
             ret_size += self
-                .reconstruct_file_to_writer(terms, fetch_info.clone(), 0, None, *w, None)
+                .reconstruct_file_to_writer(terms, fetch_info.clone(), 0, None, w, None)
                 .await?;
         }
 
@@ -341,6 +344,117 @@ impl RemoteClient {
         writer.flush()?;
 
         Ok(total_len)
+    }
+
+    pub async fn reconstruct_file_to_writer_parallel(
+        &self,
+        manifest: QueryReconstructionResponse,
+        byte_range: Option<FileRange>,
+        writer: &WriteProvider,
+        progress_updater: Option<Arc<dyn ProgressUpdater>>,
+    ) -> Result<u64> {
+        let total_len = if let Some(range) = byte_range {
+            range.end - range.start
+        } else {
+            manifest.terms.iter().fold(0, |acc, x| acc + x.unpacked_length as u64)
+        };
+        let task_info = TermWriteTask {
+            http_client: self.http_client.clone(),
+            chunk_cache: self.chunk_cache.clone(),
+            range_download_single_flight: self.range_download_single_flight.clone(),
+            fetch_info: Arc::new(manifest.fetch_info),
+            semaphore: Arc::new(Semaphore::new(NUM_CONCURRENT_RANGE_GETS)),
+            writer: writer.clone(),
+        };
+        // Build term tasks, computing the offsets needed for the downloaded term and
+        // offset for the output.
+        let mut bytes_written = 0;
+        let mut remaining = total_len;
+        let terms = manifest.terms.into_iter().enumerate().map(|(idx, term)| {
+            let start = if idx == 0 {
+                manifest.offset_into_first_range as usize
+            } else {
+                0
+            };
+            let end = min(start as u64 + remaining, term.unpacked_length as u64) as usize;
+            let file_offset = bytes_written;
+            let len = (end - start) as u64;
+
+            bytes_written += len;
+            remaining -= len;
+
+            let task = task_info.clone();
+            task.write_term(term, start..end, file_offset)
+        });
+
+        // Spawn the tasks
+        let mut handles = FuturesUnordered::new();
+        terms.for_each(|term| {
+            let handle = self.threadpool.spawn(term);
+            handles.push(handle);
+        });
+
+        // Join the tasks as they come in.
+        let mut total_written = 0;
+        while let Some(result) = handles.next().await {
+            match result {
+                Ok(Ok(len_written)) => {
+                    progress_updater.as_ref().inspect(|updater| updater.update(len_written));
+                    total_written += len_written;
+                },
+                Ok(Err(e)) => Err(e)?,
+                Err(e) => Err(CasClientError::Other(format!("Error joining download task {e:?}")))?,
+            }
+        }
+        Ok(total_written)
+    }
+}
+
+/// Helper object containing the structs needed when downloading and writing a term during
+/// reconstruction. Can be cheaply cloned so that the write_term function can be spawned for
+/// each term.
+#[derive(Clone)]
+struct TermWriteTask {
+    http_client: Arc<ClientWithMiddleware>,
+    chunk_cache: Option<Arc<dyn ChunkCache>>,
+    range_download_single_flight: RangeDownloadSingleFlight,
+    fetch_info: Arc<HashMap<HexMerkleHash, Vec<CASReconstructionFetchInfo>>>,
+    semaphore: Arc<Semaphore>,
+    writer: WriteProvider,
+}
+
+impl TermWriteTask {
+    /// Download the term and write it to the underlying storage.
+    async fn write_term(self, term: CASReconstructionTerm, term_range: Range<usize>, file_start: u64) -> Result<u64> {
+        // acquire permit from the semaphore limiting the download parallelism.
+        let _permit = self
+            .semaphore
+            .acquire_owned()
+            .await
+            .log_error("Couldn't download term")
+            .map_err(|_| CasClientError::Other("couldn't acquire semaphore".to_string()))?;
+
+        // download the term
+        let term_data =
+            get_one_term(self.http_client, self.chunk_cache, term, self.fetch_info, self.range_download_single_flight)
+                .await
+                .log_error("error fetching 1 term")?;
+
+        if term_range.end > term_data.len() {
+            error!(
+                "Error: expected term range: {} larger than received term length: {}",
+                term_range.end,
+                term_data.len()
+            );
+            return Err(CasClientError::Other("term range received invalid".to_string()));
+        }
+        let len = (term_range.end - term_range.start) as u64;
+
+        // write the term
+        let mut writer = self.writer.get_writer_at(file_start)?;
+        writer.write_all(&term_data[term_range])?;
+        writer.flush()?;
+        Ok(len)
     }
 }
 
@@ -636,8 +750,7 @@ mod tests {
     fn test_basic_put() {
         // Arrange
         let prefix = PREFIX_DEFAULT;
-        let (c, _, data, chunk_boundaries) =
-            build_cas_object(3, ChunkSize::Random(512, 10248), cas_object::CompressionScheme::LZ4);
+        let (c, _, data, chunk_boundaries) = build_cas_object(3, ChunkSize::Random(512, 10248), CompressionScheme::LZ4);
 
         let threadpool = Arc::new(ThreadPool::new().unwrap());
         let client = RemoteClient::new(

--- a/data/src/bin/example.rs
+++ b/data/src/bin/example.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, OnceLock};
 
 use anyhow::Result;
-use cas_client::{FileWriteProvider, WriteProvider};
+use cas_client::{FileProvider, WriteProvider};
 use clap::{Args, Parser, Subcommand};
 use data::configurations::*;
 use data::{FileDownloader, FileUploadSession, PointerFile};
@@ -116,10 +116,8 @@ async fn smudge_file(arg: &SmudgeArg) -> Result<()> {
         None => Box::new(std::io::stdin()),
     };
 
-    let writer = WriteProvider::File(FileWriteProvider::new(arg.dest.clone()));
+    let writer = WriteProvider::File(FileProvider::new(arg.dest.clone()));
     smudge(reader, &writer).await?;
-
-    // writer.flush()?;
 
     Ok(())
 }

--- a/data/src/bin/example.rs
+++ b/data/src/bin/example.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, OnceLock};
 
 use anyhow::Result;
-use cas_client::{FileProvider, WriteProvider};
+use cas_client::{FileProvider, OutputProvider};
 use clap::{Args, Parser, Subcommand};
 use data::configurations::*;
 use data::{FileDownloader, FileUploadSession, PointerFile};
@@ -116,13 +116,13 @@ async fn smudge_file(arg: &SmudgeArg) -> Result<()> {
         None => Box::new(std::io::stdin()),
     };
 
-    let writer = WriteProvider::File(FileProvider::new(arg.dest.clone()));
+    let writer = OutputProvider::File(FileProvider::new(arg.dest.clone()));
     smudge(reader, &writer).await?;
 
     Ok(())
 }
 
-async fn smudge(mut reader: impl Read, writer: &WriteProvider) -> Result<()> {
+async fn smudge(mut reader: impl Read, writer: &OutputProvider) -> Result<()> {
     let mut input = String::new();
     reader.read_to_string(&mut input)?;
 

--- a/data/src/data_client.rs
+++ b/data/src/data_client.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use cas_client::remote_client::PREFIX_DEFAULT;
-use cas_client::{CacheConfig, FileWriteProvider, WriteProvider};
+use cas_client::{CacheConfig, FileProvider, WriteProvider};
 use cas_object::CompressionScheme;
 use deduplication::DeduplicationMetrics;
 use dirs::home_dir;
@@ -200,9 +200,9 @@ async fn smudge_file(
     if let Some(parent_dir) = path.parent() {
         std::fs::create_dir_all(parent_dir)?;
     }
-    let f = WriteProvider::File(FileWriteProvider::new(path));
+    let output = WriteProvider::File(FileProvider::new(path));
     downloader
-        .smudge_file_from_pointer(pointer_file, &f, None, progress_updater)
+        .smudge_file_from_pointer(pointer_file, &output, None, progress_updater)
         .await?;
     Ok(pointer_file.path().to_string())
 }

--- a/data/src/data_client.rs
+++ b/data/src/data_client.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use cas_client::remote_client::PREFIX_DEFAULT;
-use cas_client::{CacheConfig, FileProvider, WriteProvider};
+use cas_client::{CacheConfig, FileProvider, OutputProvider};
 use cas_object::CompressionScheme;
 use deduplication::DeduplicationMetrics;
 use dirs::home_dir;
@@ -200,7 +200,7 @@ async fn smudge_file(
     if let Some(parent_dir) = path.parent() {
         std::fs::create_dir_all(parent_dir)?;
     }
-    let output = WriteProvider::File(FileProvider::new(path));
+    let output = OutputProvider::File(FileProvider::new(path));
     downloader
         .smudge_file_from_pointer(pointer_file, &output, None, progress_updater)
         .await?;

--- a/data/src/data_client.rs
+++ b/data/src/data_client.rs
@@ -1,12 +1,12 @@
 use std::env;
 use std::env::current_dir;
 use std::fs::File;
-use std::io::{Read, Write};
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use cas_client::remote_client::PREFIX_DEFAULT;
-use cas_client::CacheConfig;
+use cas_client::{CacheConfig, FileWriteProvider, WriteProvider};
 use cas_object::CompressionScheme;
 use deduplication::DeduplicationMetrics;
 use dirs::home_dir;
@@ -200,9 +200,9 @@ async fn smudge_file(
     if let Some(parent_dir) = path.parent() {
         std::fs::create_dir_all(parent_dir)?;
     }
-    let mut f: Box<dyn Write + Send> = Box::new(File::create(&path)?);
+    let f = WriteProvider::File(FileWriteProvider::new(path));
     downloader
-        .smudge_file_from_pointer(pointer_file, &mut f, None, progress_updater)
+        .smudge_file_from_pointer(pointer_file, &f, None, progress_updater)
         .await?;
     Ok(pointer_file.path().to_string())
 }

--- a/data/src/file_downloader.rs
+++ b/data/src/file_downloader.rs
@@ -56,9 +56,3 @@ impl FileDownloader {
         Ok(n_bytes)
     }
 }
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn test_smudge_file_from_pointer() {}
-}

--- a/data/src/file_downloader.rs
+++ b/data/src/file_downloader.rs
@@ -1,7 +1,6 @@
-use std::io::Write;
 use std::sync::Arc;
 
-use cas_client::Client;
+use cas_client::{Client, WriteProvider};
 use cas_types::FileRange;
 use merklehash::MerkleHash;
 use utils::progress::ProgressUpdater;
@@ -34,7 +33,7 @@ impl FileDownloader {
     pub async fn smudge_file_from_pointer(
         &self,
         pointer: &PointerFile,
-        writer: &mut Box<dyn Write + Send>,
+        writer: &WriteProvider,
         range: Option<FileRange>,
         progress_updater: Option<Arc<dyn ProgressUpdater>>,
     ) -> Result<u64> {
@@ -45,7 +44,7 @@ impl FileDownloader {
     pub async fn smudge_file_from_hash(
         &self,
         file_id: &MerkleHash,
-        writer: &mut Box<dyn Write + Send>,
+        writer: &WriteProvider,
         range: Option<FileRange>,
         progress_updater: Option<Arc<dyn ProgressUpdater>>,
     ) -> Result<u64> {
@@ -56,4 +55,10 @@ impl FileDownloader {
 
         Ok(n_bytes)
     }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_smudge_file_from_pointer() {}
 }

--- a/data/src/file_downloader.rs
+++ b/data/src/file_downloader.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use cas_client::{Client, WriteProvider};
+use cas_client::{Client, OutputProvider};
 use cas_types::FileRange;
 use merklehash::MerkleHash;
 use utils::progress::ProgressUpdater;
@@ -33,23 +33,23 @@ impl FileDownloader {
     pub async fn smudge_file_from_pointer(
         &self,
         pointer: &PointerFile,
-        writer: &WriteProvider,
+        output: &OutputProvider,
         range: Option<FileRange>,
         progress_updater: Option<Arc<dyn ProgressUpdater>>,
     ) -> Result<u64> {
-        self.smudge_file_from_hash(&pointer.hash()?, writer, range, progress_updater)
+        self.smudge_file_from_hash(&pointer.hash()?, output, range, progress_updater)
             .await
     }
 
     pub async fn smudge_file_from_hash(
         &self,
         file_id: &MerkleHash,
-        writer: &WriteProvider,
+        output: &OutputProvider,
         range: Option<FileRange>,
         progress_updater: Option<Arc<dyn ProgressUpdater>>,
     ) -> Result<u64> {
         // Currently, this works by always directly querying the remote server.
-        let n_bytes = self.client.get_file(file_id, range, writer, progress_updater).await?;
+        let n_bytes = self.client.get_file(file_id, range, output, progress_updater).await?;
 
         prometheus_metrics::FILTER_BYTES_SMUDGED.inc_by(n_bytes);
 

--- a/data/src/file_upload_session.rs
+++ b/data/src/file_upload_session.rs
@@ -349,7 +349,7 @@ mod tests {
     /// * `output_path`: path to write the hydrated/original file
     async fn test_smudge_file(runtime: Arc<ThreadPool>, cas_path: &Path, pointer_path: &Path, output_path: &Path) {
         let mut reader = File::open(pointer_path).unwrap();
-        let writer = WriteProvider::File(FileProvider::new(output_path.to_path_buf()));
+        let writer = OutputProvider::File(FileProvider::new(output_path.to_path_buf()));
 
         let mut input = String::new();
         reader.read_to_string(&mut input).unwrap();
@@ -372,12 +372,10 @@ mod tests {
 
     use std::fs::{read, write};
 
-    use cas_client::{FileProvider, WriteProvider};
+    use cas_client::{FileProvider, OutputProvider};
     use tempfile::tempdir;
 
-    /// Unit tests
     use super::*;
-
 
     #[test]
     fn test_clean_smudge_round_trip() {

--- a/data/src/file_upload_session.rs
+++ b/data/src/file_upload_session.rs
@@ -349,7 +349,7 @@ mod tests {
     /// * `output_path`: path to write the hydrated/original file
     async fn test_smudge_file(runtime: Arc<ThreadPool>, cas_path: &Path, pointer_path: &Path, output_path: &Path) {
         let mut reader = File::open(pointer_path).unwrap();
-        let writer = WriteProvider::File(FileWriteProvider::new(output_path.to_path_buf()));
+        let writer = WriteProvider::File(FileProvider::new(output_path.to_path_buf()));
 
         let mut input = String::new();
         reader.read_to_string(&mut input).unwrap();
@@ -372,7 +372,7 @@ mod tests {
 
     use std::fs::{read, write};
 
-    use cas_client::{FileWriteProvider, WriteProvider};
+    use cas_client::{FileProvider, WriteProvider};
     use tempfile::tempdir;
 
     /// Unit tests

--- a/data/src/file_upload_session.rs
+++ b/data/src/file_upload_session.rs
@@ -295,7 +295,6 @@ impl FileUploadSession {
 
 #[cfg(test)]
 mod tests {
-
     use std::fs::{File, OpenOptions};
     use std::io::{Read, Write};
     use std::path::Path;
@@ -350,14 +349,7 @@ mod tests {
     /// * `output_path`: path to write the hydrated/original file
     async fn test_smudge_file(runtime: Arc<ThreadPool>, cas_path: &Path, pointer_path: &Path, output_path: &Path) {
         let mut reader = File::open(pointer_path).unwrap();
-        let writer: Box<dyn Write + Send + 'static> = Box::new(
-            OpenOptions::new()
-                .create(true)
-                .write(true)
-                .truncate(true)
-                .open(output_path)
-                .unwrap(),
-        );
+        let writer = WriteProvider::File(FileWriteProvider::new(output_path.to_path_buf()));
 
         let mut input = String::new();
         reader.read_to_string(&mut input).unwrap();
@@ -373,17 +365,19 @@ mod tests {
             .unwrap();
 
         translator
-            .smudge_file_from_pointer(&pointer_file, &mut (Box::new(writer) as Box<dyn Write + Send>), None, None)
+            .smudge_file_from_pointer(&pointer_file, &writer, None, None)
             .await
             .unwrap();
     }
 
     use std::fs::{read, write};
 
+    use cas_client::{FileWriteProvider, WriteProvider};
     use tempfile::tempdir;
 
     /// Unit tests
     use super::*;
+
 
     #[test]
     fn test_clean_smudge_round_trip() {

--- a/data/tests/test_clean_smudge.rs
+++ b/data/tests/test_clean_smudge.rs
@@ -2,7 +2,7 @@ use std::fs::{create_dir_all, read_dir, File};
 use std::io::{Read, Write};
 use std::path::Path;
 
-use cas_client::{FileWriteProvider, WriteProvider};
+use cas_client::{FileProvider, WriteProvider};
 use data::configurations::TranslatorConfig;
 use data::data_client::clean_file;
 use data::{FileDownloader, FileUploadSession, PointerFile};
@@ -142,7 +142,7 @@ async fn hydrate_directory(cas_dir: &Path, ptr_dir: &Path, out_dir: &Path) {
         let out_filename = out_dir.join(entry.file_name());
 
         // Create an output file for writing
-        let file_out = WriteProvider::File(FileWriteProvider::new(out_filename));
+        let file_out = WriteProvider::File(FileProvider::new(out_filename));
 
         // Pointer file.
         let pf = PointerFile::init_from_path(entry.path());

--- a/data/tests/test_clean_smudge.rs
+++ b/data/tests/test_clean_smudge.rs
@@ -2,7 +2,7 @@ use std::fs::{create_dir_all, read_dir, File};
 use std::io::{Read, Write};
 use std::path::Path;
 
-use cas_client::{FileProvider, WriteProvider};
+use cas_client::{FileProvider, OutputProvider};
 use data::configurations::TranslatorConfig;
 use data::data_client::clean_file;
 use data::{FileDownloader, FileUploadSession, PointerFile};
@@ -142,7 +142,7 @@ async fn hydrate_directory(cas_dir: &Path, ptr_dir: &Path, out_dir: &Path) {
         let out_filename = out_dir.join(entry.file_name());
 
         // Create an output file for writing
-        let file_out = WriteProvider::File(FileProvider::new(out_filename));
+        let file_out = OutputProvider::File(FileProvider::new(out_filename));
 
         // Pointer file.
         let pf = PointerFile::init_from_path(entry.path());

--- a/data/tests/test_clean_smudge.rs
+++ b/data/tests/test_clean_smudge.rs
@@ -2,6 +2,7 @@ use std::fs::{create_dir_all, read_dir, File};
 use std::io::{Read, Write};
 use std::path::Path;
 
+use cas_client::{FileWriteProvider, WriteProvider};
 use data::configurations::TranslatorConfig;
 use data::data_client::clean_file;
 use data::{FileDownloader, FileUploadSession, PointerFile};
@@ -141,16 +142,13 @@ async fn hydrate_directory(cas_dir: &Path, ptr_dir: &Path, out_dir: &Path) {
         let out_filename = out_dir.join(entry.file_name());
 
         // Create an output file for writing
-        let mut file_out: Box<dyn Write + Send> = Box::new(File::create(&out_filename).unwrap());
+        let file_out = WriteProvider::File(FileWriteProvider::new(out_filename));
 
         // Pointer file.
         let pf = PointerFile::init_from_path(entry.path());
         assert!(pf.is_valid());
 
-        downloader
-            .smudge_file_from_pointer(&pf, &mut file_out, None, None)
-            .await
-            .unwrap();
+        downloader.smudge_file_from_pointer(&pf, &file_out, None, None).await.unwrap();
     }
 }
 

--- a/hf_xet/Cargo.lock
+++ b/hf_xet/Cargo.lock
@@ -322,8 +322,10 @@ dependencies = [
  "futures",
  "half",
  "lz4_flex",
+ "mdb_shard",
  "merkledb",
  "merklehash",
+ "more-asserts",
  "parutils",
  "rand 0.8.5",
  "serde",
@@ -629,6 +631,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,10 +661,11 @@ dependencies = [
  "cas_types",
  "chrono",
  "clap 3.2.25",
+ "countio",
+ "deduplication",
  "dirs",
  "error_printer",
  "file_utils",
- "gearhash",
  "glob",
  "hashers",
  "http 0.2.12",
@@ -661,6 +674,7 @@ dependencies = [
  "mdb_shard",
  "merkledb",
  "merklehash",
+ "more-asserts",
  "openssl",
  "parutils",
  "prometheus",
@@ -689,6 +703,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "uuid",
+]
+
+[[package]]
+name = "deduplication"
+version = "0.14.5"
+dependencies = [
+ "async-trait",
+ "gearhash",
+ "lazy_static",
+ "mdb_shard",
+ "merkledb",
+ "merklehash",
+ "more-asserts",
+ "utils",
 ]
 
 [[package]]
@@ -1763,6 +1791,7 @@ version = "0.14.5"
 dependencies = [
  "anyhow",
  "async-trait",
+ "blake3",
  "clap 3.2.25",
  "futures-io",
  "futures-util",
@@ -1895,6 +1924,12 @@ dependencies = [
  "quote",
  "syn 2.0.87",
 ]
+
+[[package]]
+name = "more-asserts"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 
 [[package]]
 name = "native-tls"
@@ -2147,6 +2182,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45ca20c77d80be666aef2b45486da86238fabe33e38306bd3118fe4af33fa880"
+dependencies = [
+ "paste-impl",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "paste-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6"
+dependencies = [
+ "proc-macro-hack",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2295,6 +2349,12 @@ dependencies = [
  "quote",
  "version_check",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -3620,9 +3680,12 @@ version = "0.14.5"
 dependencies = [
  "async-trait",
  "bytes",
+ "ctor",
  "futures",
+ "lazy_static",
  "merklehash",
  "parking_lot 0.11.2",
+ "paste",
  "pin-project",
  "thiserror 2.0.11",
  "tokio",


### PR DESCRIPTION
When investigating slowness between hf_xet download and hf_transfer, we noticed that one source of slowness was due to the fact that although terms were downloaded concurrently, they were being written sequentially to disk. In [hf_transfer](https://github.com/huggingface/hf_transfer/blob/main/src/lib.rs#L334-L361), each chunk downloaded is written to the output file directly.

This PR updates the way the cas_client writes reconstructed terms to the output file to behave similarly to hf_transfer:
* Refactors the reconstruction path to take a `OutputProvider` enum instead of a `&Box<dyn Write + Send>`.
* `OutputProvider` enum can be called to provide a `Write` implementation for a particular location.
* New method: `RemoteClient::reconstruct_file_to_writer_parallel` to write terms to the output file in parallel.
* Env variable: `HF_XET_RECONSTRUCT_WRITE_SEQUENTIALLY` that, when set by the user, will enable writing terms to the output sequentially instead of in parallel.

TODO:

- [x] Clean up
- [x] More Testing