### PR TITLE
Update hf_xet to 1.0.0

### DIFF
--- a/hf_xet/Cargo.lock
+++ b/hf_xet/Cargo.lock
@@ -1207,7 +1207,7 @@ checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hf_xet"
-version = "0.1.4"
+version = "1.0.0"
 dependencies = [
  "async-trait",
  "bipbuffer",

--- a/hf_xet/Cargo.toml
+++ b/hf_xet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hf_xet"
-version = "0.1.4"
+version = "1.0.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/hf_xet/src/token_refresh.rs
+++ b/hf_xet/src/token_refresh.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::PyAnyMethods;
 use pyo3::{Py, PyAny, PyErr, PyResult, Python};
-use tracing::{error, info};
+use tracing::error;
 use utils::auth::{TokenInfo, TokenRefresher};
 use utils::errors::AuthError;
 


### PR DESCRIPTION
Now that we've released the integration with huggingface_hub and users are expected to use hf_xet in production, we should bump up the version of hf_xet to reflect this.

This does imply that we will not be breaking the interface to hf_xet (i.e. the pyo3 interface), however, I think that that is something to adhere to as breaking that interface will break current huggingface_hub versions.