### PR TITLE
configure cache size and default endpoint

### DIFF
--- a/cas_client/src/lib.rs
+++ b/cas_client/src/lib.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code)]
 
-pub use chunk_cache::CacheConfig;
-pub use chunk_cache::DEFAULT_CHUNK_CACHE_CAPACITY;
+pub use chunk_cache::{CacheConfig, DEFAULT_CHUNK_CACHE_CAPACITY};
 pub use http_client::{build_auth_http_client, build_http_client, RetryConfig};
 use interface::RegistrationClient;
 pub use interface::{Client, FileProvider, OutputProvider, ReconstructionClient, UploadClient};

--- a/cas_client/src/lib.rs
+++ b/cas_client/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 pub use chunk_cache::CacheConfig;
+pub use chunk_cache::DEFAULT_CHUNK_CACHE_CAPACITY;
 pub use http_client::{build_auth_http_client, build_http_client, RetryConfig};
 use interface::RegistrationClient;
 pub use interface::{Client, FileProvider, OutputProvider, ReconstructionClient, UploadClient};

--- a/cas_client/src/lib.rs
+++ b/cas_client/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-pub use chunk_cache::{CacheConfig, DEFAULT_CHUNK_CACHE_CAPACITY};
+pub use chunk_cache::{CacheConfig, CHUNK_CACHE_SIZE_BYTES};
 pub use http_client::{build_auth_http_client, build_http_client, RetryConfig};
 use interface::RegistrationClient;
 pub use interface::{Client, FileProvider, OutputProvider, ReconstructionClient, UploadClient};

--- a/cas_client/src/remote_client.rs
+++ b/cas_client/src/remote_client.rs
@@ -80,13 +80,17 @@ impl RemoteClient {
     ) -> Self {
         // use disk cache if cache_config provided.
         let chunk_cache = if let Some(cache_config) = cache_config {
-            debug!(
-                "Using disk cache directory: {:?}, size: {}.",
-                cache_config.cache_directory, cache_config.cache_size
-            );
-            chunk_cache::get_cache(cache_config)
-                .log_error("failed to initialize cache, not using cache")
-                .ok()
+            if cache_config.cache_size == 0 {
+                None
+            } else {
+                debug!(
+                    "Using disk cache directory: {:?}, size: {}.",
+                    cache_config.cache_directory, cache_config.cache_size
+                );
+                chunk_cache::get_cache(cache_config)
+                    .log_error("failed to initialize cache, not using cache")
+                    .ok()
+            }
         } else {
             None
         };

--- a/cas_client/src/remote_client.rs
+++ b/cas_client/src/remote_client.rs
@@ -25,7 +25,7 @@ use merklehash::{HashedWrite, MerkleHash};
 use reqwest::{StatusCode, Url};
 use reqwest_middleware::ClientWithMiddleware;
 use tokio::sync::Semaphore;
-use tracing::{debug, error, trace};
+use tracing::{debug, error, info, trace};
 use utils::auth::AuthConfig;
 use utils::progress::ProgressUpdater;
 use utils::singleflight::Group;
@@ -81,6 +81,7 @@ impl RemoteClient {
         // use disk cache if cache_config provided.
         let chunk_cache = if let Some(cache_config) = cache_config {
             if cache_config.cache_size == 0 {
+                info!("Chunk cache size set to 0, disabling chunk cache");
                 None
             } else {
                 debug!(

--- a/cas_client/src/remote_client.rs
+++ b/cas_client/src/remote_client.rs
@@ -45,7 +45,7 @@ pub const PREFIX_DEFAULT: &str = "default";
 utils::configurable_constants! {
    ref NUM_CONCURRENT_RANGE_GETS: usize = 16;
 
-// Env (XET_RECONSTRUCT_WRITE_SEQUENTIALLY) to switch to writing terms sequentially to disk.
+// Env (HF_XET_RECONSTRUCT_WRITE_SEQUENTIALLY) to switch to writing terms sequentially to disk.
 // Benchmarks have shown that on SSD machines, writing in parallel seems to far outperform
 // sequential term writes.
 // However, this is not likely the case for writing to HDD and may in fact be worse,
@@ -170,7 +170,7 @@ impl ReconstructionClient for RemoteClient {
         let terms = manifest.terms;
         let fetch_info = Arc::new(manifest.fetch_info);
 
-        // If the user has set the `XET_RECONSTRUCT_WRITE_SEQUENTIALLY=true` env variable, then we
+        // If the user has set the `HF_XET_RECONSTRUCT_WRITE_SEQUENTIALLY=true` env variable, then we
         // should write the file to the output sequentially instead of in parallel.
         if *RECONSTRUCT_WRITE_SEQUENTIALLY {
             self.reconstruct_file_to_writer(

--- a/chunk_cache/src/disk.rs
+++ b/chunk_cache/src/disk.rs
@@ -1210,16 +1210,15 @@ mod tests {
             "evicted key that should have remained in cache"
         );
     }
-    
+
     #[test]
     fn test_initialize_with_cache_size_0() {
         assert!(DiskCache::initialize(&CacheConfig {
             cache_directory: "/tmp".into(),
             cache_size: 0,
-        }).is_err());
-
+        })
+        .is_err());
     }
-    
 }
 
 #[cfg(test)]

--- a/chunk_cache/src/disk.rs
+++ b/chunk_cache/src/disk.rs
@@ -106,6 +106,8 @@ impl DiskCache {
     /// the cache file system layout is rooted at the provided config.cache_directory and initialize
     /// will attempt to load any pre-existing cache state into memory.
     ///
+    /// an configured size of 0 caused initialization to fail
+    ///
     /// The cache layout is as follows:
     ///
     /// each key (cas hash) in the cache is a directory, containing "cache items" that each provide
@@ -129,6 +131,9 @@ impl DiskCache {
     /// │       ├── [range 404-405, file_len, file_hash]
     /// │       └── [range 679-700, file_len, file_hash]
     pub fn initialize(config: &CacheConfig) -> Result<Self, ChunkCacheError> {
+        if config.cache_size == 0 {
+            return Err(ChunkCacheError::InvalidArguments);
+        }
         let capacity = config.cache_size;
         let cache_root = config.cache_directory.clone();
 
@@ -1205,6 +1210,16 @@ mod tests {
             "evicted key that should have remained in cache"
         );
     }
+    
+    #[test]
+    fn test_initialize_with_cache_size_0() {
+        assert!(DiskCache::initialize(&CacheConfig {
+            cache_directory: "/tmp".into(),
+            cache_size: 0,
+        }).is_err());
+
+    }
+    
 }
 
 #[cfg(test)]

--- a/chunk_cache/src/disk.rs
+++ b/chunk_cache/src/disk.rs
@@ -27,7 +27,7 @@ pub mod test_utils;
 
 // consistently use URL_SAFE (also file path safe) base64 codec
 pub(crate) const BASE64_ENGINE: GeneralPurpose = URL_SAFE;
-pub const DEFAULT_CAPACITY: u64 = 10 << 30; // 10 GB
+pub const DEFAULT_CHUNK_CACHE_CAPACITY: u64 = 10 << 30; // 10 GB
 const PREFIX_DIR_NAME_LEN: usize = 2;
 
 type OptionResult<T, E> = Result<Option<T>, E>;
@@ -674,10 +674,10 @@ fn try_parse_cache_file(file_result: io::Result<DirEntry>, capacity: u64) -> Opt
     if !md.is_file() {
         return Ok(None);
     }
-    if md.len() > DEFAULT_CAPACITY {
+    if md.len() > DEFAULT_CHUNK_CACHE_CAPACITY {
         return Err(ChunkCacheError::general(format!(
             "Cache directory contains a file larger than {} GB, cache directory state is invalid",
-            (DEFAULT_CAPACITY as f64 / (1 << 30) as f64)
+            (DEFAULT_CHUNK_CACHE_CAPACITY as f64 / (1 << 30) as f64)
         )));
     }
 
@@ -805,7 +805,7 @@ mod tests {
     use rand::SeedableRng;
     use tempdir::TempDir;
 
-    use super::{DiskCache, DEFAULT_CAPACITY};
+    use super::{DiskCache, DEFAULT_CHUNK_CACHE_CAPACITY};
     use crate::disk::test_utils::*;
     use crate::disk::try_parse_key;
     use crate::{CacheConfig, ChunkCache};
@@ -818,7 +818,7 @@ mod tests {
         let cache_root = TempDir::new("empty").unwrap();
         let config = CacheConfig {
             cache_directory: cache_root.path().to_path_buf(),
-            cache_size: DEFAULT_CAPACITY,
+            cache_size: DEFAULT_CHUNK_CACHE_CAPACITY,
             ..Default::default()
         };
         let cache = DiskCache::initialize(&config).unwrap();
@@ -831,7 +831,7 @@ mod tests {
         let cache_root = TempDir::new("put_get_simple").unwrap();
         let config = CacheConfig {
             cache_directory: cache_root.path().to_path_buf(),
-            cache_size: DEFAULT_CAPACITY,
+            cache_size: DEFAULT_CHUNK_CACHE_CAPACITY,
             ..Default::default()
         };
         let cache = DiskCache::initialize(&config).unwrap();
@@ -857,7 +857,7 @@ mod tests {
         let cache_root = TempDir::new("put_get_subrange").unwrap();
         let config = CacheConfig {
             cache_directory: cache_root.path().to_path_buf(),
-            cache_size: DEFAULT_CAPACITY,
+            cache_size: DEFAULT_CHUNK_CACHE_CAPACITY,
             ..Default::default()
         };
         let cache = DiskCache::initialize(&config).unwrap();
@@ -917,7 +917,7 @@ mod tests {
         let cache_root = TempDir::new("same_puts_noop").unwrap();
         let config = CacheConfig {
             cache_directory: cache_root.path().to_path_buf(),
-            cache_size: DEFAULT_CAPACITY,
+            cache_size: DEFAULT_CHUNK_CACHE_CAPACITY,
             ..Default::default()
         };
         let cache = DiskCache::initialize(&config).unwrap();
@@ -934,7 +934,7 @@ mod tests {
             let cache_root = TempDir::new("overlap_range_data_mismatch_fail").unwrap();
             let config = CacheConfig {
                 cache_directory: cache_root.path().to_path_buf(),
-                cache_size: DEFAULT_CAPACITY,
+                cache_size: DEFAULT_CHUNK_CACHE_CAPACITY,
                 ..Default::default()
             };
             let cache = DiskCache::initialize(&config).unwrap();
@@ -984,7 +984,7 @@ mod tests {
         let cache_root = TempDir::new("initialize_non_empty").unwrap();
         let config = CacheConfig {
             cache_directory: cache_root.path().to_path_buf(),
-            cache_size: DEFAULT_CAPACITY,
+            cache_size: DEFAULT_CHUNK_CACHE_CAPACITY,
             ..Default::default()
         };
         let cache = DiskCache::initialize(&config).unwrap();
@@ -1017,7 +1017,7 @@ mod tests {
         let cache_root = TempDir::new("initialize_too_large_file").unwrap();
         let config = CacheConfig {
             cache_directory: cache_root.path().to_path_buf(),
-            cache_size: DEFAULT_CAPACITY,
+            cache_size: DEFAULT_CHUNK_CACHE_CAPACITY,
             ..Default::default()
         };
         let cache = DiskCache::initialize(&config).unwrap();
@@ -1115,7 +1115,7 @@ mod tests {
         let cache_root = TempDir::new("put_subrange").unwrap();
         let config = CacheConfig {
             cache_directory: cache_root.path().to_path_buf(),
-            cache_size: DEFAULT_CAPACITY,
+            cache_size: DEFAULT_CHUNK_CACHE_CAPACITY,
             ..Default::default()
         };
         let cache = DiskCache::initialize(&config).unwrap();
@@ -1212,7 +1212,7 @@ mod concurrency_tests {
     use tempdir::TempDir;
 
     use super::DiskCache;
-    use crate::disk::DEFAULT_CAPACITY;
+    use crate::disk::DEFAULT_CHUNK_CACHE_CAPACITY;
     use crate::{CacheConfig, ChunkCache, RandomEntryIterator, RANGE_LEN};
 
     const NUM_ITEMS_PER_TASK: usize = 20;
@@ -1224,7 +1224,7 @@ mod concurrency_tests {
 
         let config = CacheConfig {
             cache_directory: cache_root.path().to_path_buf(),
-            cache_size: DEFAULT_CAPACITY,
+            cache_size: DEFAULT_CHUNK_CACHE_CAPACITY,
             ..Default::default()
         };
         let cache = DiskCache::initialize(&config).unwrap();

--- a/chunk_cache/src/lib.rs
+++ b/chunk_cache/src/lib.rs
@@ -11,7 +11,7 @@ pub use disk::DiskCache;
 use error::ChunkCacheError;
 use mockall::automock;
 
-use crate::disk::DEFAULT_CAPACITY;
+pub use crate::disk::DEFAULT_CHUNK_CACHE_CAPACITY;
 
 /// ChunkCache is a trait for storing and fetching Xorb ranges.
 /// implementors are expected to return bytes for a key and a given chunk range
@@ -67,7 +67,7 @@ impl Default for CacheConfig {
     fn default() -> Self {
         CacheConfig {
             cache_directory: PathBuf::from("/tmp"),
-            cache_size: DEFAULT_CAPACITY,
+            cache_size: DEFAULT_CHUNK_CACHE_CAPACITY,
         }
     }
 }

--- a/chunk_cache/src/lib.rs
+++ b/chunk_cache/src/lib.rs
@@ -13,6 +13,10 @@ use mockall::automock;
 
 pub use crate::disk::DEFAULT_CHUNK_CACHE_CAPACITY;
 
+utils::configurable_constants! {
+    ref CHUNK_CACHE_SIZE_BYTES: u64 = DEFAULT_CHUNK_CACHE_CAPACITY;
+}
+
 /// ChunkCache is a trait for storing and fetching Xorb ranges.
 /// implementors are expected to return bytes for a key and a given chunk range
 /// (no compression or further deserialization should be required)
@@ -67,7 +71,7 @@ impl Default for CacheConfig {
     fn default() -> Self {
         CacheConfig {
             cache_directory: PathBuf::from("/tmp"),
-            cache_size: DEFAULT_CHUNK_CACHE_CAPACITY,
+            cache_size: *CHUNK_CACHE_SIZE_BYTES,
         }
     }
 }

--- a/data/src/configurations.rs
+++ b/data/src/configurations.rs
@@ -11,7 +11,7 @@ use crate::errors::Result;
 use crate::repo_salt::RepoSalt;
 
 utils::configurable_constants! {
-    ref CHUNK_CACHE_SIZE: u64 = cas_client::DEFAULT_CHUNK_CACHE_CAPACITY;
+    ref CHUNK_CACHE_SIZE_BYTES: u64 = cas_client::DEFAULT_CHUNK_CACHE_CAPACITY;
 }
 
 #[derive(Debug)]

--- a/data/src/configurations.rs
+++ b/data/src/configurations.rs
@@ -3,16 +3,12 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use cas_client::remote_client::PREFIX_DEFAULT;
-use cas_client::CacheConfig;
+use cas_client::{CacheConfig, CHUNK_CACHE_SIZE_BYTES};
 use cas_object::CompressionScheme;
 use utils::auth::AuthConfig;
 
 use crate::errors::Result;
 use crate::repo_salt::RepoSalt;
-
-utils::configurable_constants! {
-    ref CHUNK_CACHE_SIZE_BYTES: u64 = cas_client::DEFAULT_CHUNK_CACHE_CAPACITY;
-}
 
 #[derive(Debug)]
 pub enum Endpoint {
@@ -94,7 +90,7 @@ impl TranslatorConfig {
                 prefix: PREFIX_DEFAULT.into(),
                 cache_config: CacheConfig {
                     cache_directory: path.join("cache"),
-                    cache_size: *CHUNK_CACHE_SIZE,
+                    cache_size: *CHUNK_CACHE_SIZE_BYTES,
                 },
                 staging_directory: None,
             },

--- a/data/src/configurations.rs
+++ b/data/src/configurations.rs
@@ -10,6 +10,10 @@ use utils::auth::AuthConfig;
 use crate::errors::Result;
 use crate::repo_salt::RepoSalt;
 
+utils::configurable_constants! {
+    ref CHUNK_CACHE_SIZE: u64 = cas_client::DEFAULT_CHUNK_CACHE_CAPACITY;
+}
+
 #[derive(Debug)]
 pub enum Endpoint {
     Server(String),
@@ -90,7 +94,7 @@ impl TranslatorConfig {
                 prefix: PREFIX_DEFAULT.into(),
                 cache_config: CacheConfig {
                     cache_directory: path.join("cache"),
-                    cache_size: 10 * 1024 * 1024 * 1024, // 10 GiB
+                    cache_size: *CHUNK_CACHE_SIZE,
                 },
                 staging_directory: None,
             },

--- a/data/src/data_client.rs
+++ b/data/src/data_client.rs
@@ -107,8 +107,7 @@ pub async fn upload_async(
     // produce Xorbs + Shards
     // upload shards and xorbs
     // for each file, return the filehash
-    let config =
-        default_config(endpoint.unwrap_or(DEFAULT_CAS_ENDPOINT.clone()), None, token_info, token_refresher)?;
+    let config = default_config(endpoint.unwrap_or(DEFAULT_CAS_ENDPOINT.clone()), None, token_info, token_refresher)?;
 
     let upload_session = FileUploadSession::new(config, threadpool, progress_updater).await?;
 

--- a/data/src/data_client.rs
+++ b/data/src/data_client.rs
@@ -21,7 +21,9 @@ use crate::errors::DataProcessingError;
 use crate::repo_salt::RepoSalt;
 use crate::{errors, FileDownloader, FileUploadSession, PointerFile};
 
-const DEFAULT_CAS_ENDPOINT: &str = "http://localhost:8080";
+utils::configurable_constants! {
+    ref DEFAULT_CAS_ENDPOINT: String = "http://localhost:8080".to_string();
+}
 
 pub fn default_config(
     endpoint: String,
@@ -106,7 +108,7 @@ pub async fn upload_async(
     // upload shards and xorbs
     // for each file, return the filehash
     let config =
-        default_config(endpoint.unwrap_or(DEFAULT_CAS_ENDPOINT.to_string()), None, token_info, token_refresher)?;
+        default_config(endpoint.unwrap_or(DEFAULT_CAS_ENDPOINT.clone()), None, token_info, token_refresher)?;
 
     let upload_session = FileUploadSession::new(config, threadpool, progress_updater).await?;
 

--- a/file_utils/src/privilege_context.rs
+++ b/file_utils/src/privilege_context.rs
@@ -245,14 +245,14 @@ mod test {
 
         /* For Unix
             1. Run the below shell script in an empty dir with standard privileges.
-            2. Set env var 'XET_TEST_PATH' to this path.
+            2. Set env var 'HF_XET_TEST_PATH' to this path.
             3. Build the test executable by running 'cargo test -p gitxetcore --lib --no-run'.
             4. Locate the path to the executable as TEST_EXE
             5. Run test with a non-root user: 'TEST_EXE config::permission::test::test_create_dir_all --exact --nocapture --include-ignored'
             sudo mkdir rootdir
         */
 
-        let test_path = std::env::var("XET_TEST_PATH")?;
+        let test_path = std::env::var("HF_XET_TEST_PATH")?;
         std::env::set_current_dir(test_path)?;
         let permission = PrivilgedExecutionContext::current();
 
@@ -271,7 +271,7 @@ mod test {
 
         /* For Unix
             1. Run the below shell script in an empty dir with standard privileges.
-            2. Set env var 'XET_TEST_PATH' to this path.
+            2. Set env var 'HF_XET_TEST_PATH' to this path.
             3. Build the test executable by running 'cargo test -p gitxetcore --lib --no-run'.
             4. Locate the path to the executable as TEST_EXE
             5. Run test with a non-root user: 'sudo -E TEST_EXE config::permission::test::test_create_dir_all_sudo --exact --nocapture --include-ignored'
@@ -279,7 +279,7 @@ mod test {
             mkdir regdir
         */
 
-        let test_path = std::env::var("XET_TEST_PATH")?;
+        let test_path = std::env::var("HF_XET_TEST_PATH")?;
         std::env::set_current_dir(test_path)?;
         let permission = PrivilgedExecutionContext::current();
 
@@ -307,7 +307,7 @@ mod test {
 
         /* For Unix
             1. Run the below shell script in an empty dir with standard privileges.
-            2. Set env var 'XET_TEST_PATH' to this path.
+            2. Set env var 'HF_XET_TEST_PATH' to this path.
             3. Build the test executable by running 'cargo test -p gitxetcore --lib --no-run'.
             4. Locate the path to the executable as TEST_EXE
             5. Run test with a non-root user: 'TEST_EXE config::permission::test::test_create_file --exact --nocapture --include-ignored'
@@ -316,7 +316,7 @@ mod test {
         sudo touch rootdir/file
          */
 
-        let test_path = std::env::var("XET_TEST_PATH")?;
+        let test_path = std::env::var("HF_XET_TEST_PATH")?;
         std::env::set_current_dir(test_path)?;
         let permission = PrivilgedExecutionContext::current();
 
@@ -341,14 +341,14 @@ mod test {
 
         /* For Unix
             1. Run the below shell script in an empty dir with standard privileges.
-            2. Set env var 'XET_TEST_PATH' to this path.
+            2. Set env var 'HF_XET_TEST_PATH' to this path.
             3. Build the test executable by running 'cargo test -p gitxetcore --lib --no-run'.
             4. Locate the path to the executable as TEST_EXE
             5. Run test with a non-root user: 'sudo -E TEST_EXE config::permission::test::test_create_file_sudo --exact --nocapture --include-ignored'
             mkdir regdir
         */
 
-        let test_path = std::env::var("XET_TEST_PATH")?;
+        let test_path = std::env::var("HF_XET_TEST_PATH")?;
         std::env::set_current_dir(test_path)?;
 
         let test = Path::new("regdir/regdir1/regdir2/file");

--- a/utils/src/constant_declarations.rs
+++ b/utils/src/constant_declarations.rs
@@ -34,7 +34,7 @@ macro_rules! configurable_constants {
                 pub static ref $name: $type = {
                     let v : GlobalConfigMode<$type> = ($value).into();
                     let try_load_from_env = |v_| {
-                        std::env::var(concat!("XET_",stringify!($name)))
+                        std::env::var(concat!("HF_XET_",stringify!($name)))
                             .ok()
                             .and_then(|s| s.parse::<$type>().ok())
                             .unwrap_or(v_)
@@ -54,7 +54,7 @@ macro_rules! configurable_constants {
 pub use ctor as ctor_reexport;
 
 #[cfg(not(doctest))]
-/// A macro for **tests** that sets `XET_<GLOBAL_NAME>` to `$value` **before**
+/// A macro for **tests** that sets `HF_XET_<GLOBAL_NAME>` to `$value` **before**
 /// the global is initialized, and then checks that the global actually picks up
 /// that value. If the global was already accessed (thus initialized), or if it
 /// doesn't match after being set, this macro panics.
@@ -89,8 +89,8 @@ macro_rules! test_set_globals {
             $(
                 let val = $val;
 
-                // Construct the environment variable name, e.g. "XET_MAX_NUM_CHUNKS"
-                let env_name = concat!("XET_", stringify!($var_name));
+                // Construct the environment variable name, e.g. "HF_XET_MAX_NUM_CHUNKS"
+                let env_name = concat!("HF_XET_", stringify!($var_name));
                 // Convert the $val to a string and set it
                 std::env::set_var(env_name, val.to_string());
 


### PR DESCRIPTION
allows cache size and default endpoint to be configured with env vars:

XET_CHUNK_CACHE_SIZE_BYTES
XET_DEFAULT_CAS_ENDPOINT

Fix XET-276, concurrency controls already configurable from previous PR.