### PR TITLE
rm tmpdir use in safe file creater

### DIFF
--- a/cas_client/src/remote_client.rs
+++ b/cas_client/src/remote_client.rs
@@ -744,7 +744,7 @@ impl ShardDedupProber for RemoteClient {
             return Ok(None);
         }
 
-        let writer = SafeFileCreator::new_unnamed()?;
+        let writer = SafeFileCreator::new_unnamed(&self.shard_cache_directory)?;
         // Compute the actual hash to use as the shard file name
         let mut hashed_writer = HashedWrite::new(writer);
 

--- a/file_utils/Cargo.toml
+++ b/file_utils/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 tracing = "0.1.*"
 libc = "0.2"
 lazy_static = "1.4.0"
-tempfile = "3.2.0"
 rand = "0.8.5"
 
 [target.'cfg(windows)'.dependencies]
@@ -25,3 +24,4 @@ colored = "2.0.0"
 
 [dev-dependencies]
 anyhow = "1"
+tempfile = "3.2.0"

--- a/file_utils/src/lib.rs
+++ b/file_utils/src/lib.rs
@@ -3,4 +3,4 @@ mod privilege_context;
 mod safe_file_creator;
 
 pub use privilege_context::{create_dir_all, create_file, PrivilgedExecutionContext};
-pub use safe_file_creator::{write_all_safe, SafeFileCreator};
+pub use safe_file_creator::SafeFileCreator;

--- a/file_utils/src/safe_file_creator.rs
+++ b/file_utils/src/safe_file_creator.rs
@@ -4,7 +4,6 @@ use std::path::{Path, PathBuf};
 
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
-use tempfile::NamedTempFile;
 
 use crate::create_file;
 use crate::file_metadata::set_file_metadata;
@@ -149,35 +148,6 @@ impl Drop for SafeFileCreator {
             eprintln!("Error: Failed to close writer for {:?}: {}", &self.dest_path, e);
         }
     }
-}
-
-/// Write all bytes
-pub fn write_all_safe(path: &Path, bytes: &[u8]) -> io::Result<()> {
-    if !path.as_os_str().is_empty() {
-        let dir = path.parent().ok_or_else(|| {
-            io::Error::new(io::ErrorKind::InvalidInput, format!("Unable to find parent path from {path:?}"))
-        })?;
-
-        // Make sure dir exists.
-        if !dir.exists() {
-            fs::create_dir_all(dir)?;
-        }
-
-        let mut tempfile = create_temp_file(dir, "")?;
-        tempfile.write_all(bytes)?;
-        tempfile.persist(path).map_err(|e| e.error)?;
-    }
-
-    Ok(())
-}
-
-pub fn create_temp_file(dir: &Path, suffix: &str) -> io::Result<NamedTempFile> {
-    let tempfile = tempfile::Builder::new()
-        .prefix(&format!("{}.", std::process::id()))
-        .suffix(suffix)
-        .tempfile_in(dir)?;
-
-    Ok(tempfile)
 }
 
 #[cfg(test)]

--- a/hf_xet/Cargo.lock
+++ b/hf_xet/Cargo.lock
@@ -848,7 +848,6 @@ dependencies = [
  "lazy_static",
  "libc",
  "rand 0.8.5",
- "tempfile",
  "tracing",
  "whoami",
  "winapi",


### PR DESCRIPTION
Fix XET-477.

Removes all (non-test) uses of temp directories from SafeFileCreator, changes functionality of SafeFileCreator::new_unnamed to take a directory in which to operate. Changes usage of SafeFileCreator::new_unnamed to use the shard cache directory.