### PR TITLE
Running huggingface_hub xet tests on PRs

### DIFF
--- a/.github/workflows/hf-xet-tests.yml
+++ b/.github/workflows/hf-xet-tests.yml
@@ -16,7 +16,9 @@ jobs:
   hub-python-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # checkout out xet-core
+      - uses: actions/checkout@v4 
+      # checkout out huggingface_hub
       - uses: actions/checkout@v4
         with:
           repository: huggingface/huggingface_hub

--- a/.github/workflows/hf-xet-tests.yml
+++ b/.github/workflows/hf-xet-tests.yml
@@ -1,0 +1,42 @@
+name: Test huggingface_hub xet tests
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  hub-python-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: huggingface/huggingface_hub
+          path: huggingface_hub
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Create venv
+        run: python3 -m venv .venv
+      - name: Build wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          command: develop
+          sccache: 'true'
+          working-directory: hf_xet
+      - name: Install huggingface_hub dependencies
+        run: |
+          source .venv/bin/activate
+          python3 -m pip install -e 'huggingface_hub[testing]'
+      - name: Run huggingface_hub xet tests
+        run: |
+          source .venv/bin/activate
+          pytest huggingface_hub/tests/test_xet_*.py


### PR DESCRIPTION
Adding huggingface_hub xet tests to run on every PR and checkin. 

We build the hf_xet wheel, clone huggingface_hub, and run the xet tests in huggingface_hub agains the new build.