### PR TITLE
use safe file writer in local client

### DIFF
--- a/file_utils/src/safe_file_creator.rs
+++ b/file_utils/src/safe_file_creator.rs
@@ -1,5 +1,5 @@
 use std::fs::{self, File, Metadata};
-use std::io::{self, BufWriter, Write};
+use std::io::{self, BufWriter, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
 use rand::distributions::Alphanumeric;
@@ -139,6 +139,12 @@ impl Write for SafeFileCreator {
 
     fn flush(&mut self) -> io::Result<()> {
         self.writer()?.flush()
+    }
+}
+
+impl Seek for SafeFileCreator {
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        self.writer()?.seek(pos)
     }
 }
 


### PR DESCRIPTION
Attempted to identify the error we keep getting on windows tests. Tracked it down to persisting the tempfile in LocalClient. While I'm not 100% confident using SafeFileCreator will fix this, I expect it will make it a bit more consistent.