### PR TITLE
ChunkCache interface returns chunk indices

### DIFF
--- a/cas_client/src/remote_client.rs
+++ b/cas_client/src/remote_client.rs
@@ -897,14 +897,26 @@ mod tests {
                 expect_error: false,
             },
         ];
+
+        fn mock_chunk_cache() -> impl ChunkCache {
+            let mut chunk_cache = MockChunkCache::new();
+            chunk_cache.expect_get().returning(|_, range| {
+                Ok(Some(chunk_cache::CacheRange {
+                    offsets: (range.start..=range.end)
+                        .map(|x| x * TEST_CHUNK_SIZE as u32)
+                        .collect::<Vec<_>>()
+                        .into(),
+                    data: vec![1; (range.end - range.start) as usize * TEST_CHUNK_SIZE].into(),
+                    range: range.clone(),
+                }))
+            });
+            chunk_cache
+        }
+
         for test in test_cases {
             let test1 = test.clone();
             // test writing to file term-by-term
-            let mut chunk_cache = MockChunkCache::new();
-            chunk_cache
-                .expect_get()
-                .returning(|_, range| Ok(Some(vec![1; (range.end - range.start) as usize * TEST_CHUNK_SIZE])));
-
+            let chunk_cache = mock_chunk_cache();
             let http_client = Arc::new(http_client::build_http_client(RetryConfig::default()).unwrap());
 
             let threadpool = Arc::new(ThreadPool::new().unwrap());
@@ -945,10 +957,7 @@ mod tests {
             }
 
             // test writing terms to file in parallel
-            let mut chunk_cache = MockChunkCache::new();
-            chunk_cache
-                .expect_get()
-                .returning(|_, range| Ok(Some(vec![1; (range.end - range.start) as usize * TEST_CHUNK_SIZE])));
+            let chunk_cache = mock_chunk_cache();
 
             let http_client = Arc::new(http_client::build_http_client(RetryConfig::default()).unwrap());
             let authenticated_http_client = http_client.clone();

--- a/cas_client/src/remote_client.rs
+++ b/cas_client/src/remote_client.rs
@@ -170,7 +170,7 @@ impl ReconstructionClient for RemoteClient {
         progress_updater: Option<Arc<dyn ProgressUpdater>>,
     ) -> Result<u64> {
         // get manifest of xorbs to download, api call to CAS
-        let manifest = self.get_reconstruction(hash, byte_range.clone()).await?;
+        let manifest = self.get_reconstruction(hash, byte_range).await?;
         let terms = manifest.terms;
         let fetch_info = Arc::new(manifest.fetch_info);
 
@@ -532,7 +532,7 @@ pub(crate) async fn get_one_term(
             hash: term.hash.into(),
         };
         if let Ok(Some(cached)) = cache.get(&key, &term.range).log_error("cache error") {
-            return Ok(cached);
+            return Ok(cached.data.to_vec());
         }
     }
 

--- a/cas_types/src/lib.rs
+++ b/cas_types/src/lib.rs
@@ -34,6 +34,8 @@ pub struct Range<Idx> {
     pub end: Idx,
 }
 
+impl<Idx: Copy> Copy for Range<Idx> {}
+
 impl<Idx: fmt::Display> fmt::Display for Range<Idx> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Range { start, end } = self;

--- a/chunk_cache/src/disk.rs
+++ b/chunk_cache/src/disk.rs
@@ -19,7 +19,7 @@ use utils::output_bytes;
 use crate::disk::cache_file_header::CacheFileHeader;
 use crate::disk::cache_item::{CacheItem, VerificationCell};
 use crate::error::ChunkCacheError;
-use crate::{CacheConfig, ChunkCache};
+use crate::{CacheConfig, CacheRange, ChunkCache};
 
 mod cache_file_header;
 mod cache_item;
@@ -234,7 +234,7 @@ impl DiskCache {
         Ok(CacheState::new(state, num_items, total_bytes))
     }
 
-    fn get_impl(&self, key: &Key, range: &ChunkRange) -> OptionResult<Vec<u8>, ChunkCacheError> {
+    fn get_impl(&self, key: &Key, range: &ChunkRange) -> OptionResult<CacheRange, ChunkCacheError> {
         if range.start >= range.end {
             return Err(ChunkCacheError::InvalidArguments);
         }
@@ -468,8 +468,8 @@ impl DiskCache {
             }
         }
 
-        let stored_data = get_range_from_cache_file(&header, &mut reader, range, cache_item.range.start)?;
-        if data != stored_data {
+        let stored = get_range_from_cache_file(&header, &mut reader, range, cache_item.range.start)?;
+        if data.as_ref() != stored.data.as_ref() {
             return Err(ChunkCacheError::InvalidArguments);
         }
         Ok(true)
@@ -600,19 +600,26 @@ fn get_range_from_cache_file<R: Read + Seek>(
     file_contents: &mut R,
     range: &ChunkRange,
     start: u32,
-) -> Result<Vec<u8>, ChunkCacheError> {
-    let start_byte = header
-        .chunk_byte_indices
-        .get((range.start - start) as usize)
-        .ok_or(ChunkCacheError::BadRange)?;
-    let end_byte = header
-        .chunk_byte_indices
-        .get((range.end - start) as usize)
-        .ok_or(ChunkCacheError::BadRange)?;
+) -> Result<CacheRange, ChunkCacheError> {
+    let start_idx = (range.start - start) as usize;
+    let end_idx = (range.end - start) as usize;
+    let start_byte = header.chunk_byte_indices.get(start_idx).ok_or(ChunkCacheError::BadRange)?;
+    let end_byte = header.chunk_byte_indices.get(end_idx).ok_or(ChunkCacheError::BadRange)?;
     file_contents.seek(SeekFrom::Start((*start_byte as usize + header.header_len()) as u64))?;
-    let mut buf = vec![0; (end_byte - start_byte) as usize];
-    file_contents.read_exact(&mut buf)?;
-    Ok(buf)
+    let mut data = vec![0; (end_byte - start_byte) as usize];
+    file_contents.read_exact(&mut data)?;
+    let offsets: Vec<u32> = header.chunk_byte_indices[start_idx..=end_idx]
+        .iter()
+        .map(|v| *v - header.chunk_byte_indices[start_idx])
+        .collect();
+
+    debug_assert_eq!(range.end - range.start, offsets.len() as u32 - 1);
+
+    Ok(CacheRange {
+        offsets: offsets.into(),
+        data: data.into(),
+        range: range.clone(),
+    })
 }
 
 // wrapper over std::fs::read_dir
@@ -794,7 +801,7 @@ fn key_dir(key: &Key) -> PathBuf {
 }
 
 impl ChunkCache for DiskCache {
-    fn get(&self, key: &Key, range: &ChunkRange) -> Result<Option<Vec<u8>>, ChunkCacheError> {
+    fn get(&self, key: &Key, range: &ChunkRange) -> Result<Option<CacheRange>, ChunkCacheError> {
         self.get_impl(key, range)
     }
 
@@ -858,7 +865,13 @@ mod tests {
         print_directory_contents(cache_root.as_ref());
 
         // hit
-        assert!(cache.get(&key, &range).unwrap().is_some());
+        let cache_result = cache.get(&key, &range).unwrap();
+        assert!(cache_result.is_some());
+        let cache_range = cache_result.unwrap();
+        assert_eq!(cache_range.data.as_ref(), data.as_slice());
+        assert_eq!(cache_range.range, range);
+        assert_eq!(cache_range.offsets.as_ref(), chunk_byte_indices.as_slice());
+
         let miss_range = ChunkRange { start: 100, end: 101 };
         // miss
         assert!(cache.get(&key, &miss_range).unwrap().is_none());
@@ -876,6 +889,7 @@ mod tests {
         let cache = DiskCache::initialize(&config).unwrap();
 
         let key = random_key(&mut rng);
+        // following parts of test assume overall inserted range includes chunk 0
         let range = ChunkRange { start: 0, end: 4 };
         let (chunk_byte_indices, data) = random_bytes(&mut rng, &range, RANGE_LEN);
         let put_result = cache.put(&key, &range, &chunk_byte_indices, data.as_slice());
@@ -885,18 +899,28 @@ mod tests {
 
         for start in range.start..range.end {
             for end in (start + 1)..=range.end {
-                let get_result = cache.get(&key, &ChunkRange { start, end }).unwrap();
+                let sub_range = ChunkRange { start, end };
+                let get_result = cache.get(&key, &sub_range).unwrap();
                 assert!(get_result.is_some(), "range: [{start} {end})");
-                let data_portion = get_data(&ChunkRange { start, end }, &chunk_byte_indices, &data);
-                assert_eq!(data_portion, get_result.unwrap())
+                let cache_range = get_result.unwrap();
+                assert_eq!(cache_range.range, sub_range);
+                // assert that offsets has 1 more item than the range len difference
+                assert_eq!(cache_range.offsets.len() as u32, sub_range.end - sub_range.start + 1);
+
+                for (expected, actual) in chunk_byte_indices[(start as usize)..=(end as usize)]
+                    .iter()
+                    .map(|v| *v - chunk_byte_indices[start as usize])
+                    .zip(cache_range.offsets.iter())
+                {
+                    assert_eq!(*actual, expected);
+                }
+
+                let start_byte = chunk_byte_indices[sub_range.start as usize] as usize;
+                let end_byte = chunk_byte_indices[sub_range.end as usize] as usize;
+                let data_portion = &data[start_byte..end_byte];
+                assert_eq!(data_portion, cache_range.data.as_ref());
             }
         }
-    }
-
-    fn get_data<'a>(range: &ChunkRange, chunk_byte_indices: &[u32], data: &'a [u8]) -> &'a [u8] {
-        let start = chunk_byte_indices[range.start as usize] as usize;
-        let end = chunk_byte_indices[range.end as usize] as usize;
-        &data[start..end]
     }
 
     #[test]

--- a/chunk_cache/src/disk.rs
+++ b/chunk_cache/src/disk.rs
@@ -334,7 +334,7 @@ impl DiskCache {
         };
 
         let cache_item = CacheItem {
-            range: range.clone(),
+            range: *range,
             len: (header_buf.len() + data.len()) as u64,
             checksum,
         };
@@ -469,7 +469,7 @@ impl DiskCache {
         }
 
         let stored = get_range_from_cache_file(&header, &mut reader, range, cache_item.range.start)?;
-        if data.as_ref() != stored.data.as_ref() {
+        if data != stored.data.as_ref() {
             return Err(ChunkCacheError::InvalidArguments);
         }
         Ok(true)
@@ -618,7 +618,7 @@ fn get_range_from_cache_file<R: Read + Seek>(
     Ok(CacheRange {
         offsets: offsets.into(),
         data: data.into(),
-        range: range.clone(),
+        range: *range,
     })
 }
 

--- a/chunk_cache/src/lib.rs
+++ b/chunk_cache/src/lib.rs
@@ -2,14 +2,15 @@ mod cache_manager;
 mod disk;
 pub mod error;
 
+use std::path::PathBuf;
+use std::sync::Arc;
+
 pub use cache_manager::get_cache;
 use cas_types::{ChunkRange, Key};
 pub use disk::test_utils::*;
 pub use disk::DiskCache;
 use error::ChunkCacheError;
 use mockall::automock;
-use std::path::PathBuf;
-use std::sync::Arc;
 
 pub use crate::disk::DEFAULT_CHUNK_CACHE_CAPACITY;
 

--- a/chunk_cache/src/lib.rs
+++ b/chunk_cache/src/lib.rs
@@ -2,19 +2,32 @@ mod cache_manager;
 mod disk;
 pub mod error;
 
-use std::path::PathBuf;
-
 pub use cache_manager::get_cache;
 use cas_types::{ChunkRange, Key};
 pub use disk::test_utils::*;
 pub use disk::DiskCache;
 use error::ChunkCacheError;
 use mockall::automock;
+use std::path::PathBuf;
+use std::sync::Arc;
 
 pub use crate::disk::DEFAULT_CHUNK_CACHE_CAPACITY;
 
 utils::configurable_constants! {
     ref CHUNK_CACHE_SIZE_BYTES: u64 = DEFAULT_CHUNK_CACHE_CAPACITY;
+}
+
+/// Return dto for cache gets
+/// offsets has 1 more than then number of chunks in the specified range
+/// suppose the range is for chunks [2, 5) then offsets may look like:
+/// [0, 2000, 4000, 6000] where chunk 2 is made of bytes [0, 2000)
+/// chunk 3 [2000, 4000) and chunk 4 is [4000, 6000).
+/// It is guaranteed that the first number in offsets is 0 and the last number is data.len()
+#[derive(Debug, Clone)]
+pub struct CacheRange {
+    pub offsets: Arc<[u32]>,
+    pub data: Arc<[u8]>,
+    pub range: ChunkRange,
 }
 
 /// ChunkCache is a trait for storing and fetching Xorb ranges.
@@ -39,7 +52,7 @@ pub trait ChunkCache: Sync + Send {
     /// key is required to be a valid CAS Key
     /// range is intended to be an index range within the xorb with constraint
     ///     0 <= range.start < range.end <= num_chunks_in_xorb(key)
-    fn get(&self, key: &Key, range: &ChunkRange) -> Result<Option<Vec<u8>>, ChunkCacheError>;
+    fn get(&self, key: &Key, range: &ChunkRange) -> Result<Option<CacheRange>, ChunkCacheError>;
 
     /// put should return Ok(()) if the put succeeded with no error, check the error
     /// variant for issues with validating the input, cache state, IO, etc.

--- a/chunk_cache_bench/Cargo.lock
+++ b/chunk_cache_bench/Cargo.lock
@@ -148,7 +148,7 @@ checksum = "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -486,7 +486,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -715,6 +715,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "daemonize"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,7 +761,7 @@ checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -795,7 +805,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -884,7 +894,6 @@ dependencies = [
  "lazy_static",
  "libc",
  "rand 0.8.5",
- "tempfile",
  "tracing",
  "whoami",
  "winapi",
@@ -1038,7 +1047,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1531,7 +1540,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1831,7 +1840,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2027,7 +2036,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2129,6 +2138,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45ca20c77d80be666aef2b45486da86238fabe33e38306bd3118fe4af33fa880"
+dependencies = [
+ "paste-impl",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "paste-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6"
+dependencies = [
+ "proc-macro-hack",
+]
+
+[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2198,7 +2226,7 @@ checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2368,6 +2396,12 @@ dependencies = [
  "predicates-core",
  "termtree",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -3143,7 +3177,7 @@ checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3166,7 +3200,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3351,6 +3385,17 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
@@ -3386,7 +3431,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3501,7 +3546,7 @@ checksum = "a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3512,7 +3557,7 @@ checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3616,7 +3661,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3790,7 +3835,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3898,9 +3943,12 @@ version = "0.14.5"
 dependencies = [
  "async-trait",
  "bytes",
+ "ctor",
  "futures",
+ "lazy_static",
  "merklehash",
  "parking_lot 0.11.2",
+ "paste",
  "pin-project",
  "thiserror 2.0.11",
  "tokio",
@@ -4012,7 +4060,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
  "wasm-bindgen-shared",
 ]
 
@@ -4046,7 +4094,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4409,7 +4457,7 @@ checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
  "synstructure",
 ]
 
@@ -4440,7 +4488,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4451,7 +4499,7 @@ checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4471,7 +4519,7 @@ checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
  "synstructure",
 ]
 
@@ -4500,7 +4548,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.87",
 ]
 
 [[package]]


### PR DESCRIPTION
Needed step for: https://linear.app/xet/issue/XET-493/download-each-fetch-info-once-to-fulfill-all-repeat-uses

When using the cache to fulfill multiple ranges at once, we will need to be able to separate out chunks from the cache hit range. This is necessary to avoid multiple cache get requests.