### PR TITLE
Fix variable name to agree with the logic

### DIFF
--- a/cas_object/src/cas_chunk_format/deserialize_async.rs
+++ b/cas_object/src/cas_chunk_format/deserialize_async.rs
@@ -61,7 +61,7 @@ pub async fn deserialize_chunks_to_writer_from_async_read<R: AsyncRead + Unpin, 
     // chunk indices are expected to record the byte indices of uncompressed chunks
     // as they are read from the reader, so start with [0, len(uncompressed chunk 0..n), total length]
     let mut chunk_byte_indices = Vec::<u32>::new();
-    chunk_byte_indices.push(num_compressed_written as u32);
+    chunk_byte_indices.push(num_uncompressed_written as u32);
 
     loop {
         match deserialize_chunk_to_writer(reader, writer).await {

--- a/cas_object/src/cas_chunk_format/deserialize_async.rs
+++ b/cas_object/src/cas_chunk_format/deserialize_async.rs
@@ -61,7 +61,7 @@ pub async fn deserialize_chunks_to_writer_from_async_read<R: AsyncRead + Unpin, 
     // chunk indices are expected to record the byte indices of uncompressed chunks
     // as they are read from the reader, so start with [0, len(uncompressed chunk 0..n), total length]
     let mut chunk_byte_indices = Vec::<u32>::new();
-    chunk_byte_indices.push(num_uncompressed_written as u32);
+    chunk_byte_indices.push(num_uncompressed_written);
 
     loop {
         match deserialize_chunk_to_writer(reader, writer).await {


### PR DESCRIPTION
`chunk_byte_indices` tracks uncompressed boundaries. There was no impact to the correctness, but the variable name didn't agree with the logic.