### PR TITLE
make utils wasm-compat

### DIFF
--- a/chunk_cache/src/disk.rs
+++ b/chunk_cache/src/disk.rs
@@ -68,7 +68,7 @@ impl DiskCache {
         println!(
             "total items: {}, total bytes {} for the whole cache",
             total_num_items,
-            output_bytes(total_total_bytes as usize)
+            output_bytes(total_total_bytes)
         );
 
         for (key, items) in state.inner.iter() {
@@ -76,14 +76,14 @@ impl DiskCache {
             let num_items = items.len();
             let total_bytes: usize = items.iter().map(|item| item.len).fold(0usize, |acc, len| acc + len as usize);
             println!("key: {key}");
-            println!("\ttotal items: {}, total bytes {} for key {key}", num_items, output_bytes(total_bytes));
+            println!("\ttotal items: {}, total bytes {} for key {key}", num_items, output_bytes(total_bytes as u64));
             println!();
             for item in items.iter() {
                 println!(
                     "\titem: chunk range [{}-{}) ; len({}); checksum({})",
                     item.range.start,
                     item.range.end,
-                    output_bytes(item.len as usize),
+                    output_bytes(item.len),
                     item.checksum,
                 );
             }

--- a/progress_reporting/src/data_progress.rs
+++ b/progress_reporting/src/data_progress.rs
@@ -190,8 +190,8 @@ impl DataProgressReporter {
                         format!(
                             "{}: {} | {}/s{}",
                             self.message,
-                            &output_bytes(b),
-                            &output_bytes(byte_rate),
+                            &output_bytes(b as u64),
+                            &output_bytes(byte_rate as u64),
                             if is_final { ", done." } else { "." }
                         )
                     },
@@ -208,8 +208,8 @@ impl DataProgressReporter {
                             self.message,
                             c,
                             if is_final { format!("{c}") } else { "??".to_owned() },
-                            &output_bytes(b),
-                            &output_bytes(byte_rate),
+                            &output_bytes(b as u64),
+                            &output_bytes(byte_rate as u64),
                             if is_final { ", done." } else { "." }
                         )
                     },
@@ -222,9 +222,9 @@ impl DataProgressReporter {
                 format!(
                     "{}: ({} / {}) | {}/s{}",
                     self.message,
-                    &output_bytes(if is_final { total_bytes } else { current_bytes }),
-                    &output_bytes(total_bytes),
-                    &output_bytes(byte_rate),
+                    &output_bytes(if is_final { total_bytes } else { current_bytes } as u64),
+                    &output_bytes(total_bytes as u64),
+                    &output_bytes(byte_rate as u64),
                     if is_final { ", done." } else { "." }
                 )
             },
@@ -237,8 +237,8 @@ impl DataProgressReporter {
                         self.message,
                         if is_final { total_count } else { current_count },
                         total_count,
-                        &output_bytes(current_bytes),
-                        &output_bytes(byte_rate),
+                        &output_bytes(current_bytes as u64),
+                        &output_bytes(byte_rate as u64),
                         if is_final { ", done." } else { "." }
                     )
                 } else {
@@ -262,8 +262,8 @@ impl DataProgressReporter {
                     self.message,
                     if is_final { total_count } else { current_count },
                     total_count,
-                    &output_bytes(if is_final { total_bytes } else { current_bytes }),
-                    &output_bytes(byte_rate),
+                    &output_bytes(if is_final { total_bytes } else { current_bytes } as u64),
+                    &output_bytes(byte_rate as u64),
                     if is_final { ", done." } else { "." }
                 )
             },

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -16,19 +16,18 @@ lazy_static = "1.4.0"
 paste = "0.1"
 ctor = "0.1"
 
-# singleflight & threadpool
-tokio = { version = "1.41", features = ["full"] }
-parking_lot = "0.11"
-pin-project = "1.0.12"
-
 # consistenthash
 tracing = "0.1.31"
 bytes = "1.8.0"
 async-trait = "0.1.87"
 
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+# singleflight & threadpool
+tokio = { version = "1.41", features = ["full"] }
+parking_lot = "0.11"
+pin-project = "1.0.12"
 
-[dev-dependencies]
-tokio = { version = "1.36", features = ["full"] }
+[target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 tempfile = "3.14.0"
 
 [features]

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -3,13 +3,17 @@
 pub mod auth;
 pub mod errors;
 pub mod serialization_utils;
+#[cfg(not(target_family = "wasm"))]
 pub mod singleflight;
 
+#[cfg(not(target_family = "wasm"))]
 mod async_read;
+#[cfg(not(target_family = "wasm"))]
 pub mod limited_joinset;
 mod output_bytes;
 pub mod progress;
 
+#[cfg(not(target_family = "wasm"))]
 pub use async_read::CopyReader;
 pub use output_bytes::output_bytes;
 

--- a/utils/src/output_bytes.rs
+++ b/utils/src/output_bytes.rs
@@ -4,6 +4,7 @@
 /// * `v` - the size in bytes
 pub fn output_bytes(v: usize) -> String {
     let map = vec![
+        #[cfg(not(target_arch = "wasm32"))]
         (1_099_511_627_776, "TiB"),
         (1_073_741_824, "GiB"),
         (1_048_576, "MiB"),
@@ -44,9 +45,12 @@ mod tests {
         assert_eq!("999.99 MiB", output_bytes(1_048_565_514));
         assert_eq!("1 GiB", output_bytes(1_073_741_824));
         assert_eq!("1.00 GiB", output_bytes(1_073_741_825));
-        assert_eq!("999.99 GiB", output_bytes(1_073_731_086_581));
-        assert_eq!("1 TiB", output_bytes(1_099_511_627_776));
-        assert_eq!("1.00 TiB", output_bytes(1_099_511_627_777));
-        assert_eq!("1234.57 TiB", output_bytes(1_357_424_070_303_416));
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            assert_eq!("999.99 GiB", output_bytes(1_073_731_086_581));
+            assert_eq!("1 TiB", output_bytes(1_099_511_627_776));
+            assert_eq!("1.00 TiB", output_bytes(1_099_511_627_777));
+            assert_eq!("1234.57 TiB", output_bytes(1_357_424_070_303_416));
+        }
     }
 }

--- a/utils/src/output_bytes.rs
+++ b/utils/src/output_bytes.rs
@@ -2,9 +2,8 @@
 ///
 /// # Arguments
 /// * `v` - the size in bytes
-pub fn output_bytes(v: usize) -> String {
+pub fn output_bytes(v: u64) -> String {
     let map = vec![
-        #[cfg(not(target_arch = "wasm32"))]
         (1_099_511_627_776, "TiB"),
         (1_073_741_824, "GiB"),
         (1_048_576, "MiB"),
@@ -45,12 +44,9 @@ mod tests {
         assert_eq!("999.99 MiB", output_bytes(1_048_565_514));
         assert_eq!("1 GiB", output_bytes(1_073_741_824));
         assert_eq!("1.00 GiB", output_bytes(1_073_741_825));
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            assert_eq!("999.99 GiB", output_bytes(1_073_731_086_581));
-            assert_eq!("1 TiB", output_bytes(1_099_511_627_776));
-            assert_eq!("1.00 TiB", output_bytes(1_099_511_627_777));
-            assert_eq!("1234.57 TiB", output_bytes(1_357_424_070_303_416));
-        }
+        assert_eq!("999.99 GiB", output_bytes(1_073_731_086_581));
+        assert_eq!("1 TiB", output_bytes(1_099_511_627_776));
+        assert_eq!("1.00 TiB", output_bytes(1_099_511_627_777));
+        assert_eq!("1234.57 TiB", output_bytes(1_357_424_070_303_416));
     }
 }


### PR DESCRIPTION
Progress for wasm, this is required before any other crate that uses utils can even attempt to export anything that is wasm compat.

This doesn't make all of utils wasm compat, it just excludes things we don't care about for now e.g. singleflight.