### PR TITLE
configurable boolean constants follows hf_hub truthy values

### DIFF
--- a/cas_client/src/remote_client.rs
+++ b/cas_client/src/remote_client.rs
@@ -46,13 +46,15 @@ utils::configurable_constants! {
         standard: 16,
         high_performance: 100,
     };
+}
 
+utils::configurable_bool_constants! {
 // Env (HF_XET_RECONSTRUCT_WRITE_SEQUENTIALLY) to switch to writing terms sequentially to disk.
 // Benchmarks have shown that on SSD machines, writing in parallel seems to far outperform
 // sequential term writes.
 // However, this is not likely the case for writing to HDD and may in fact be worse,
 // so for those machines, setting this env may help download perf.
-    ref RECONSTRUCT_WRITE_SEQUENTIALLY: bool = false;
+    ref RECONSTRUCT_WRITE_SEQUENTIALLY = false;
 }
 
 pub struct RemoteClient {


### PR DESCRIPTION
Adds a macro to generate bool configurable constants that accept "truthy" values as true following the hf_hub docs.

Same logic applies when determining the HF_XET_HP or HF_XET_HIGH_PERFORMANCE env vars and uses the macro for HF_XET_RECONSTRUCT_WRITE_SEQUENTIALLY