### PR TITLE
Reduce Usage of Compression Format Detection

### DIFF
--- a/cas_client/src/interface.rs
+++ b/cas_client/src/interface.rs
@@ -36,7 +36,7 @@ pub trait UploadClient {
         hash: &MerkleHash,
         data: Vec<u8>,
         chunk_and_boundaries: Vec<(MerkleHash, u32)>,
-        compression: Option<CompressionScheme>
+        compression: Option<CompressionScheme>,
     ) -> Result<usize>;
 
     /// Check if a XORB already exists.

--- a/cas_client/src/interface.rs
+++ b/cas_client/src/interface.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use cas_object::CompressionScheme;
 use cas_types::{FileRange, QueryReconstructionResponse};
 use mdb_shard::shard_file_reconstructor::FileReconstructor;
 use merklehash::MerkleHash;
@@ -35,6 +36,7 @@ pub trait UploadClient {
         hash: &MerkleHash,
         data: Vec<u8>,
         chunk_and_boundaries: Vec<(MerkleHash, u32)>,
+        compression: Option<CompressionScheme>
     ) -> Result<usize>;
 
     /// Check if a XORB already exists.

--- a/cas_client/src/local_client.rs
+++ b/cas_client/src/local_client.rs
@@ -230,7 +230,7 @@ impl UploadClient for LocalClient {
         hash: &MerkleHash,
         data: Vec<u8>,
         chunk_and_boundaries: Vec<(MerkleHash, u32)>,
-        compression: Option<CompressionScheme>
+        compression: Option<CompressionScheme>,
     ) -> Result<usize> {
         // no empty writes
         if chunk_and_boundaries.is_empty() || data.is_empty() {
@@ -253,13 +253,7 @@ impl UploadClient for LocalClient {
         info!("Writing XORB {hash:?} to local path {file_path:?}");
 
         let mut file = SafeFileCreator::new(&file_path)?;
-        let (_, bytes_written) = CasObject::serialize(
-            &mut file,
-            hash,
-            &data,
-            &chunk_and_boundaries,
-            compression
-        )?;
+        let (_, bytes_written) = CasObject::serialize(&mut file, hash, &data, &chunk_and_boundaries, compression)?;
         file.close()?;
 
         // attempt to set to readonly on unix.
@@ -452,7 +446,10 @@ mod tests {
 
         // Act & Assert
         let client = LocalClient::temporary().unwrap();
-        assert!(client.put("key", &hash, data, vec![(hash, chunk_boundaries)], None).await.is_ok());
+        assert!(client
+            .put("key", &hash, data, vec![(hash, chunk_boundaries)], None)
+            .await
+            .is_ok());
 
         let returned_data = client.get(&hash).unwrap();
         assert_eq!(data_again, returned_data);
@@ -487,7 +484,7 @@ mod tests {
         let ranges: Vec<(u32, u32)> = vec![(0, 1), (2, 3)];
         let returned_ranges = client.get_object_range(&c.info.cashash, ranges).unwrap();
 
-        let expected = vec![
+        let expected = [
             data[0..chunk_and_boundaries[0].1 as usize].to_vec(),
             data[chunk_and_boundaries[1].1 as usize..chunk_and_boundaries[2].1 as usize].to_vec(),
         ];
@@ -556,7 +553,13 @@ mod tests {
         assert_eq!(
             CasClientError::InvalidArguments,
             client
-                .put("hellp2", &hello_hash, "hellp wod".as_bytes().to_vec(), vec![(hello_hash, hello.len() as u32)], None)
+                .put(
+                    "hellp2",
+                    &hello_hash,
+                    "hellp wod".as_bytes().to_vec(),
+                    vec![(hello_hash, hello.len() as u32)],
+                    None
+                )
                 .await
                 .unwrap_err()
         );

--- a/cas_client/src/remote_client.rs
+++ b/cas_client/src/remote_client.rs
@@ -123,7 +123,7 @@ impl UploadClient for RemoteClient {
         hash: &MerkleHash,
         data: Vec<u8>,
         chunk_and_boundaries: Vec<(MerkleHash, u32)>,
-        compression: Option<CompressionScheme>
+        compression: Option<CompressionScheme>,
     ) -> Result<usize> {
         let key = Key {
             prefix: prefix.to_string(),
@@ -753,17 +753,14 @@ mod tests {
         let (c, _, data, chunk_boundaries) = build_cas_object(3, ChunkSize::Random(512, 10248), CompressionScheme::LZ4);
 
         let threadpool = Arc::new(ThreadPool::new().unwrap());
-        let client = RemoteClient::new(
-            threadpool.clone(),
-            CAS_ENDPOINT,
-            &None,
-            &None,
-            "".into(),
-            false,
-        );
+        let client = RemoteClient::new(threadpool.clone(), CAS_ENDPOINT, &None, &None, "".into(), false);
         // Act
         let result = threadpool
-            .external_run_async_task(async move { client.put(prefix, &c.info.cashash, data, chunk_boundaries, Some(CompressionScheme::LZ4)).await })
+            .external_run_async_task(async move {
+                client
+                    .put(prefix, &c.info.cashash, data, chunk_boundaries, Some(CompressionScheme::LZ4))
+                    .await
+            })
             .unwrap();
 
         // Assert
@@ -1091,7 +1088,7 @@ mod tests {
             file_range: FileRange::new(SKIP_BYTES, FILE_SIZE - SKIP_BYTES),
             expected_data: [
                 &raw_data[SKIP_BYTES as usize..(5 * CHUNK_SIZE) as usize],
-                &raw_data[(6 * CHUNK_SIZE) as usize as usize..(NUM_CHUNKS * CHUNK_SIZE) as usize - SKIP_BYTES as usize],
+                &raw_data[(6 * CHUNK_SIZE) as usize..(NUM_CHUNKS * CHUNK_SIZE) as usize - SKIP_BYTES as usize],
             ]
             .concat(),
             expect_error: false,

--- a/cas_object/src/cas_chunk_format.rs
+++ b/cas_object/src/cas_chunk_format.rs
@@ -213,7 +213,6 @@ mod tests {
     use std::io::Cursor;
 
     use rand::Rng;
-    use CompressionScheme;
 
     use super::*;
 

--- a/cas_object/src/cas_object_format.rs
+++ b/cas_object/src/cas_object_format.rs
@@ -1856,7 +1856,7 @@ mod tests {
             + size_of::<CasObjectIdent>()
             + size_of::<u8>();
 
-        let chunks = xorb_bytes[start_pos..].chunks(10).map(|c| Ok(c)).collect::<Vec<_>>();
+        let chunks = xorb_bytes[start_pos..].chunks(10).map(Ok).collect::<Vec<_>>();
         let mut xorb_footer_async_reader = futures::stream::iter(chunks).into_async_read();
         let cas_object_result =
             CasObject::deserialize_async(&mut xorb_footer_async_reader, CAS_OBJECT_FORMAT_VERSION).await;

--- a/cas_object/src/compression_scheme.rs
+++ b/cas_object/src/compression_scheme.rs
@@ -289,47 +289,39 @@ mod tests {
             let random_u8s: Vec<_> = (0..n).map(|_| rng.gen_range(0..255)).collect();
             let random_f32s_ng1_1: Vec<_> = (0..n / size_of::<f32>())
                 .map(|_| rng.gen_range(-1.0f32..=1.0))
-                .map(|f| f.to_le_bytes())
-                .flatten()
+                .flat_map(|f| f.to_le_bytes())
                 .collect();
             let random_f32s_0_2: Vec<_> = (0..n / size_of::<f32>())
                 .map(|_| rng.gen_range(0f32..=2.0))
-                .map(|f| f.to_le_bytes())
-                .flatten()
+                .flat_map(|f| f.to_le_bytes())
                 .collect();
             let random_f64s_ng1_1: Vec<_> = (0..n / size_of::<f64>())
                 .map(|_| rng.gen_range(-1.0f64..=1.0))
-                .map(|f| f.to_le_bytes())
-                .flatten()
+                .flat_map(|f| f.to_le_bytes())
                 .collect();
             let random_f64s_0_2: Vec<_> = (0..n / size_of::<f64>())
                 .map(|_| rng.gen_range(0f64..=2.0))
-                .map(|f| f.to_le_bytes())
-                .flatten()
+                .flat_map(|f| f.to_le_bytes())
                 .collect();
 
             // f16, a.k.a binary16 format: sign (1 bit), exponent (5 bit), mantissa (10 bit)
             let random_f16s_ng1_1: Vec<_> = (0..n / size_of::<f16>())
                 .map(|_| f16::from_f32(rng.gen_range(-1.0f32..=1.0)))
-                .map(|f| f.to_le_bytes())
-                .flatten()
+                .flat_map(|f| f.to_le_bytes())
                 .collect();
             let random_f16s_0_2: Vec<_> = (0..n / size_of::<f16>())
                 .map(|_| f16::from_f32(rng.gen_range(0f32..=2.0)))
-                .map(|f| f.to_le_bytes())
-                .flatten()
+                .flat_map(|f| f.to_le_bytes())
                 .collect();
 
             // bf16 format: sign (1 bit), exponent (8 bit), mantissa (7 bit)
             let random_bf16s_ng1_1: Vec<_> = (0..n / size_of::<bf16>())
                 .map(|_| bf16::from_f32(rng.gen_range(-1.0f32..=1.0)))
-                .map(|f| f.to_le_bytes())
-                .flatten()
+                .flat_map(|f| f.to_le_bytes())
                 .collect();
             let random_bf16s_0_2: Vec<_> = (0..n / size_of::<bf16>())
                 .map(|_| bf16::from_f32(rng.gen_range(0f32..=2.0)))
-                .map(|f| f.to_le_bytes())
-                .flatten()
+                .flat_map(|f| f.to_le_bytes())
                 .collect();
 
             let dataset = [

--- a/cas_object/src/compression_scheme.rs
+++ b/cas_object/src/compression_scheme.rs
@@ -23,6 +23,7 @@ pub enum CompressionScheme {
     LZ4 = 1,
     ByteGrouping4LZ4 = 2, // 4 byte groups
 }
+pub const NUM_COMPRESSION_SCHEMES: usize = 3;
 
 impl Display for CompressionScheme {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/data/src/remote_client_interface.rs
+++ b/data/src/remote_client_interface.rs
@@ -18,7 +18,6 @@ pub(crate) fn create_remote_client(
         Endpoint::Server(ref endpoint) => Ok(Arc::new(RemoteClient::new(
             threadpool,
             endpoint,
-            cas_storage_config.compression,
             &cas_storage_config.auth,
             &Some(cas_storage_config.cache_config.clone()),
             config.shard_config.cache_directory.clone(),


### PR DESCRIPTION
We use a KL-divergence based predictor to select between the LZ4 and BG-LZ4 schemes. This is done for every chunk and seems to consume about 20% CPU time. Instead, we only run this for the first Xorb, lock the scheme and use it from then on.

 - Removes compression scheme from RemoteClient construction and instead as an argument to put (xorb)
 - FileUploadSession is used to track compression scheme
 - Other changes demanded by clippy.