### PR TITLE
Suppress errors on cache.put

### DIFF
--- a/cas_client/src/download_utils.rs
+++ b/cas_client/src/download_utils.rs
@@ -328,7 +328,9 @@ pub(crate) async fn get_one_term(
             prefix: PREFIX_DEFAULT.to_string(),
             hash: term.hash.into(),
         };
-        cache.put(&key, &fetch_term.range, &chunk_byte_indices, &data)?;
+        if let Err(e) = cache.put(&key, &fetch_term.range, &chunk_byte_indices, &data) {
+            info!("failed to put into cache: {}", e);
+        }
     }
 
     // if the requested range is smaller than the fetched range, trim it down to the right data

--- a/cas_client/src/download_utils.rs
+++ b/cas_client/src/download_utils.rs
@@ -329,7 +329,7 @@ pub(crate) async fn get_one_term(
             hash: term.hash.into(),
         };
         if let Err(e) = cache.put(&key, &fetch_term.range, &chunk_byte_indices, &data) {
-            info!("failed to put into cache: {}", e);
+            info!("Writing to local cache failed, continuing. Error: {}", e);
         }
     }
 


### PR DESCRIPTION
The cache.put call seems to fail due to various disk errors under some circumstances. For instance, it appears to be responsible for [this error](https://x.com/realmrfakename/status/1915575840261513661?s=46).

If the cache.put fails the rest of the get_one_term call should still succeed.

Logging the message as `info` rather than `error` or `warn` because it can happen somewhat frequently (I was able to repro it with a whole spew of errors from a single file download, repeatedly); we don't want to litter the user's console in that case.