### PR TITLE
Release commit from event rather than latest on main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,4 +235,4 @@ jobs:
         env: 
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create ${{ github.event.inputs.tag}} wheels-*/* --generate-notes --prerelease
+          gh release create ${{ github.event.inputs.tag}} wheels-*/* --generate-notes --prerelease --target ${{github.sha}}


### PR DESCRIPTION
The release should tag the sha at the time of the workflow dispatch time instead of when the release gets executed