### PR TITLE
wasm poc cas client compiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,7 +484,6 @@ version = "0.14.5"
 dependencies = [
  "anyhow",
  "async-trait",
- "bytes",
  "cas_object",
  "cas_types",
  "chunk_cache",
@@ -496,12 +495,10 @@ dependencies = [
  "heed",
  "http 1.2.0",
  "httpmock",
- "itertools 0.10.5",
  "mdb_shard",
  "merkledb",
  "merklehash",
- "rand 0.8.5",
- "reqwest 0.12.12",
+ "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
  "tempfile",
@@ -576,6 +573,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -945,7 +948,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "regex",
- "reqwest 0.11.27",
+ "reqwest",
  "reqwest-middleware",
  "serde_json",
  "serial_test",
@@ -1377,25 +1380,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.7.1",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
@@ -1613,7 +1597,6 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -1636,7 +1619,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.7",
+ "h2",
  "http 1.2.0",
  "http-body 1.0.1",
  "httparse",
@@ -1662,19 +1645,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper 0.14.32",
- "native-tls",
- "tokio",
- "tokio-native-tls",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2166,7 +2137,7 @@ dependencies = [
  "rand 0.9.0",
  "rand_chacha 0.9.0",
  "rayon",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "serde",
  "tempfile",
  "thiserror 2.0.11",
@@ -2765,6 +2736,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
+name = "quinn"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3bd15a6f2967aef83887dcb9fec0014580467e33720d073560cf015a5683012"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.11",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcbafbbdbb0f638fe3f35f3c56739f77a8a1d070cb25603226c83339b391472b"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.1",
+ "rand 0.9.0",
+ "ring",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.11",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "541d0f57c6ec747a90738a52741d3221f7960e8ac2f0ff4b1a63680e033b4ab5"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2974,63 +2999,22 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-tls 0.5.0",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pemfile 1.0.4",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration 0.5.1",
- "tokio",
- "tokio-native-tls",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots",
- "winreg",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.12.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.7",
+ "h2",
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
  "hyper-rustls",
- "hyper-tls 0.6.0",
+ "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -3040,14 +3024,18 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile 2.2.0",
+ "quinn",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
- "system-configuration 0.6.1",
+ "sync_wrapper",
+ "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-service",
@@ -3056,19 +3044,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots",
  "windows-registry",
 ]
 
 [[package]]
 name = "reqwest-middleware"
-version = "0.3.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562ceb5a604d3f7c885a792d42c199fd8af239d0a51b2fa6a78aafa092452b04"
+checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
 dependencies = [
  "anyhow",
  "async-trait",
  "http 1.2.0",
- "reqwest 0.12.12",
+ "reqwest",
  "serde",
  "thiserror 1.0.69",
  "tower-service",
@@ -3076,9 +3065,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest-retry"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a83df1aaec00176d0fabb65dea13f832d2a446ca99107afc17c5d2d4981221d0"
+checksum = "29c73e4195a6bfbcb174b790d9b3407ab90646976c55de58a6515da25d851178"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3087,9 +3076,10 @@ dependencies = [
  "http 1.2.0",
  "hyper 1.6.0",
  "parking_lot 0.11.2",
- "reqwest 0.12.12",
+ "reqwest",
  "reqwest-middleware",
  "retry-policies",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "wasm-timer",
@@ -3132,6 +3122,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3164,19 +3160,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fb9263ab4eb695e42321db096e3b8fbd715a59b154d5c88d82db2175b681ba7"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -3193,6 +3181,9 @@ name = "rustls-pki-types"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+dependencies = [
+ "web-time",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -3572,12 +3563,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -3607,34 +3592,13 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys 0.5.0",
-]
-
-[[package]]
-name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.8.0",
  "core-foundation",
- "system-configuration-sys 0.6.0",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -3822,6 +3786,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3901,7 +3880,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -4281,10 +4260,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.25.4"
+name = "web-time"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29aad86cec885cafd03e8305fd727c418e970a521322c91688414d5b8efba16b"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "whoami"
@@ -4338,33 +4330,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-registry"
-version = "0.2.0"
+name = "windows-link"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
  "windows-result",
  "windows-strings",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
- "windows-result",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -4418,11 +4415,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -4438,6 +4451,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4448,6 +4467,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4462,10 +4487,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4480,6 +4517,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4490,6 +4533,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4504,6 +4553,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4516,14 +4571,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winreg"
-version = "0.50.0"
+name = "windows_x86_64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if 1.0.0",
- "windows-sys 0.48.0",
-]
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/cas_client/Cargo.toml
+++ b/cas_client/Cargo.toml
@@ -9,7 +9,7 @@ strict = []
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cas_types = { version = "0.1.0", path = "../cas_types" }
+cas_types = { path = "../cas_types" }
 cas_object = { path = "../cas_object" }
 chunk_cache = { path = "../chunk_cache" }
 error_printer = { path = "../error_printer" }
@@ -19,7 +19,7 @@ merkledb = { path = "../merkledb" }
 mdb_shard = { path = "../mdb_shard" }
 merklehash = { path = "../merklehash" }
 xet_threadpool = { path = "../xet_threadpool" }
-deduplication = {path = "../deduplication" }
+deduplication = { path = "../deduplication" }
 thiserror = "2.0"
 tokio = { version = "1.44", features = ["sync"] }
 async-trait = "0.1.9"
@@ -27,17 +27,16 @@ anyhow = "1"
 http = "1.1.0"
 tempfile = "3.13.0"
 tracing = "0.1.31"
-bytes = "1"
-itertools = "0.10"
-reqwest = { version = "0.12.7", features = ["json", "stream"] }
-reqwest-middleware = "0.3.3"
+reqwest = { version = "0.12.15", features = ["json", "stream"] }
+reqwest-middleware = "0.4.1"
 url = "2.5.2"
-reqwest-retry = "0.6.1"
-heed = "0.11"
+reqwest-retry = "0.7.0"
 futures = "0.3.31"
 derivative = "2.2.0"
 
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+heed = "0.11"
+
 [dev-dependencies]
-rand = "0.8.5"
 httpmock = "0.7.0"
 tracing-test = { version = "0.2.5", features = ["no-env-filter"] }

--- a/cas_client/src/download_utils.rs
+++ b/cas_client/src/download_utils.rs
@@ -18,8 +18,8 @@ use url::Url;
 use utils::singleflight::Group;
 
 use crate::error::{CasClientError, Result};
+use crate::output_provider::OutputProvider;
 use crate::remote_client::{get_reconstruction_with_endpoint_and_client, PREFIX_DEFAULT};
-use crate::OutputProvider;
 
 #[derive(Clone, Debug)]
 pub(crate) enum DownloadRangeResult {

--- a/cas_client/src/error.rs
+++ b/cas_client/src/error.rs
@@ -81,6 +81,7 @@ impl PartialEq for CasClientError {
     }
 }
 
+#[cfg(not(target_family = "wasm"))]
 impl From<utils::errors::SingleflightError<CasClientError>> for CasClientError {
     fn from(value: utils::singleflight::SingleflightError<CasClientError>) -> Self {
         match value {

--- a/cas_client/src/http_client.rs
+++ b/cas_client/src/http_client.rs
@@ -138,7 +138,8 @@ impl OptionalMiddleware for ClientBuilder {
 /// Adds logging middleware that will trace::warn! on retryable errors.
 pub struct LoggingMiddleware;
 
-#[async_trait::async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl Middleware for LoggingMiddleware {
     async fn handle(
         &self,
@@ -200,7 +201,8 @@ impl From<&AuthConfig> for AuthMiddleware {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl Middleware for AuthMiddleware {
     async fn handle(
         &self,

--- a/cas_client/src/interface.rs
+++ b/cas_client/src/interface.rs
@@ -1,3 +1,6 @@
+use crate::CasClientError;
+use mdb_shard::shard_file_reconstructor::FileReconstructor;
+
 /// A Client to the Shard service. The shard service
 /// provides for
 /// 1. upload shard to the shard service
@@ -5,11 +8,7 @@
 /// 3. querying of chunk->shard information
 #[cfg(not(target_family = "wasm"))]
 pub trait ShardClientInterface:
-    RegistrationClient
-    + mdb_shard::shard_file_reconstructor::FileReconstructor<crate::CasClientError>
-    + ShardDedupProbe
-    + Send
-    + Sync
+    RegistrationClient + FileReconstructor<CasClientError> + ShardDedupProbe + Send + Sync
 {
 }
 
@@ -24,8 +23,6 @@ pub trait Client: UploadClient + ShardClientInterface {}
 #[cfg(not(target_family = "wasm"))]
 mod download {
     use std::collections::HashMap;
-    use std::io::{Seek, SeekFrom, Write};
-    use std::path::PathBuf;
     use std::sync::Arc;
 
     use cas_types::{FileRange, QueryReconstructionResponse};
@@ -33,6 +30,7 @@ mod download {
     use utils::progress::ProgressUpdater;
 
     use crate::error::Result;
+    use crate::output_provider::OutputProvider;
 
     /// A Client to the CAS (Content Addressed Storage) service to allow reconstructing a
     /// pointer file based on FileID (MerkleHash).
@@ -63,47 +61,6 @@ mod download {
                 n_bytes += self.get_file(&h, None, w, None).await?;
             }
             Ok(n_bytes)
-        }
-    }
-
-    /// Enum of different output formats to write reconstructed files.
-    #[derive(Debug, Clone)]
-    pub enum OutputProvider {
-        File(FileProvider),
-        #[cfg(test)]
-        Buffer(crate::interface::buffer::BufferProvider),
-    }
-
-    impl OutputProvider {
-        /// Create a new writer to start writing at the indicated start location.
-        pub(crate) fn get_writer_at(&self, start: u64) -> Result<Box<dyn Write + Send>> {
-            match self {
-                OutputProvider::File(fp) => fp.get_writer_at(start),
-                #[cfg(test)]
-                OutputProvider::Buffer(bp) => bp.get_writer_at(start),
-            }
-        }
-    }
-
-    /// Provides new Writers to a file located at a particular location
-    #[derive(Debug, Clone)]
-    pub struct FileProvider {
-        filename: PathBuf,
-    }
-
-    impl FileProvider {
-        pub fn new(filename: PathBuf) -> Self {
-            Self { filename }
-        }
-
-        fn get_writer_at(&self, start: u64) -> Result<Box<dyn Write + Send>> {
-            let mut file = std::fs::OpenOptions::new()
-                .write(true)
-                .truncate(false)
-                .create(true)
-                .open(&self.filename)?;
-            file.seek(SeekFrom::Start(start))?;
-            Ok(Box::new(file))
         }
     }
 
@@ -195,51 +152,3 @@ mod upload {
 #[cfg(not(target_family = "wasm"))]
 pub use download::*;
 pub use upload::*;
-
-#[cfg(test)]
-pub mod buffer {
-    use std::io::Cursor;
-    use std::sync::{Arc, Mutex};
-
-    #[derive(Debug, Default, Clone)]
-    pub struct BufferProvider {
-        pub buf: ThreadSafeBuffer,
-    }
-
-    impl BufferProvider {
-        pub fn get_writer_at(&self, start: u64) -> crate::error::Result<Box<dyn std::io::Write + Send>> {
-            let mut buffer = self.buf.clone();
-            buffer.idx = start;
-            Ok(Box::new(buffer))
-        }
-    }
-
-    #[derive(Debug, Default, Clone)]
-    /// Thread-safe in-memory buffer that implements [Write](Write) trait at some position
-    /// within an underlying buffer and allows access to inner buffer.
-    /// Thread-safe in-memory buffer that implements [Write](Write) trait and allows
-    /// access to inner buffer
-    pub struct ThreadSafeBuffer {
-        idx: u64,
-        inner: Arc<Mutex<Cursor<Vec<u8>>>>,
-    }
-    impl ThreadSafeBuffer {
-        pub fn value(&self) -> Vec<u8> {
-            self.inner.lock().unwrap().get_ref().clone()
-        }
-    }
-
-    impl std::io::Write for ThreadSafeBuffer {
-        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-            let mut guard = self.inner.lock().map_err(|e| std::io::Error::other(format!("{e}")))?;
-            guard.set_position(self.idx);
-            let num_written = guard.write(buf)?;
-            self.idx = guard.position();
-            Ok(num_written)
-        }
-
-        fn flush(&mut self) -> std::io::Result<()> {
-            Ok(())
-        }
-    }
-}

--- a/cas_client/src/interface.rs
+++ b/cas_client/src/interface.rs
@@ -124,8 +124,6 @@ mod download {
 }
 
 mod upload {
-    use std::path::PathBuf;
-
     use merklehash::MerkleHash;
 
     use crate::error::Result;
@@ -148,12 +146,20 @@ mod upload {
     #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
     #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
     pub trait ShardDedupProbe {
+        #[cfg(not(target_family = "wasm"))]
         async fn query_for_global_dedup_shard(
             &self,
             prefix: &str,
             chunk_hash: &MerkleHash,
             salt: &[u8; 32],
-        ) -> Result<Option<PathBuf>>;
+        ) -> Result<Option<std::path::PathBuf>>;
+        #[cfg(target_family = "wasm")]
+        async fn query_for_global_dedup_shard_in_memory(
+            &self,
+            prefix: &str,
+            chunk_hash: &MerkleHash,
+            salt: &[u8; 32],
+        ) -> Result<Option<Vec<u8>>>;
     }
 
     /// A Client to the CAS (Content Addressed Storage) service to allow storage and

--- a/cas_client/src/interface.rs
+++ b/cas_client/src/interface.rs
@@ -1,167 +1,194 @@
-use std::collections::HashMap;
-use std::fs::OpenOptions;
-use std::io::{Seek, SeekFrom, Write};
-use std::path::PathBuf;
-use std::sync::Arc;
-
-use async_trait::async_trait;
-use cas_types::{FileRange, QueryReconstructionResponse};
-use mdb_shard::shard_file_reconstructor::FileReconstructor;
-use merklehash::MerkleHash;
-use utils::progress::ProgressUpdater;
-
-use crate::error::Result;
-use crate::CasClientError;
-
-/// A Client to the CAS (Content Addressed Storage) service to allow storage and
-/// management of XORBs (Xet Object Remote Block). A XORB represents a collection
-/// of arbitrary bytes. These bytes are hashed according to a Xet Merkle Hash
-/// producing a Merkle Tree. XORBs in the CAS are identified by a combination of
-/// a prefix namespacing the XORB and the hash at the root of the Merkle Tree.
-#[async_trait]
-pub trait UploadClient {
-    /// Insert the provided data into the CAS as a XORB indicated by the prefix and hash.
-    /// The hash will be verified on the SERVER-side according to the chunk boundaries.
-    /// Chunk Boundaries must be complete; i.e. the last entry in chunk boundary
-    /// must be the length of data. For instance, if data="helloworld" with 2 chunks
-    /// ["hello" "world"], chunk_boundaries should be [5, 10].
-    /// Empty data and empty chunk boundaries are not accepted.
-    ///
-    /// Note that put may background in some implementations and a flush()
-    /// will be needed.
-    async fn put(
-        &self,
-        prefix: &str,
-        hash: &MerkleHash,
-        data: Vec<u8>,
-        chunk_and_boundaries: Vec<(MerkleHash, u32)>,
-    ) -> Result<usize>;
-
-    /// Check if a XORB already exists.
-    async fn exists(&self, prefix: &str, hash: &MerkleHash) -> Result<bool>;
-}
-
-/// A Client to the CAS (Content Addressed Storage) service to allow reconstructing a
-/// pointer file based on FileID (MerkleHash).
-///
-/// To simplify this crate, it is intentional that the client does not create its own http_client or
-/// spawn its own threads. Instead, it is expected to be given the parallelism harness/threadpool/queue
-/// on which it is expected to run. This allows the caller to better optimize overall system utilization
-/// by controlling the number of concurrent requests.
-#[async_trait]
-pub trait ReconstructionClient {
-    /// Get an entire file by file hash with an optional bytes range.
-    ///
-    /// The http_client passed in is a non-authenticated client. This is used to directly communicate
-    /// with the backing store (S3) to retrieve xorbs.
-    async fn get_file(
-        &self,
-        hash: &MerkleHash,
-        byte_range: Option<FileRange>,
-        output_provider: &OutputProvider,
-        progress_updater: Option<Arc<dyn ProgressUpdater>>,
-    ) -> Result<u64>;
-
-    async fn batch_get_file(&self, files: HashMap<MerkleHash, &OutputProvider>) -> Result<u64> {
-        let mut n_bytes = 0;
-        // Provide the basic naive implementation as a default.
-        for (h, w) in files {
-            n_bytes += self.get_file(&h, None, w, None).await?;
-        }
-        Ok(n_bytes)
-    }
-}
-
-/// Enum of different output formats to write reconstructed files.
-#[derive(Debug, Clone)]
-pub enum OutputProvider {
-    File(FileProvider),
-    #[cfg(test)]
-    Buffer(buffer::BufferProvider),
-}
-
-impl OutputProvider {
-    /// Create a new writer to start writing at the indicated start location.
-    pub(crate) fn get_writer_at(&self, start: u64) -> Result<Box<dyn Write + Send>> {
-        match self {
-            OutputProvider::File(fp) => fp.get_writer_at(start),
-            #[cfg(test)]
-            OutputProvider::Buffer(bp) => bp.get_writer_at(start),
-        }
-    }
-}
-
-/// Provides new Writers to a file located at a particular location
-#[derive(Debug, Clone)]
-pub struct FileProvider {
-    filename: PathBuf,
-}
-
-impl FileProvider {
-    pub fn new(filename: PathBuf) -> Self {
-        Self { filename }
-    }
-
-    fn get_writer_at(&self, start: u64) -> Result<Box<dyn Write + Send>> {
-        let mut file = OpenOptions::new()
-            .write(true)
-            .truncate(false)
-            .create(true)
-            .open(&self.filename)?;
-        file.seek(SeekFrom::Start(start))?;
-        Ok(Box::new(file))
-    }
-}
-
-/// A Client to the CAS (Content Addressed Storage) service that is able to obtain
-/// the reconstruction info of a file by FileID (MerkleHash). Return
-/// - Ok(Some(response)) if the query succeeded,
-/// - Ok(None) if the specified range can't be satisfied,
-/// - Err(e) for other errors.
-#[async_trait]
-pub trait Reconstructable {
-    async fn get_reconstruction(
-        &self,
-        hash: &MerkleHash,
-        byte_range: Option<FileRange>,
-    ) -> Result<Option<QueryReconstructionResponse>>;
-}
-
-/// Probes for shards that provide dedup information for a chunk, and, if
-/// any are found, writes them to disk and returns the path.
-#[async_trait]
-pub trait ShardDedupProber {
-    async fn query_for_global_dedup_shard(
-        &self,
-        prefix: &str,
-        chunk_hash: &MerkleHash,
-        salt: &[u8; 32],
-    ) -> Result<Option<PathBuf>>;
-}
-
-#[async_trait]
-pub trait RegistrationClient {
-    async fn upload_shard(
-        &self,
-        prefix: &str,
-        hash: &MerkleHash,
-        force_sync: bool,
-        shard_data: &[u8],
-        salt: &[u8; 32],
-    ) -> Result<bool>;
-}
-
 /// A Client to the Shard service. The shard service
 /// provides for
 /// 1. upload shard to the shard service
 /// 2. querying of file->reconstruction information
 /// 3. querying of chunk->shard information
+#[cfg(not(target_family = "wasm"))]
 pub trait ShardClientInterface:
-    RegistrationClient + FileReconstructor<CasClientError> + ShardDedupProber + Send + Sync
+    RegistrationClient
+    + mdb_shard::shard_file_reconstructor::FileReconstructor<crate::CasClientError>
+    + ShardDedupProbe
+    + Send
+    + Sync
 {
 }
 
+#[cfg(target_family = "wasm")]
+pub trait ShardClientInterface: RegistrationClient + ShardDedupProbe {}
+
+#[cfg(not(target_family = "wasm"))]
 pub trait Client: UploadClient + ReconstructionClient + ShardClientInterface {}
+#[cfg(target_family = "wasm")]
+pub trait Client: UploadClient + ShardClientInterface {}
+
+#[cfg(not(target_family = "wasm"))]
+mod download {
+    use std::collections::HashMap;
+    use std::io::{Seek, SeekFrom, Write};
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use cas_types::{FileRange, QueryReconstructionResponse};
+    use merklehash::MerkleHash;
+    use utils::progress::ProgressUpdater;
+
+    use crate::error::Result;
+
+    /// A Client to the CAS (Content Addressed Storage) service to allow reconstructing a
+    /// pointer file based on FileID (MerkleHash).
+    ///
+    /// To simplify this crate, it is intentional that the client does not create its own http_client or
+    /// spawn its own threads. Instead, it is expected to be given the parallelism harness/threadpool/queue
+    /// on which it is expected to run. This allows the caller to better optimize overall system utilization
+    /// by controlling the number of concurrent requests.
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    pub trait ReconstructionClient {
+        /// Get an entire file by file hash with an optional bytes range.
+        ///
+        /// The http_client passed in is a non-authenticated client. This is used to directly communicate
+        /// with the backing store (S3) to retrieve xorbs.
+        async fn get_file(
+            &self,
+            hash: &MerkleHash,
+            byte_range: Option<FileRange>,
+            output_provider: &OutputProvider,
+            progress_updater: Option<Arc<dyn ProgressUpdater>>,
+        ) -> Result<u64>;
+
+        async fn batch_get_file(&self, files: HashMap<MerkleHash, &OutputProvider>) -> Result<u64> {
+            let mut n_bytes = 0;
+            // Provide the basic naive implementation as a default.
+            for (h, w) in files {
+                n_bytes += self.get_file(&h, None, w, None).await?;
+            }
+            Ok(n_bytes)
+        }
+    }
+
+    /// Enum of different output formats to write reconstructed files.
+    #[derive(Debug, Clone)]
+    pub enum OutputProvider {
+        File(FileProvider),
+        #[cfg(test)]
+        Buffer(crate::interface::buffer::BufferProvider),
+    }
+
+    impl OutputProvider {
+        /// Create a new writer to start writing at the indicated start location.
+        pub(crate) fn get_writer_at(&self, start: u64) -> Result<Box<dyn Write + Send>> {
+            match self {
+                OutputProvider::File(fp) => fp.get_writer_at(start),
+                #[cfg(test)]
+                OutputProvider::Buffer(bp) => bp.get_writer_at(start),
+            }
+        }
+    }
+
+    /// Provides new Writers to a file located at a particular location
+    #[derive(Debug, Clone)]
+    pub struct FileProvider {
+        filename: PathBuf,
+    }
+
+    impl FileProvider {
+        pub fn new(filename: PathBuf) -> Self {
+            Self { filename }
+        }
+
+        fn get_writer_at(&self, start: u64) -> Result<Box<dyn Write + Send>> {
+            let mut file = std::fs::OpenOptions::new()
+                .write(true)
+                .truncate(false)
+                .create(true)
+                .open(&self.filename)?;
+            file.seek(SeekFrom::Start(start))?;
+            Ok(Box::new(file))
+        }
+    }
+
+    /// A Client to the CAS (Content Addressed Storage) service that is able to obtain
+    /// the reconstruction info of a file by FileID (MerkleHash). Return
+    /// - Ok(Some(response)) if the query succeeded,
+    /// - Ok(None) if the specified range can't be satisfied,
+    /// - Err(e) for other errors.
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    pub trait Reconstruct {
+        async fn get_reconstruction(
+            &self,
+            hash: &MerkleHash,
+            byte_range: Option<FileRange>,
+        ) -> Result<Option<QueryReconstructionResponse>>;
+    }
+}
+
+mod upload {
+    use std::path::PathBuf;
+
+    use merklehash::MerkleHash;
+
+    use crate::error::Result;
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    pub trait RegistrationClient {
+        async fn upload_shard(
+            &self,
+            prefix: &str,
+            hash: &MerkleHash,
+            force_sync: bool,
+            shard_data: &[u8],
+            salt: &[u8; 32],
+        ) -> Result<bool>;
+    }
+
+    /// Probes for shards that provide dedup information for a chunk, and, if
+    /// any are found, writes them to disk and returns the path.
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    pub trait ShardDedupProbe {
+        async fn query_for_global_dedup_shard(
+            &self,
+            prefix: &str,
+            chunk_hash: &MerkleHash,
+            salt: &[u8; 32],
+        ) -> Result<Option<PathBuf>>;
+    }
+
+    /// A Client to the CAS (Content Addressed Storage) service to allow storage and
+    /// management of XORBs (Xet Object Remote Block). A XORB represents a collection
+    /// of arbitrary bytes. These bytes are hashed according to a Xet Merkle Hash
+    /// producing a Merkle Tree. XORBs in the CAS are identified by a combination of
+    /// a prefix namespacing the XORB and the hash at the root of the Merkle Tree.
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    pub trait UploadClient {
+        /// Insert the provided data into the CAS as a XORB indicated by the prefix and hash.
+        /// The hash will be verified on the SERVER-side according to the chunk boundaries.
+        /// Chunk Boundaries must be complete; i.e. the last entry in chunk boundary
+        /// must be the length of data. For instance, if data="helloworld" with 2 chunks
+        /// ["hello" "world"], chunk_boundaries should be [5, 10].
+        /// Empty data and empty chunk boundaries are not accepted.
+        ///
+        /// Note that put may background in some implementations and a flush()
+        /// will be needed.
+        async fn put(
+            &self,
+            prefix: &str,
+            hash: &MerkleHash,
+            data: Vec<u8>,
+            chunk_and_boundaries: Vec<(MerkleHash, u32)>,
+        ) -> Result<usize>;
+
+        /// Check if a XORB already exists.
+        async fn exists(&self, prefix: &str, hash: &MerkleHash) -> Result<bool>;
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+pub use download::*;
+pub use upload::*;
 
 #[cfg(test)]
 pub mod buffer {

--- a/cas_client/src/interface.rs
+++ b/cas_client/src/interface.rs
@@ -199,9 +199,7 @@ pub use upload::*;
 #[cfg(test)]
 pub mod buffer {
     use std::io::Cursor;
-    use std::sync::Mutex;
-
-    use super::*;
+    use std::sync::{Arc, Mutex};
 
     #[derive(Debug, Default, Clone)]
     pub struct BufferProvider {
@@ -209,7 +207,7 @@ pub mod buffer {
     }
 
     impl BufferProvider {
-        pub fn get_writer_at(&self, start: u64) -> Result<Box<dyn Write + Send>> {
+        pub fn get_writer_at(&self, start: u64) -> crate::error::Result<Box<dyn std::io::Write + Send>> {
             let mut buffer = self.buf.clone();
             buffer.idx = start;
             Ok(Box::new(buffer))
@@ -231,7 +229,7 @@ pub mod buffer {
         }
     }
 
-    impl Write for ThreadSafeBuffer {
+    impl std::io::Write for ThreadSafeBuffer {
         fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
             let mut guard = self.inner.lock().map_err(|e| std::io::Error::other(format!("{e}")))?;
             guard.set_position(self.idx);

--- a/cas_client/src/interface.rs
+++ b/cas_client/src/interface.rs
@@ -1,5 +1,6 @@
-use crate::CasClientError;
 use mdb_shard::shard_file_reconstructor::FileReconstructor;
+
+use crate::CasClientError;
 
 /// A Client to the Shard service. The shard service
 /// provides for

--- a/cas_client/src/lib.rs
+++ b/cas_client/src/lib.rs
@@ -5,9 +5,11 @@ pub use http_client::{build_auth_http_client, build_http_client, RetryConfig};
 use interface::RegistrationClient;
 pub use interface::{Client, UploadClient};
 #[cfg(not(target_family = "wasm"))]
-pub use interface::{FileProvider, OutputProvider, Reconstruct, ReconstructionClient};
+pub use interface::{Reconstruct, ReconstructionClient};
 #[cfg(not(target_family = "wasm"))]
 pub use local_client::LocalClient;
+#[cfg(not(target_family = "wasm"))]
+pub use output_provider::{FileProvider, OutputProvider};
 pub use remote_client::RemoteClient;
 
 pub use crate::error::CasClientError;
@@ -20,4 +22,6 @@ mod http_client;
 mod interface;
 #[cfg(not(target_family = "wasm"))]
 mod local_client;
+#[cfg(not(target_family = "wasm"))]
+mod output_provider;
 pub mod remote_client;

--- a/cas_client/src/lib.rs
+++ b/cas_client/src/lib.rs
@@ -3,16 +3,21 @@
 pub use chunk_cache::{CacheConfig, CHUNK_CACHE_SIZE_BYTES};
 pub use http_client::{build_auth_http_client, build_http_client, RetryConfig};
 use interface::RegistrationClient;
-pub use interface::{Client, FileProvider, OutputProvider, Reconstructable, ReconstructionClient, UploadClient};
+pub use interface::{Client, UploadClient};
+#[cfg(not(target_family = "wasm"))]
+pub use interface::{FileProvider, OutputProvider, Reconstruct, ReconstructionClient};
+#[cfg(not(target_family = "wasm"))]
 pub use local_client::LocalClient;
 pub use remote_client::RemoteClient;
 
 pub use crate::error::CasClientError;
 pub use crate::interface::ShardClientInterface;
 
+#[cfg(not(target_family = "wasm"))]
 mod download_utils;
 mod error;
 mod http_client;
 mod interface;
+#[cfg(not(target_family = "wasm"))]
 mod local_client;
 pub mod remote_client;

--- a/cas_client/src/local_client.rs
+++ b/cas_client/src/local_client.rs
@@ -21,7 +21,8 @@ use tracing::{debug, error, info, warn};
 use utils::progress::ProgressUpdater;
 
 use crate::error::{CasClientError, Result};
-use crate::interface::{OutputProvider, ShardDedupProbe, UploadClient};
+use crate::interface::{ShardDedupProbe, UploadClient};
+use crate::output_provider::OutputProvider;
 use crate::{Client, ReconstructionClient, RegistrationClient, ShardClientInterface};
 
 pub struct LocalClient {

--- a/cas_client/src/local_client.rs
+++ b/cas_client/src/local_client.rs
@@ -21,7 +21,7 @@ use tracing::{debug, error, info, warn};
 use utils::progress::ProgressUpdater;
 
 use crate::error::{CasClientError, Result};
-use crate::interface::{OutputProvider, ShardDedupProber, UploadClient};
+use crate::interface::{OutputProvider, ShardDedupProbe, UploadClient};
 use crate::{Client, ReconstructionClient, RegistrationClient, ShardClientInterface};
 
 pub struct LocalClient {
@@ -354,7 +354,7 @@ impl FileReconstructor<CasClientError> for LocalClient {
 }
 
 #[async_trait]
-impl ShardDedupProber for LocalClient {
+impl ShardDedupProbe for LocalClient {
     async fn query_for_global_dedup_shard(
         &self,
         _prefix: &str,

--- a/cas_client/src/output_provider.rs
+++ b/cas_client/src/output_provider.rs
@@ -1,0 +1,88 @@
+use std::io::{Cursor, Seek, SeekFrom, Write};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use crate::error::Result;
+
+/// Enum of different output formats to write reconstructed files.
+#[derive(Debug, Clone)]
+pub enum OutputProvider {
+    File(FileProvider),
+    #[cfg(test)]
+    Buffer(BufferProvider),
+}
+
+impl OutputProvider {
+    /// Create a new writer to start writing at the indicated start location.
+    pub(crate) fn get_writer_at(&self, start: u64) -> Result<Box<dyn Write + Send>> {
+        match self {
+            OutputProvider::File(fp) => fp.get_writer_at(start),
+            #[cfg(test)]
+            OutputProvider::Buffer(bp) => bp.get_writer_at(start),
+        }
+    }
+}
+
+/// Provides new Writers to a file located at a particular location
+#[derive(Debug, Clone)]
+pub struct FileProvider {
+    filename: PathBuf,
+}
+
+impl FileProvider {
+    pub fn new(filename: PathBuf) -> Self {
+        Self { filename }
+    }
+
+    fn get_writer_at(&self, start: u64) -> Result<Box<dyn Write + Send>> {
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .truncate(false)
+            .create(true)
+            .open(&self.filename)?;
+        file.seek(SeekFrom::Start(start))?;
+        Ok(Box::new(file))
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct BufferProvider {
+    pub buf: ThreadSafeBuffer,
+}
+
+impl BufferProvider {
+    pub fn get_writer_at(&self, start: u64) -> crate::error::Result<Box<dyn std::io::Write + Send>> {
+        let mut buffer = self.buf.clone();
+        buffer.idx = start;
+        Ok(Box::new(buffer))
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+/// Thread-safe in-memory buffer that implements [Write](Write) trait at some position
+/// within an underlying buffer and allows access to inner buffer.
+/// Thread-safe in-memory buffer that implements [Write](Write) trait and allows
+/// access to inner buffer
+pub struct ThreadSafeBuffer {
+    idx: u64,
+    inner: Arc<Mutex<Cursor<Vec<u8>>>>,
+}
+impl ThreadSafeBuffer {
+    pub fn value(&self) -> Vec<u8> {
+        self.inner.lock().unwrap().get_ref().clone()
+    }
+}
+
+impl std::io::Write for ThreadSafeBuffer {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let mut guard = self.inner.lock().map_err(|e| std::io::Error::other(format!("{e}")))?;
+        guard.set_position(self.idx);
+        let num_written = guard.write(buf)?;
+        self.idx = guard.position();
+        Ok(num_written)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}

--- a/chunk_cache/src/lib.rs
+++ b/chunk_cache/src/lib.rs
@@ -34,7 +34,7 @@ pub struct CacheRange {
 /// ChunkCache is a trait for storing and fetching Xorb ranges.
 /// implementors are expected to return bytes for a key and a given chunk range
 /// (no compression or further deserialization should be required)
-/// Range inputs use chunk indices in a end exclusive way i.e. [start, end)
+/// Range inputs use chunk indices in an end exclusive way i.e. [start, end)
 ///
 /// implementors are allowed to evict data, a get after a put is not required to
 /// be a cache hit.

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -50,7 +50,7 @@ serde_json = "1.0.133"
 
 # Need to specify this as optional to allow the openssl/vendored option below
 openssl = { version = "0.10", features = [], optional = true }
-reqwest-middleware = "0.3.3"
+reqwest-middleware = "0.4.1"
 chrono = "0.4.39"
 
 [target.'cfg(not(windows))'.dependencies]
@@ -59,10 +59,10 @@ openssl = "0.10"
 # use embedded webpki root certs for MacOS as native certs take a very long time
 # to load, which affects startup time significantly
 [target.'cfg(macos)'.dependencies]
-reqwest = { version = "0.11.4", features = ["json", "webpki-roots"] }
+reqwest = { version = "0.12.15", features = ["json", "rustls-tls-webpki-roots"] }
 
 [target.'cfg(not(macos))'.dependencies]
-reqwest = { version = "0.11.4", features = ["json"] }
+reqwest = { version = "0.12.15", features = ["json"] }
 
 # Windows doesn't support assembly for compilation
 [target.'cfg(not(target_os = "windows"))'.dependencies]

--- a/data/src/remote_client_interface.rs
+++ b/data/src/remote_client_interface.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 pub use cas_client::Client;
-use cas_client::{LocalClient, RemoteClient};
+use cas_client::RemoteClient;
 use xet_threadpool::ThreadPool;
 
 use crate::configurations::*;
@@ -24,6 +24,13 @@ pub(crate) fn create_remote_client(
             config.shard_config.cache_directory.clone(),
             dry_run,
         ))),
-        Endpoint::FileSystem(ref path) => Ok(Arc::new(LocalClient::new(path, None)?)),
+        Endpoint::FileSystem(ref path) => {
+            #[cfg(not(target_family = "wasm"))]
+            {
+                Ok(Arc::new(cas_client::LocalClient::new(path, None)?))
+            }
+            #[cfg(target_family = "wasm")]
+            unimplemented!("Local file system access is not supported in WASM builds")
+        },
     }
 }

--- a/file_utils/src/privilege_context.rs
+++ b/file_utils/src/privilege_context.rs
@@ -52,6 +52,12 @@ fn is_elevated_impl() -> bool {
             elevation.TokenIsElevated != 0
         }
     }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        // For other platforms, we assume not elevated
+        false
+    }
 }
 
 lazy_static! {

--- a/hf_xet/Cargo.lock
+++ b/hf_xet/Cargo.lock
@@ -283,7 +283,6 @@ version = "0.14.5"
 dependencies = [
  "anyhow",
  "async-trait",
- "bytes",
  "cas_object",
  "cas_types",
  "chunk_cache",
@@ -293,12 +292,11 @@ dependencies = [
  "file_utils",
  "futures",
  "heed",
- "http 1.1.0",
- "itertools 0.10.5",
+ "http",
  "mdb_shard",
  "merkledb",
  "merklehash",
- "reqwest 0.12.9",
+ "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
  "tempfile",
@@ -676,7 +674,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "regex",
- "reqwest 0.11.27",
+ "reqwest",
  "reqwest-middleware",
  "serde_json",
  "sha2",
@@ -1050,25 +1048,6 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "h2"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.6.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
@@ -1078,7 +1057,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.1.0",
+ "http",
  "indexmap 2.6.0",
  "slab",
  "tokio",
@@ -1194,7 +1173,7 @@ dependencies = [
  "parutils",
  "pprof",
  "pyo3",
- "reqwest 0.11.27",
+ "reqwest",
  "serde",
  "serde_json",
  "signal-hook",
@@ -1203,17 +1182,6 @@ dependencies = [
  "tracing-subscriber",
  "utils",
  "xet_threadpool",
-]
-
-[[package]]
-name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
 ]
 
 [[package]]
@@ -1229,23 +1197,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.1.0",
+ "http",
 ]
 
 [[package]]
@@ -1256,8 +1213,8 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.1.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -1268,36 +1225,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "hyper"
-version = "0.14.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
 name = "hyper"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1306,9 +1233,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.7",
- "http 1.1.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -1324,27 +1251,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
- "http 1.1.0",
- "hyper 1.5.1",
+ "http",
+ "hyper",
  "hyper-util",
  "rustls",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper 0.14.31",
- "native-tls",
- "tokio",
- "tokio-native-tls",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1355,7 +1270,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.5.1",
+ "hyper",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -1372,9 +1287,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.1.0",
- "http-body 1.0.1",
- "hyper 1.5.1",
+ "http",
+ "http-body",
+ "hyper",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1823,7 +1738,7 @@ dependencies = [
  "merklehash",
  "rand_chacha 0.9.0",
  "rayon",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "serde",
  "tempfile",
  "thiserror 2.0.11",
@@ -2474,6 +2389,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3bd15a6f2967aef83887dcb9fec0014580467e33720d073560cf015a5683012"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.11",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcbafbbdbb0f638fe3f35f3c56739f77a8a1d070cb25603226c83339b391472b"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.1",
+ "rand 0.9.0",
+ "ring",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.11",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "541d0f57c6ec747a90738a52741d3221f7960e8ac2f0ff4b1a63680e033b4ab5"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2637,63 +2606,22 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.31",
- "hyper-tls 0.5.0",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pemfile 1.0.4",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration 0.5.1",
- "tokio",
- "tokio-native-tls",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots",
- "winreg",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.12.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.7",
- "http 1.1.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.5.1",
+ "hyper",
  "hyper-rustls",
- "hyper-tls 0.6.0",
+ "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -2703,34 +2631,40 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile 2.2.0",
+ "quinn",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
- "system-configuration 0.6.1",
+ "sync_wrapper",
+ "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
+ "tower",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots",
  "windows-registry",
 ]
 
 [[package]]
 name = "reqwest-middleware"
-version = "0.3.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562ceb5a604d3f7c885a792d42c199fd8af239d0a51b2fa6a78aafa092452b04"
+checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
 dependencies = [
  "anyhow",
  "async-trait",
- "http 1.1.0",
- "reqwest 0.12.9",
+ "http",
+ "reqwest",
  "serde",
  "thiserror 1.0.69",
  "tower-service",
@@ -2738,20 +2672,21 @@ dependencies = [
 
 [[package]]
 name = "reqwest-retry"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a83df1aaec00176d0fabb65dea13f832d2a446ca99107afc17c5d2d4981221d0"
+checksum = "29c73e4195a6bfbcb174b790d9b3407ab90646976c55de58a6515da25d851178"
 dependencies = [
  "anyhow",
  "async-trait",
  "futures",
  "getrandom 0.2.15",
- "http 1.1.0",
- "hyper 1.5.1",
+ "http",
+ "hyper",
  "parking_lot 0.11.2",
- "reqwest 0.12.9",
+ "reqwest",
  "reqwest-middleware",
  "retry-policies",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "wasm-timer",
@@ -2803,6 +2738,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustix"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2822,19 +2763,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f1a745511c54ba6d4465e8d5dfbd81b45791756de28d4981af70d6dca128f1e"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -2851,6 +2784,9 @@ name = "rustls-pki-types"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+dependencies = [
+ "web-time",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -3164,12 +3100,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -3199,34 +3129,13 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys 0.5.0",
-]
-
-[[package]]
-name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.6.0",
  "core-foundation",
- "system-configuration-sys 0.6.0",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -3371,6 +3280,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3441,6 +3365,27 @@ checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
@@ -3786,10 +3731,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.25.4"
+name = "web-time"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29aad86cec885cafd03e8305fd727c418e970a521322c91688414d5b8efba16b"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "whoami"
@@ -3843,33 +3801,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-registry"
-version = "0.2.0"
+name = "windows-link"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
  "windows-result",
  "windows-strings",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
- "windows-result",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -3923,11 +3886,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -3943,6 +3922,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3953,6 +3938,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3967,10 +3958,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3985,6 +3988,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3995,6 +4004,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4009,6 +4024,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4021,14 +4042,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winreg"
-version = "0.50.0"
+name = "windows_x86_64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if 1.0.0",
- "windows-sys 0.48.0",
-]
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/hf_xet/Cargo.toml
+++ b/hf_xet/Cargo.toml
@@ -29,7 +29,7 @@ tracing-subscriber = { version = "0.3", features = [
     "env-filter",
 ] }
 bipbuffer = "0.1"
-reqwest = "0.11.27"
+reqwest = "0.12.15"
 serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.133"
 lazy_static = "1.5"

--- a/mdb_shard/src/shard_file_manager.rs
+++ b/mdb_shard/src/shard_file_manager.rs
@@ -3,7 +3,6 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use merklehash::{HMACKey, MerkleHash};
 use tokio::sync::RwLock;
 use tracing::{debug, info, trace};
@@ -313,7 +312,8 @@ impl ShardFileManager {
     }
 }
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 impl FileReconstructor<MDBShardError> for ShardFileManager {
     // Given a file pointer, returns the information needed to reconstruct the file.
     // The information is stored in the destination vector dest_results.  The function

--- a/mdb_shard/src/shard_file_reconstructor.rs
+++ b/mdb_shard/src/shard_file_reconstructor.rs
@@ -1,9 +1,9 @@
-use async_trait::async_trait;
 use merklehash::MerkleHash;
 
 use crate::file_structs::MDBFileInfo;
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 pub trait FileReconstructor<E> {
     /// Returns a pair of (file reconstruction information,  maybe shard ID)
     /// Err(_) if an error occured


### PR DESCRIPTION
This PR makes the cas_client crate compile into WASM (at least with wasm-pack). It separates out download & upload traits and functions when necessary to then target_family block the downloads path (easy way out). There's other generally necessary changes particularly having to do with async_trait that are added.

Tested by adding the cas_client dependency to hf_xet_wasm and using it and it compiling. however I didn't test that calling the functions works. Notably, the dedupe query function expects to be able to write a file and return the path to it, that will have to change.

@seanses feel free to make changes & merge this PR if you want to