### PR TITLE
sanitize url in reqwest error

### DIFF
--- a/cas_client/src/remote_client.rs
+++ b/cas_client/src/remote_client.rs
@@ -223,7 +223,7 @@ pub(crate) async fn get_reconstruction_with_endpoint_and_client(
         let e = response.unwrap_err();
 
         // bytes_range not satisfiable
-        if let CasClientError::ReqwestError(e) = &e {
+        if let CasClientError::ReqwestError(e, _) = &e {
             if let Some(StatusCode::RANGE_NOT_SATISFIABLE) = e.status() {
                 return Ok(None);
             }


### PR DESCRIPTION
When we have a reqwest::Error in hf_xet it can get logged at different places and it currently logs presigned urls that include data to reach S3/CF, this PR attempts to sanitize those urls when the error is logged/returned