### PR TITLE
cache put

### DIFF
--- a/cas_client/src/download_utils.rs
+++ b/cas_client/src/download_utils.rs
@@ -268,7 +268,7 @@ impl DownloadScheduler {
             self.n_concurrent_download_task.forget_permits(1);
         } else {
             // TODO: check download speed and consider if we should increase or decrease
-            info!("expanding segment size by one range");
+            debug!("expanding segment size by one range");
             *self.n_range_in_segment.lock()? += 1;
             self.n_concurrent_download_task.add_permits(1);
         }

--- a/chunk_cache/src/disk.rs
+++ b/chunk_cache/src/disk.rs
@@ -12,7 +12,7 @@ use cas_types::{ChunkRange, Key};
 use error_printer::ErrorPrinter;
 use file_utils::SafeFileCreator;
 use merklehash::MerkleHash;
-use tracing::{debug, error, warn};
+use tracing::{debug, error};
 use utils::output_bytes;
 
 use crate::disk::cache_file_header::CacheFileHeader;
@@ -262,7 +262,7 @@ impl DiskCache {
                     cache_item.verify();
                     file.rewind()?;
                 } else {
-                    warn!("computed checksum {checksum} mismatch on cache item {key}/{cache_item}");
+                    debug!("computed checksum {checksum} mismatch on cache item {key}/{cache_item}");
                     self.remove_item(key, &cache_item)?;
                     continue;
                 }
@@ -713,14 +713,14 @@ fn try_parse_cache_file(file_result: io::Result<DirEntry>, capacity: u64) -> Opt
     {
         Ok(i) => i,
         Err(e) => {
-            warn!("not a valid cache file, removing: {:?} {e:?}", item.file_name());
+            debug!("not a valid cache file, removing: {:?} {e:?}", item.file_name());
             remove_file(item.path())?;
             return Ok(None);
         },
     };
     if md.len() != cache_item.len {
         // file is invalid, remove it
-        warn!(
+        debug!(
             "cache file len {} does not match expected length {}, removing path: {:?}",
             md.len(),
             cache_item.len,

--- a/chunk_cache/src/disk.rs
+++ b/chunk_cache/src/disk.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fs::{DirEntry, File};
 use std::io::{self, Cursor, ErrorKind, Read, Seek, SeekFrom, Write};
 use std::mem::size_of;
@@ -11,7 +11,6 @@ use base64::Engine;
 use cas_types::{ChunkRange, Key};
 use error_printer::ErrorPrinter;
 use file_utils::SafeFileCreator;
-use log::info;
 use merklehash::MerkleHash;
 use tracing::{debug, error, warn};
 use utils::output_bytes;
@@ -475,7 +474,7 @@ impl DiskCache {
                 state.total_bytes -= len;
                 state.num_items -= 1;
             } else {
-                error!("attempted to evict item that is not found in cache state {key}, {idx}");
+                error!("attempted to evict item, but no item could be found to be evicted");
                 break;
             }
         }
@@ -805,15 +804,16 @@ impl ChunkCache for DiskCache {
 mod tests {
     use std::collections::BTreeSet;
 
-    use super::{DiskCache, DEFAULT_CHUNK_CACHE_CAPACITY};
-    use crate::disk::test_utils::*;
-    use crate::disk::try_parse_key;
-    use crate::{CacheConfig, ChunkCache};
     use cas_types::{ChunkRange, Key};
     use rand::rngs::StdRng;
     use rand::SeedableRng;
     use tempdir::TempDir;
     use utils::output_bytes;
+
+    use super::{DiskCache, DEFAULT_CHUNK_CACHE_CAPACITY};
+    use crate::disk::test_utils::*;
+    use crate::disk::try_parse_key;
+    use crate::{CacheConfig, ChunkCache};
 
     const RANDOM_SEED: u64 = 9089 << 20 | 120043;
 

--- a/chunk_cache/src/disk.rs
+++ b/chunk_cache/src/disk.rs
@@ -11,9 +11,9 @@ use base64::Engine;
 use cas_types::{ChunkRange, Key};
 use error_printer::ErrorPrinter;
 use file_utils::SafeFileCreator;
+use log::info;
 use merklehash::MerkleHash;
-use tracing::{debug, warn};
-#[cfg(feature = "analysis")]
+use tracing::{debug, error, warn};
 use utils::output_bytes;
 
 use crate::disk::cache_file_header::CacheFileHeader;
@@ -307,11 +307,11 @@ impl DiskCache {
         data: &[u8],
     ) -> Result<(), ChunkCacheError> {
         if range.start >= range.end
-        || chunk_byte_indices.len() != (range.end - range.start + 1) as usize
-        // chunk_byte_indices is guaranteed to be more than 1 element at this point
-        || chunk_byte_indices[0] != 0
-        || *chunk_byte_indices.last().unwrap() as usize != data.len()
-        || !strictly_increasing(chunk_byte_indices)
+            || chunk_byte_indices.len() != (range.end - range.start + 1) as usize
+            // chunk_byte_indices is guaranteed to be more than 1 element at this point
+            || chunk_byte_indices[0] != 0
+            || *chunk_byte_indices.last().unwrap() as usize != data.len()
+            || !strictly_increasing(chunk_byte_indices)
         {
             return Err(ChunkCacheError::InvalidArguments);
         }
@@ -326,6 +326,12 @@ impl DiskCache {
         let header = CacheFileHeader::new(chunk_byte_indices);
         let mut header_buf = Vec::with_capacity(header.header_len());
         header.serialize(&mut header_buf)?;
+        let len = (header_buf.len() + data.len()) as u64;
+        if len > self.capacity {
+            // refusing to add this item as it is too large for the cache with configured capacity
+            return Ok(());
+        }
+
         let checksum = {
             let mut hasher = crc32fast::Hasher::new();
             hasher.update(&header_buf);
@@ -335,7 +341,7 @@ impl DiskCache {
 
         let cache_item = CacheItem {
             range: *range,
-            len: (header_buf.len() + data.len()) as u64,
+            len,
             checksum,
         };
 
@@ -352,35 +358,6 @@ impl DiskCache {
         // to avoid removing new item.
         let mut state = self.state.lock()?;
 
-        let items = state.inner.entry(key.clone()).or_default();
-
-        // remove from state any items that would be encompassed by the new value
-        // first collect their indices, then remove them by index in reverse
-        let mut to_remove: Vec<usize> = Vec::new();
-        for (i, item) in items.iter().enumerate() {
-            if item.range.start >= cache_item.range.start && item.range.end <= cache_item.range.end {
-                to_remove.push(i);
-            }
-        }
-
-        // collection of paths to remove from file system
-        let mut overlapping_item_paths = HashSet::new();
-        let mut total_bytes_rm = 0;
-        let num_items_rm = to_remove.len();
-        // removing by index in reverse to guarantee lower-index items aren't shifted/moved
-        for item_idx in to_remove.into_iter().rev() {
-            let item = items.swap_remove(item_idx);
-            // We only remove from the disk if the item found is not equal to the cache_item
-            // we just wrote. This can happen when multiple put calls are made for the same
-            // item simultaneously.
-            if item != cache_item {
-                overlapping_item_paths.insert(self.item_path(key, &item)?);
-                total_bytes_rm += item.len;
-            }
-        }
-        state.num_items -= num_items_rm;
-        state.total_bytes -= total_bytes_rm;
-
         // add evicted paths to paths to remove from file system
         let evicted_paths = self.maybe_evict(&mut state, cache_item.len)?;
 
@@ -394,9 +371,6 @@ impl DiskCache {
         drop(state);
 
         // remove files after done with modifying in memory state and releasing lock
-        for path in overlapping_item_paths {
-            remove_file(&path)?;
-        }
         for path in evicted_paths {
             remove_file(&path)?;
             // check and try to remove key path if all items evicted for key
@@ -485,39 +459,48 @@ impl DiskCache {
         state: &mut MutexGuard<'_, CacheState>,
         expected_add: u64,
     ) -> Result<Vec<PathBuf>, ChunkCacheError> {
-        let total_bytes = state.total_bytes;
-        let to_remove = total_bytes as i64 - self.capacity as i64 + expected_add as i64;
-        let mut bytes_removed = 0;
+        let original_total_bytes = state.total_bytes;
         let mut paths = Vec::new();
-        while to_remove > bytes_removed {
+        while state.total_bytes + expected_add > self.capacity {
             if let Some((key, idx)) = self.random_item(state) {
                 let items = state.inner.get_mut(&key).ok_or(ChunkCacheError::Infallible)?;
                 let cache_item = &items[idx];
                 let len = cache_item.len;
                 let path = self.item_path(&key, cache_item)?;
                 paths.push(path);
-                items.remove(idx);
+                items.swap_remove(idx);
                 if items.is_empty() {
                     state.inner.remove(&key);
                 }
                 state.total_bytes -= len;
                 state.num_items -= 1;
-                bytes_removed += len as i64;
             } else {
+                error!("attempted to evict item that is not found in cache state {key}, {idx}");
                 break;
             }
         }
+        debug!(
+            "cache evicting {} items totaling {}",
+            paths.len(),
+            output_bytes(original_total_bytes - state.total_bytes)
+        );
 
         Ok(paths)
     }
 
     /// returns the key and index within that key for a random item
     fn random_item(&self, state: &MutexGuard<'_, CacheState>) -> Option<(Key, usize)> {
-        let num_items = state.num_items;
-        if num_items == 0 {
+        debug_assert_eq!(
+            state.inner.values().map(|v| v.len()).sum::<usize>(),
+            state.num_items,
+            "real num items != stored num items"
+        );
+
+        if state.num_items == 0 {
+            error!("cache random_item for eviction: no items in cache");
             return None;
         }
-        let random_item = rand::random::<usize>() % num_items;
+        let random_item = rand::random::<usize>() % state.num_items;
         let mut count = 0;
         for (key, items) in state.inner.iter() {
             if random_item < count + items.len() {
@@ -525,6 +508,8 @@ impl DiskCache {
             }
             count += items.len();
         }
+        // should never occur
+        error!("cache random_item for eviction: tried to return random item error not enough items");
         None
     }
 
@@ -820,15 +805,15 @@ impl ChunkCache for DiskCache {
 mod tests {
     use std::collections::BTreeSet;
 
-    use cas_types::{ChunkRange, Key};
-    use rand::rngs::StdRng;
-    use rand::SeedableRng;
-    use tempdir::TempDir;
-
     use super::{DiskCache, DEFAULT_CHUNK_CACHE_CAPACITY};
     use crate::disk::test_utils::*;
     use crate::disk::try_parse_key;
     use crate::{CacheConfig, ChunkCache};
+    use cas_types::{ChunkRange, Key};
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
+    use tempdir::TempDir;
+    use utils::output_bytes;
 
     const RANDOM_SEED: u64 = 9089 << 20 | 120043;
 
@@ -941,12 +926,12 @@ mod tests {
             let (key, range, offsets, data) = it.next().unwrap();
             assert!(cache.put(&key, &range, &offsets, &data).is_ok());
         }
-        assert!(cache.total_bytes().unwrap() <= CAP);
+        let total_bytes = cache.total_bytes().unwrap();
+        assert!(total_bytes <= CAP, "cache size: {} <= {}", output_bytes(total_bytes), output_bytes(CAP));
 
         let (key, range, offsets, data) = it.next().unwrap();
         let result = cache.put(&key, &range, &offsets, &data);
         assert!(result.is_ok());
-        assert!(cache.total_bytes().unwrap() <= CAP);
     }
 
     #[test]

--- a/file_utils/src/lib.rs
+++ b/file_utils/src/lib.rs
@@ -2,5 +2,5 @@ mod file_metadata;
 mod privilege_context;
 mod safe_file_creator;
 
-pub use privilege_context::{create_dir_all, create_file, PrivilgedExecutionContext};
+pub use privilege_context::{create_dir_all, create_file, PrivilegedExecutionContext};
 pub use safe_file_creator::SafeFileCreator;

--- a/file_utils/src/privilege_context.rs
+++ b/file_utils/src/privilege_context.rs
@@ -75,23 +75,23 @@ pub fn is_elevated() -> bool {
 //    control.
 
 #[derive(Debug, Clone, Copy)]
-pub enum PrivilgedExecutionContext {
+pub enum PrivilegedExecutionContext {
     Regular,
     Elevated,
 }
 
-impl PrivilgedExecutionContext {
-    pub fn current() -> PrivilgedExecutionContext {
+impl PrivilegedExecutionContext {
+    pub fn current() -> PrivilegedExecutionContext {
         match is_elevated() {
-            false => PrivilgedExecutionContext::Regular,
-            true => PrivilgedExecutionContext::Elevated,
+            false => PrivilegedExecutionContext::Regular,
+            true => PrivilegedExecutionContext::Elevated,
         }
     }
 
     pub fn is_elevated(&self) -> bool {
         match self {
-            PrivilgedExecutionContext::Regular => false,
-            PrivilgedExecutionContext::Elevated => true,
+            PrivilegedExecutionContext::Regular => false,
+            PrivilegedExecutionContext::Elevated => true,
         }
     }
 
@@ -196,11 +196,11 @@ impl PrivilgedExecutionContext {
 }
 
 pub fn create_dir_all(path: impl AsRef<Path>) -> std::io::Result<()> {
-    PrivilgedExecutionContext::current().create_dir_all(path)
+    PrivilegedExecutionContext::current().create_dir_all(path)
 }
 
 pub fn create_file(path: impl AsRef<Path>) -> std::io::Result<File> {
-    PrivilgedExecutionContext::current().create_file(path)
+    PrivilegedExecutionContext::current().create_file(path)
 }
 
 #[allow(unused_variables)]
@@ -236,7 +236,7 @@ mod test {
     use std::os::unix::fs::MetadataExt;
     use std::path::Path;
 
-    use super::{PrivilgedExecutionContext, WARNING_PRINTED};
+    use super::{PrivilegedExecutionContext, WARNING_PRINTED};
 
     #[test]
     #[ignore = "run manually"]
@@ -254,7 +254,7 @@ mod test {
 
         let test_path = std::env::var("HF_XET_TEST_PATH")?;
         std::env::set_current_dir(test_path)?;
-        let permission = PrivilgedExecutionContext::current();
+        let permission = PrivilegedExecutionContext::current();
 
         let test = Path::new("rootdir/regdir1/regdir2");
 
@@ -281,7 +281,7 @@ mod test {
 
         let test_path = std::env::var("HF_XET_TEST_PATH")?;
         std::env::set_current_dir(test_path)?;
-        let permission = PrivilgedExecutionContext::current();
+        let permission = PrivilegedExecutionContext::current();
 
         let test = Path::new("regdir/regdir1/regdir2");
 
@@ -318,7 +318,7 @@ mod test {
 
         let test_path = std::env::var("HF_XET_TEST_PATH")?;
         std::env::set_current_dir(test_path)?;
-        let permission = PrivilgedExecutionContext::current();
+        let permission = PrivilegedExecutionContext::current();
 
         let test1 = Path::new("rootdir/regdir1/regdir2/file");
 
@@ -353,7 +353,7 @@ mod test {
 
         let test = Path::new("regdir/regdir1/regdir2/file");
 
-        let permission = PrivilgedExecutionContext::current();
+        let permission = PrivilegedExecutionContext::current();
         permission.create_file(test)?;
 
         assert!(test.exists());

--- a/file_utils/src/safe_file_creator.rs
+++ b/file_utils/src/safe_file_creator.rs
@@ -88,6 +88,18 @@ impl SafeFileCreator {
         self.dest_path = Some(dest_path);
     }
 
+    // abort the writing process and delete the temporary file
+    pub fn abort(&mut self) -> io::Result<()> {
+        if self.writer.is_none() {
+            return Ok(());
+        }
+        self.writer = None;
+        if self.temp_path.exists() {
+            fs::remove_file(&self.temp_path)?;
+        }
+        Ok(())
+    }
+
     /// Closes the writer and replaces the original file with the temporary file
     pub fn close(&mut self) -> io::Result<()> {
         let Some(dest_path) = &self.dest_path else {


### PR DESCRIPTION
FIX XET-531

There are issues in the cache code with state interior mutability such that we attempt to "smart evict" some items that overlap with the new items to be inserted, the file in the issue triggered this path in particular and exposed a bug causing the the total_bytes and num_items tracked by the cache to be incorrect that then caused a lot of other issues, namely evictions stopped working and cache puts were failing as a result.