### PR TITLE
Initial warning huggingface-hub < 0.30.0, no tests

### DIFF
--- a/hf_xet/.gitignore
+++ b/hf_xet/.gitignore
@@ -1,0 +1,2 @@
+python/**/*.so
+**/__pycache__*

--- a/hf_xet/python/hf_xet/__init__.py
+++ b/hf_xet/python/hf_xet/__init__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from importlib.metadata import version as _version, PackageNotFoundError
+from packaging.version import Version as _Version
+import warnings
+
+def get_hfhub_version() -> str:
+    try:
+        return _version("huggingface_hub")
+    except importlib.metadata.PackageNotFoundError:
+        # package is not installed
+        return "0.0.0"
+
+if _Version(get_hfhub_version()) < _Version("0.30.0"):
+    warnings.warn(
+        "To use hf_xet, huggingface_hub >= 0.30.0 is required. "
+        "Please update to the latest version for full functionality.",
+        UserWarning,
+    )


### PR DESCRIPTION
@jsulz: I'm not sure emitting this warning will ever be useful - because in order for this warning to happen the user has to do the following:

```
# pip install huggingface_hub==0.29.0
# pip install hf-xet

ipython
import hf_xet
```

Since users don't actually interact with `hf-xet` directly they won't run the import themselves, and no version of `huggingface-hub` < 0.30.0 will know to try importing `hf-xet`, so the user won't see the warning.

I am more and more inclined to close XET-461 as wontfix for these reasons.

Fixes [XET-461](https://linear.app/xet/issue/XET-461/hf-xet-should-emit-a-warning-if-in-a-python-environment-where)

I have tested this builds into the .whl from maturin