### PR TITLE
Adding session_id to requests and spans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -959,6 +959,8 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "tracing-test",
+ "ulid",
  "utils",
  "walkdir",
  "xet_threadpool",
@@ -4027,6 +4029,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand 0.9.0",
+ "web-time",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4278,6 +4290,16 @@ name = "web-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/cas_client/Cargo.toml
+++ b/cas_client/Cargo.toml
@@ -19,14 +19,14 @@ merkledb = { path = "../merkledb" }
 mdb_shard = { path = "../mdb_shard" }
 merklehash = { path = "../merklehash" }
 xet_threadpool = { path = "../xet_threadpool" }
-deduplication = {path = "../deduplication" }
+deduplication = { path = "../deduplication" }
 thiserror = "2.0"
 tokio = { version = "1.44", features = ["sync"] }
 async-trait = "0.1.9"
 anyhow = "1"
 http = "1.1.0"
 tempfile = "3.13.0"
-tracing = "0.1.31"
+tracing = "0.1.41"
 bytes = "1"
 itertools = "0.10"
 reqwest = { version = "0.12.7", features = ["json", "stream"] }

--- a/cas_client/src/download_utils.rs
+++ b/cas_client/src/download_utils.rs
@@ -18,6 +18,7 @@ use url::Url;
 use utils::singleflight::Group;
 
 use crate::error::{CasClientError, Result};
+use crate::http_client::Api;
 use crate::remote_client::{get_reconstruction_with_endpoint_and_client, PREFIX_DEFAULT};
 use crate::OutputProvider;
 
@@ -375,6 +376,7 @@ async fn download_range(
     let response = match http_client
         .get(url)
         .header(RANGE, fetch_term.url_range.range_header())
+        .with_extension(Api("s3::get_range"))
         .send()
         .await
         .map_err(CasClientError::from)
@@ -473,7 +475,7 @@ mod tests {
             MerkleHash::default(),
             file_range,
             server.base_url(),
-            Arc::new(build_http_client(RetryConfig::default())?),
+            Arc::new(build_http_client(RetryConfig::default(), "")?),
         );
 
         fetch_info.query().await?;
@@ -520,7 +522,7 @@ mod tests {
             MerkleHash::default(),
             file_range_to_refresh,
             server.base_url(),
-            Arc::new(build_http_client(RetryConfig::default())?),
+            Arc::new(build_http_client(RetryConfig::default(), "")?),
         ));
 
         // Spawn multiple tasks each calling into refresh with a different delay in
@@ -589,7 +591,7 @@ mod tests {
             MerkleHash::default(),
             file_range,
             server.base_url(),
-            Arc::new(build_http_client(RetryConfig::default())?),
+            Arc::new(build_http_client(RetryConfig::default(), "")?),
         );
 
         let (offset_info_first_range, terms) = fetch_info.query().await?.unwrap();
@@ -600,7 +602,7 @@ mod tests {
             take: file_range.length(),
             fetch_info: Arc::new(fetch_info),
             chunk_cache: None,
-            client: Arc::new(build_http_client(RetryConfig::default())?),
+            client: Arc::new(build_http_client(RetryConfig::default(), "")?),
             range_download_single_flight: Arc::new(Group::new()),
         };
 

--- a/cas_client/src/lib.rs
+++ b/cas_client/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
 pub use chunk_cache::{CacheConfig, CHUNK_CACHE_SIZE_BYTES};
-pub use http_client::{build_auth_http_client, build_http_client, RetryConfig};
+pub use http_client::{build_auth_http_client, build_http_client, Api, RetryConfig};
 use interface::RegistrationClient;
 pub use interface::{Client, FileProvider, OutputProvider, Reconstructable, ReconstructionClient, UploadClient};
 pub use local_client::LocalClient;

--- a/cas_client/src/remote_client.rs
+++ b/cas_client/src/remote_client.rs
@@ -23,7 +23,7 @@ use reqwest::{StatusCode, Url};
 use reqwest_middleware::ClientWithMiddleware;
 use tokio::sync::{mpsc, OwnedSemaphorePermit};
 use tokio::task::{JoinError, JoinHandle, JoinSet};
-use tracing::{debug, info};
+use tracing::{debug, info, instrument};
 use utils::auth::AuthConfig;
 use utils::progress::ProgressUpdater;
 use utils::singleflight::Group;
@@ -31,7 +31,7 @@ use xet_threadpool::ThreadPool;
 
 use crate::download_utils::*;
 use crate::error::{CasClientError, Result};
-use crate::http_client::{ResponseErrorLogger, RetryConfig};
+use crate::http_client::{Api, ResponseErrorLogger, RetryConfig};
 use crate::interface::{ShardDedupProber, *};
 use crate::{http_client, Client, RegistrationClient, ShardClientInterface};
 
@@ -71,6 +71,7 @@ pub struct RemoteClient {
 }
 
 impl RemoteClient {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         threadpool: Arc<ThreadPool>,
         endpoint: &str,
@@ -78,6 +79,7 @@ impl RemoteClient {
         auth: &Option<AuthConfig>,
         cache_config: &Option<CacheConfig>,
         shard_cache_directory: PathBuf,
+        session_id: &str,
         dry_run: bool,
     ) -> Self {
         // use disk cache if cache_config provided.
@@ -104,12 +106,12 @@ impl RemoteClient {
             compression,
             dry_run,
             authenticated_http_client: Arc::new(
-                http_client::build_auth_http_client(auth, RetryConfig::default()).unwrap(),
+                http_client::build_auth_http_client(auth, RetryConfig::default(), session_id).unwrap(),
             ),
             conservative_authenticated_http_client: Arc::new(
-                http_client::build_auth_http_client(auth, RetryConfig::no429retry()).unwrap(),
+                http_client::build_auth_http_client(auth, RetryConfig::no429retry(), session_id).unwrap(),
             ),
-            http_client: Arc::new(http_client::build_http_client(RetryConfig::default()).unwrap()),
+            http_client: Arc::new(http_client::build_http_client(RetryConfig::default(), session_id).unwrap()),
             chunk_cache,
             threadpool,
             range_download_single_flight,
@@ -212,7 +214,7 @@ pub(crate) async fn get_reconstruction_with_endpoint_and_client(
 ) -> Result<Option<QueryReconstructionResponse>> {
     let url = Url::parse(&format!("{}/reconstruction/{}", endpoint, file_id.hex()))?;
 
-    let mut request = client.get(url);
+    let mut request = client.get(url).with_extension(Api("cas::get_reconstruction"));
     if let Some(range) = bytes_range {
         // convert exclusive-end to inclusive-end range
         request = request.header(RANGE, HttpRange::from(range).range_header())
@@ -245,6 +247,7 @@ pub(crate) async fn get_reconstruction_with_endpoint_and_client(
 impl Client for RemoteClient {}
 
 impl RemoteClient {
+    #[instrument(skip_all, name = "RemoteClient::batch_get_reconstruction")]
     async fn batch_get_reconstruction(
         &self,
         file_ids: impl Iterator<Item = &MerkleHash>,
@@ -265,6 +268,7 @@ impl RemoteClient {
         let response = self
             .authenticated_http_client
             .get(url)
+            .with_extension(Api("cas::batch_get_reconstruction"))
             .send()
             .await
             .process_error("batch_get_reconstruction")?;
@@ -276,6 +280,7 @@ impl RemoteClient {
         Ok(query_reconstruction_response)
     }
 
+    #[instrument(skip_all, name="RemoteClient::upload_xorb", fields(key = key.to_string(), xorb.len = contents.len(), xorb.num_chunks = chunk_and_boundaries.len()))]
     pub async fn upload(
         &self,
         key: &Key,
@@ -299,6 +304,7 @@ impl RemoteClient {
             let response = self
                 .authenticated_http_client
                 .post(url)
+                .with_extension(Api("cas::upload_xorb"))
                 .body(data)
                 .send()
                 .await
@@ -315,6 +321,7 @@ impl RemoteClient {
     // at the beginning of the download, but queried in segments. Range downloads are executed with
     // a certain degree of parallelism, but writing out to storage is sequential. Ideal when the external
     // storage uses HDDs.
+    #[instrument(skip_all, name="RemoteClient::reconstruct_file_segmented", fields(file.hash = file_hash.hex()))]
     async fn reconstruct_file_to_writer_segmented(
         &self,
         file_hash: &MerkleHash,
@@ -457,6 +464,7 @@ impl RemoteClient {
     // at the beginning of the download, but queried in segments. Range downloads are executed with
     // a certain degree of parallelism, and so does writing out to storage. Ideal when the external
     // storage is fast at seeks, e.g. RAM or SSDs.
+    #[instrument(skip_all, name="RemoteClient::reconstruct_file_segmented_parallel", fields(file.hash = file_hash.hex()))]
     async fn reconstruct_file_to_writer_segmented_parallel_write(
         &self,
         file_hash: &MerkleHash,
@@ -597,6 +605,7 @@ impl RemoteClient {
 
 #[async_trait]
 impl RegistrationClient for RemoteClient {
+    #[instrument(skip_all, name="RemoteClient::upload_shard", fields(shard.hash = hash.hex(), shard.len = shard_data.len()))]
     async fn upload_shard(
         &self,
         prefix: &str,
@@ -624,6 +633,7 @@ impl RegistrationClient for RemoteClient {
         let response = self
             .authenticated_http_client
             .request(method, url)
+            .with_extension(Api("cas::upload_shard"))
             .body(shard_data.to_vec())
             .send()
             .await
@@ -641,6 +651,7 @@ impl RegistrationClient for RemoteClient {
 
 #[async_trait]
 impl FileReconstructor<CasClientError> for RemoteClient {
+    #[instrument(skip_all, name="RemoteClient::get_file_reconstruction", fields(file.hash = file_hash.hex()))]
     async fn get_file_reconstruction_info(
         &self,
         file_hash: &MerkleHash,
@@ -650,6 +661,7 @@ impl FileReconstructor<CasClientError> for RemoteClient {
         let response = self
             .authenticated_http_client
             .get(url)
+            .with_extension(Api("cas::get_reconstruction_info"))
             .send()
             .await
             .process_error("get_reconstruction_info")?;
@@ -675,6 +687,7 @@ impl FileReconstructor<CasClientError> for RemoteClient {
 
 #[async_trait]
 impl ShardDedupProber for RemoteClient {
+    #[instrument(skip_all, name = "RemoteClient::query_global_dedup")]
     async fn query_for_global_dedup_shard(
         &self,
         prefix: &str,
@@ -699,6 +712,7 @@ impl ShardDedupProber for RemoteClient {
         let mut response = self
             .conservative_authenticated_http_client
             .get(url)
+            .with_extension(Api("cas::query_dedup"))
             .send()
             .await
             .map_err(|e| CasClientError::Other(format!("request failed with error {e}")))?;
@@ -761,6 +775,7 @@ mod tests {
             &None,
             &None,
             "".into(),
+            "",
             false,
         );
         // Act
@@ -1132,7 +1147,7 @@ mod tests {
 
         // test reconstruct and sequential write
         let test = test_case.clone();
-        let client = RemoteClient::new(threadpool.clone(), endpoint, None, &None, &None, "".into(), false);
+        let client = RemoteClient::new(threadpool.clone(), endpoint, None, &None, &None, "".into(), "", false);
         let provider = BufferProvider::default();
         let buf = provider.buf.clone();
         let writer = OutputProvider::Buffer(provider);
@@ -1150,7 +1165,7 @@ mod tests {
 
         // test reconstruct and parallel write
         let test = test_case;
-        let client = RemoteClient::new(threadpool.clone(), endpoint, None, &None, &None, "".into(), false);
+        let client = RemoteClient::new(threadpool.clone(), endpoint, None, &None, &None, "".into(), "", false);
         let provider = BufferProvider::default();
         let buf = provider.buf.clone();
         let writer = OutputProvider::Buffer(provider);

--- a/cas_object/src/cas_object_format.rs
+++ b/cas_object/src/cas_object_format.rs
@@ -272,6 +272,7 @@ impl CasObjectInfoV0 {
     }
 }
 
+#[allow(clippy::empty_line_after_doc_comments)]
 #[derive(Clone, PartialEq, Eq, Debug, Serialize)]
 /// Info struct for [CasObject]. This is stored at the end of the XORB.
 pub struct CasObjectInfoV1 {

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -43,6 +43,7 @@ dirs = "5.0.1"
 walkdir = "2.5.0"
 more-asserts = "0.3.1"
 serde = { version = "1.0.215", features = ["derive"] }
+ulid = "1.2.1"
 
 # metrics
 prometheus = "0.13.0"
@@ -74,6 +75,7 @@ sha2 = { version = "0.10.8" }
 
 [dev-dependencies]
 serial_test = "3.2.0"
+tracing-test = "0.2.5"
 
 [features]
 strict = []

--- a/data/src/configurations.rs
+++ b/data/src/configurations.rs
@@ -75,6 +75,7 @@ pub struct TranslatorConfig {
     pub data_config: DataConfig,
     pub shard_config: ShardConfig,
     pub repo_info: Option<RepoInfo>,
+    pub session_id: Option<String>,
 }
 
 impl TranslatorConfig {
@@ -104,6 +105,7 @@ impl TranslatorConfig {
             repo_info: Some(RepoInfo {
                 repo_paths: vec!["".into()],
             }),
+            session_id: None,
         };
 
         Ok(Arc::new(translator_config))

--- a/data/src/data_client.rs
+++ b/data/src/data_client.rs
@@ -11,6 +11,8 @@ use cas_object::CompressionScheme;
 use deduplication::DeduplicationMetrics;
 use dirs::home_dir;
 use parutils::{tokio_par_for_each, ParallelError};
+use tracing::{info_span, instrument, Instrument, Span};
+use ulid::Ulid;
 use utils::auth::{AuthConfig, TokenRefresher};
 use utils::progress::ProgressUpdater;
 use xet_threadpool::ThreadPool;
@@ -89,12 +91,14 @@ pub fn default_config(
         repo_info: Some(RepoInfo {
             repo_paths: vec!["".into()],
         }),
+        session_id: Some(Ulid::new().to_string()),
     };
 
     // Return the temp dir so that it's not dropped and thus the directory deleted.
     Ok(Arc::new(translator_config))
 }
 
+#[instrument(skip_all, name = "data_client::upload_bytes", fields(session_id = tracing::field::Empty, num_files=file_contents.len()))]
 pub async fn upload_bytes_async(
     thread_pool: Arc<ThreadPool>,
     file_contents: Vec<Vec<u8>>,
@@ -104,13 +108,18 @@ pub async fn upload_bytes_async(
     progress_updater: Option<Arc<dyn ProgressUpdater>>,
 ) -> errors::Result<Vec<XetFileInfo>> {
     let config = default_config(endpoint.unwrap_or(DEFAULT_CAS_ENDPOINT.clone()), None, token_info, token_refresher)?;
+    Span::current().record("session_id", &config.session_id);
 
     let upload_session = FileUploadSession::new(config, thread_pool, progress_updater).await?;
+    let files_plus = add_spans(file_contents, || info_span!("clean_task"));
 
     // clean the bytes
-    let files = tokio_par_for_each(file_contents, *MAX_CONCURRENT_FILE_INGESTION, |file_data, _| async {
-        let (xf, _metrics) = clean_bytes(upload_session.clone(), file_data).await?;
-        Ok(xf)
+    let files = tokio_par_for_each(files_plus, *MAX_CONCURRENT_FILE_INGESTION, |(file_data, span), _| {
+        async {
+            let (xf, _metrics) = clean_bytes(upload_session.clone(), file_data).await?;
+            Ok(xf)
+        }
+        .instrument(span.unwrap_or_else(|| info_span!("unexpected_span")))
     })
     .await
     .map_err(|e| match e {
@@ -124,6 +133,7 @@ pub async fn upload_bytes_async(
     Ok(files)
 }
 
+#[instrument(skip_all, name = "data_client::upload_files", fields(session_id = tracing::field::Empty, num_files=file_paths.len()))]
 pub async fn upload_async(
     thread_pool: Arc<ThreadPool>,
     file_paths: Vec<String>,
@@ -137,13 +147,18 @@ pub async fn upload_async(
     // upload shards and xorbs
     // for each file, return the filehash
     let config = default_config(endpoint.unwrap_or(DEFAULT_CAS_ENDPOINT.clone()), None, token_info, token_refresher)?;
+    Span::current().record("session_id", &config.session_id);
 
     let upload_session = FileUploadSession::new(config, thread_pool, progress_updater).await?;
+    let files_plus = add_spans(file_paths, || info_span!("clean_file_task"));
 
     // for all files, clean them, producing pointer files.
-    let files = tokio_par_for_each(file_paths, *MAX_CONCURRENT_FILE_INGESTION, |f, _| async {
-        let (xf, _metrics) = clean_file(upload_session.clone(), f).await?;
-        Ok(xf)
+    let files = tokio_par_for_each(files_plus, *MAX_CONCURRENT_FILE_INGESTION, |(f, span), _| {
+        async {
+            let (xf, _metrics) = clean_file(upload_session.clone(), f).await?;
+            Ok(xf)
+        }
+        .instrument(span.unwrap_or_else(|| info_span!("unexpected_span")))
     })
     .await
     .map_err(|e| match e {
@@ -159,6 +174,7 @@ pub async fn upload_async(
     Ok(files)
 }
 
+#[instrument(skip_all, name = "data_client::download", fields(session_id = tracing::field::Empty, num_files=file_infos.len()))]
 pub async fn download_async(
     threadpool: Arc<ThreadPool>,
     file_infos: Vec<(XetFileInfo, String)>,
@@ -176,20 +192,25 @@ pub async fn download_async(
     }
     let config =
         default_config(endpoint.unwrap_or(DEFAULT_CAS_ENDPOINT.to_string()), None, token_info, token_refresher)?;
+    Span::current().record("session_id", &config.session_id);
 
     let updaters = match progress_updaters {
         None => vec![None; file_infos.len()],
         Some(updaters) => updaters.into_iter().map(Some).collect(),
     };
     let pointer_files_plus = file_infos.into_iter().zip(updaters).collect::<Vec<_>>();
+    let pointer_files_plus = add_spans(pointer_files_plus, || info_span!("download_file"));
 
     let processor = &Arc::new(FileDownloader::new(config, threadpool).await?);
     let paths = tokio_par_for_each(
         pointer_files_plus,
         *MAX_CONCURRENT_DOWNLOADS,
-        |((file_info, file_path), updater), _| async move {
-            let proc = processor.clone();
-            smudge_file(&proc, &file_info, &file_path, updater).await
+        |(((file_info, file_path), updater), span), _| {
+            async move {
+                let proc = processor.clone();
+                smudge_file(&proc, &file_info, &file_path, updater).await
+            }
+            .instrument(span.unwrap_or_else(|| info_span!("unexpected_span")))
         },
     )
     .await
@@ -201,6 +222,7 @@ pub async fn download_async(
     Ok(paths)
 }
 
+#[instrument(skip_all, name = "clean_bytes", fields(bytes.len = bytes.len()))]
 pub async fn clean_bytes(
     processor: Arc<FileUploadSession>,
     bytes: Vec<u8>,
@@ -210,6 +232,7 @@ pub async fn clean_bytes(
     handle.finish().await
 }
 
+#[instrument(skip_all, name = "clean_file", fields(file.name = tracing::field::Empty, file.len = tracing::field::Empty))]
 pub async fn clean_file(
     processor: Arc<FileUploadSession>,
     filename: impl AsRef<Path>,
@@ -217,6 +240,9 @@ pub async fn clean_file(
     let mut reader = File::open(&filename)?;
 
     let n = reader.metadata()?.len() as usize;
+    let span = Span::current();
+    span.record("file.name", &filename.as_ref().to_str());
+    span.record("file.len", n);
     let mut buffer = vec![0u8; usize::min(n, *INGESTION_BLOCK_SIZE)];
 
     let mut handle = processor.start_clean(Some(filename.as_ref().to_string_lossy().into()));
@@ -250,12 +276,23 @@ async fn smudge_file(
     Ok(file_path.to_string())
 }
 
+/// Adds spans to the indicated list for each element.
+///
+/// Although a span will be added for each element, we need an Option<Span> since
+/// tokio_par_for_each requires the input list be Default, which Span isn't.
+pub fn add_spans<I, F: Fn() -> Span>(v: Vec<I>, create_span: F) -> Vec<(I, Option<Span>)> {
+    let spans: Vec<Option<Span>> = v.iter().map(|_| Some(create_span())).collect();
+    v.into_iter().zip(spans).collect()
+}
+
 #[cfg(test)]
 mod tests {
     use std::env;
 
     use serial_test::serial;
     use tempfile::tempdir;
+    use tracing::info;
+    use tracing_test::traced_test;
 
     use super::*;
 
@@ -341,5 +378,42 @@ mod tests {
         assert!(result.is_ok());
         let config = result.unwrap();
         assert!(config.data_config.cache_config.cache_directory.starts_with(&expected));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[traced_test]
+    async fn test_add_spans() {
+        let outer_span = info_span!("outer_span");
+        async {
+            let v = vec!["a", "b", "c"];
+            let expected_len = v.len();
+            let v_plus = add_spans(v, || info_span!("task_span"));
+            assert_eq!(v_plus.len(), expected_len);
+            tokio_par_for_each(v_plus, expected_len, |(s, span), i| {
+                async move {
+                    info!("inside: {s},{i}");
+                    Ok::<(), ()>(())
+                }
+                .instrument(span.unwrap())
+            })
+            .await
+            .unwrap();
+        }
+        .instrument(outer_span)
+        .await;
+
+        assert!(logs_contain("inside: a,0"));
+        assert!(logs_contain("inside: b,1"));
+        assert!(logs_contain("inside: c,2"));
+        logs_assert(|lines: &[&str]| {
+            match lines
+                .iter()
+                .filter(|line| line.contains("task_span") && line.contains("outer_span"))
+                .count()
+            {
+                3 => Ok(()),
+                n => Err(format!("Expected 3 lines, got {n}")),
+            }
+        });
     }
 }

--- a/data/src/data_client.rs
+++ b/data/src/data_client.rs
@@ -241,7 +241,7 @@ pub async fn clean_file(
 
     let n = reader.metadata()?.len() as usize;
     let span = Span::current();
-    span.record("file.name", &filename.as_ref().to_str());
+    span.record("file.name", filename.as_ref().to_str());
     span.record("file.len", n);
     let mut buffer = vec![0u8; usize::min(n, *INGESTION_BLOCK_SIZE)];
 

--- a/data/src/file_cleaner.rs
+++ b/data/src/file_cleaner.rs
@@ -6,7 +6,7 @@ use deduplication::{Chunk, Chunker, DeduplicationMetrics, FileDeduper};
 use mdb_shard::file_structs::FileMetadataExt;
 use merklehash::MerkleHash;
 use tokio::task::{JoinError, JoinHandle};
-use tracing::info;
+use tracing::{info, info_span, instrument, Instrument};
 
 use crate::constants::INGESTION_BLOCK_SIZE;
 use crate::deduplication_interface::UploadSessionDataManager;
@@ -119,13 +119,18 @@ impl SingleFileCleaner {
     /// new background task.
     async fn deduper_process_chunks(&mut self, chunks: Arc<[Chunk]>) -> Result<()> {
         let mut deduper = self.get_deduper().await?;
-        self.dedup_manager = DedupManagerBackgrounder::Background(tokio::spawn(async move {
-            let res = deduper.get_mut().process_chunks(&chunks).await;
-            Ok((deduper, res))
-        }));
+        let num_chunks = chunks.len();
+        self.dedup_manager = DedupManagerBackgrounder::Background(tokio::spawn(
+            async move {
+                let res = deduper.get_mut().process_chunks(&chunks).await;
+                Ok((deduper, res))
+            }
+            .instrument(info_span!("deduper::process_chunks_task", num_chunks)),
+        ));
         Ok(())
     }
 
+    #[instrument(skip_all, name = "FileCleaner::add_data", fields(file_name=self.file_name, len=data.len()))]
     pub async fn add_data(&mut self, data: &[u8]) -> Result<()> {
         if data.len() > *INGESTION_BLOCK_SIZE {
             let mut pos = 0;
@@ -160,6 +165,7 @@ impl SingleFileCleaner {
     }
 
     /// Return the representation of the file after clean as a pointer file instance.
+    #[instrument(skip_all, name = "FileCleaner:::finish", fields(file_name=self.file_name))]
     pub async fn finish(mut self) -> Result<(XetFileInfo, DeduplicationMetrics)> {
         // Chunk the rest of the data.
         // note that get_deduper returns the only reference to the deduper
@@ -183,17 +189,14 @@ impl SingleFileCleaner {
 
         let file_info = XetFileInfo::new(file_hash.hex(), deduplication_metrics.total_bytes);
 
-        // Let's check some things that should be invarients
+        // Let's check some things that should be invariants
         #[cfg(debug_assertions)]
         {
             // There should be exactly one file referenced in the remaining file data.
             debug_assert_eq!(remaining_file_data.pending_file_info.len(), 1);
 
             // The size should be total bytes
-            debug_assert_eq!(
-                remaining_file_data.pending_file_info[0].0.file_size(),
-                deduplication_metrics.total_bytes as usize
-            )
+            debug_assert_eq!(remaining_file_data.pending_file_info[0].0.file_size(), deduplication_metrics.total_bytes)
         }
 
         // Now, return all this information to the

--- a/data/src/file_cleaner.rs
+++ b/data/src/file_cleaner.rs
@@ -165,7 +165,7 @@ impl SingleFileCleaner {
     }
 
     /// Return the representation of the file after clean as a pointer file instance.
-    #[instrument(skip_all, name = "FileCleaner:::finish", fields(file_name=self.file_name))]
+    #[instrument(skip_all, name = "FileCleaner::finish", fields(file_name=self.file_name))]
     pub async fn finish(mut self) -> Result<(XetFileInfo, DeduplicationMetrics)> {
         // Chunk the rest of the data.
         // note that get_deduper returns the only reference to the deduper

--- a/data/src/file_downloader.rs
+++ b/data/src/file_downloader.rs
@@ -1,8 +1,11 @@
+use std::borrow::Cow;
 use std::sync::Arc;
 
 use cas_client::{Client, OutputProvider};
 use cas_types::FileRange;
 use merklehash::MerkleHash;
+use tracing::instrument;
+use ulid::Ulid;
 use utils::progress::ProgressUpdater;
 use xet_threadpool::ThreadPool;
 
@@ -25,11 +28,17 @@ pub struct FileDownloader {
 /// Smudge operations
 impl FileDownloader {
     pub async fn new(config: Arc<TranslatorConfig>, threadpool: Arc<ThreadPool>) -> Result<Self> {
-        let client = create_remote_client(&config, threadpool.clone(), false)?;
+        let session_id = config
+            .session_id
+            .as_ref()
+            .map(Cow::Borrowed)
+            .unwrap_or_else(|| Cow::Owned(Ulid::new().to_string()));
+        let client = create_remote_client(&config, threadpool.clone(), &session_id, false)?;
 
         Ok(Self { config, client })
     }
 
+    #[instrument(skip_all, name = "FileDownloader::smudge_file_from_hash", fields(hash=file_id.hex()))]
     pub async fn smudge_file_from_hash(
         &self,
         file_id: &MerkleHash,

--- a/data/src/migration_tool/hub_client.rs
+++ b/data/src/migration_tool/hub_client.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
-use cas_client::{build_http_client, RetryConfig};
+use cas_client::{build_http_client, Api, RetryConfig};
 use reqwest_middleware::ClientWithMiddleware;
 use utils::auth::{TokenInfo, TokenRefresher};
 use utils::errors::AuthError;
@@ -39,6 +39,7 @@ impl HubClient {
         let response = self
             .client
             .get(url)
+            .with_extension(Api("xet-token"))
             .bearer_auth(&self.token)
             .header("user-agent", "xtool")
             .send()

--- a/data/src/migration_tool/hub_client.rs
+++ b/data/src/migration_tool/hub_client.rs
@@ -24,7 +24,7 @@ impl HubClient {
             token: token.to_owned(),
             repo_type: repo_type.to_owned(),
             repo_id: repo_id.to_owned(),
-            client: build_http_client(RetryConfig::default())?,
+            client: build_http_client(RetryConfig::default(), "")?,
         })
     }
 
@@ -105,7 +105,7 @@ mod tests {
             token: "[MASKED]".to_owned(),
             repo_type: "dataset".to_owned(),
             repo_id: "test/t2".to_owned(),
-            client: build_http_client(RetryConfig::default())?,
+            client: build_http_client(RetryConfig::default(), "")?,
         };
 
         let (cas_endpoint, jwt_token, jwt_token_expiry) = hub_client.get_jwt_token("read").await?;

--- a/data/src/migration_tool/migrate.rs
+++ b/data/src/migration_tool/migrate.rs
@@ -43,6 +43,9 @@ pub async fn migrate_with_external_runtime(
     Ok(())
 }
 
+/// mdb file info (if dryrun), cleaned file info, total bytes uploaded
+pub type MigrationInfo = (Vec<MDBFileInfo>, Vec<(XetFileInfo, u64)>, u64);
+
 #[instrument(skip_all, name = "migrate_files", fields(session_id = tracing::field::Empty, num_files = file_paths.len()))]
 pub async fn migrate_files_impl(
     file_paths: Vec<String>,
@@ -52,7 +55,7 @@ pub async fn migrate_files_impl(
     threadpool: Arc<ThreadPool>,
     compression: Option<CompressionScheme>,
     dry_run: bool,
-) -> Result<(Vec<MDBFileInfo>, Vec<(XetFileInfo, u64)>, u64)> {
+) -> Result<MigrationInfo> {
     let token_type = "write";
     let (endpoint, jwt_token, jwt_token_expiry) = hub_client.get_jwt_token(token_type).await?;
     let token_refresher = Arc::new(HubClientTokenRefresher {

--- a/data/src/migration_tool/migrate.rs
+++ b/data/src/migration_tool/migrate.rs
@@ -75,9 +75,9 @@ pub async fn migrate_files_impl(
         FileUploadSession::new(config, threadpool, None).await?
     };
 
-    let file_paths_plus = add_spans(file_paths, || info_span!("migration::clean_file"));
+    let file_paths_with_spans = add_spans(file_paths, || info_span!("migration::clean_file"));
 
-    let clean_ret = tokio_par_for_each(file_paths_plus, num_workers, |(f, span), _| {
+    let clean_ret = tokio_par_for_each(file_paths_with_spans, num_workers, |(f, span), _| {
         async {
             let proc = processor.clone();
             let (pf, metrics) = clean_file(proc, f).await?;

--- a/data/src/remote_client_interface.rs
+++ b/data/src/remote_client_interface.rs
@@ -10,6 +10,7 @@ use crate::errors::Result;
 pub(crate) fn create_remote_client(
     config: &TranslatorConfig,
     threadpool: Arc<ThreadPool>,
+    session_id: &str,
     dry_run: bool,
 ) -> Result<Arc<dyn Client + Send + Sync>> {
     let cas_storage_config = &config.data_config;
@@ -22,6 +23,7 @@ pub(crate) fn create_remote_client(
             &cas_storage_config.auth,
             &Some(cas_storage_config.cache_config.clone()),
             config.shard_config.cache_directory.clone(),
+            session_id,
             dry_run,
         ))),
         Endpoint::FileSystem(ref path) => Ok(Arc::new(LocalClient::new(path, None)?)),

--- a/hf_xet/Cargo.lock
+++ b/hf_xet/Cargo.lock
@@ -329,7 +329,7 @@ dependencies = [
  "merklehash",
  "more-asserts",
  "parutils",
- "rand 0.8.5",
+ "rand 0.9.0",
  "serde",
  "thiserror 2.0.11",
  "tokio",
@@ -689,6 +689,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "ulid",
  "utils",
  "walkdir",
  "xet_threadpool",
@@ -828,12 +829,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -909,12 +910,6 @@ name = "fragile"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
@@ -1714,9 +1709,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -1782,11 +1777,11 @@ dependencies = [
  "itertools 0.13.0",
  "lazy_static",
  "merklehash",
- "rand 0.8.5",
+ "rand 0.9.0",
  "regex",
  "serde",
  "static_assertions",
- "tempdir",
+ "tempfile",
  "thiserror 2.0.11",
  "tokio",
  "tracing",
@@ -1830,16 +1825,14 @@ dependencies = [
  "gearhash",
  "lazy_static",
  "merklehash",
- "parutils",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
+ "rand_chacha 0.9.0",
  "rayon",
  "rustc-hash",
  "serde",
  "tempfile",
  "thiserror 2.0.11",
  "tracing",
+ "utils",
  "walkdir",
 ]
 
@@ -2495,19 +2488,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
@@ -2550,21 +2530,6 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
-name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
@@ -2599,15 +2564,6 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2682,15 +2638,6 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "reqwest"
@@ -2861,15 +2808,15 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.41"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3303,23 +3250,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
-]
-
-[[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
- "cfg-if 1.0.0",
  "fastrand",
+ "getrandom 0.3.1",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -3517,9 +3454,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -3528,9 +3465,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3539,9 +3476,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -3612,6 +3549,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand 0.9.0",
+ "web-time",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3674,7 +3621,6 @@ dependencies = [
  "thiserror 2.0.11",
  "tokio",
  "tracing",
- "xet_threadpool",
 ]
 
 [[package]]
@@ -3684,6 +3630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
  "getrandom 0.2.15",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3847,6 +3794,16 @@ name = "web-sys"
 version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/mdb_shard/src/shard_file_manager.rs
+++ b/mdb_shard/src/shard_file_manager.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use merklehash::{HMACKey, MerkleHash};
 use tokio::sync::RwLock;
-use tracing::{debug, info, trace};
+use tracing::{debug, info, instrument, trace};
 
 use crate::cas_structs::*;
 use crate::constants::{CHUNK_INDEX_TABLE_MAX_SIZE, MDB_SHARD_EXPIRATION_BUFFER_SECS, MDB_SHARD_MIN_TARGET_SIZE};
@@ -427,6 +427,7 @@ impl ShardFileManager {
 
     /// Flush the current state of the in-memory lookups to a shard in the session directory,
     /// returning the hash of the shard and the file written, or None if no file was written.
+    #[instrument(skip_all, name = "ShardFileManager::flush")]
     pub async fn flush(&self) -> Result<Option<PathBuf>> {
         let new_shard_path;
 


### PR DESCRIPTION
* Creates a session_id whenever the `data_client` is used or a FileUploadSession/FileDownloader is created to be propagated to the new remote clients.
* Adds a middleware to http clients to push the session_id into the `X-Xet-Session-Id` header for outgoing requests (CAS is already configured to accept this header).
* Adds info-level spans to the key parts of xet-core for cases where xet-core is used as a library by long-running systems (e.g. migration service or internal systems) for aid in debugging / tracing (essentially bringing: https://github.com/huggingface/xet-core/pull/82 up to current minus the hf_xet logging changes).