### PR TITLE
Fix some CAS info missing from shard bug

### DIFF
--- a/data/src/deduplication_interface.rs
+++ b/data/src/deduplication_interface.rs
@@ -88,12 +88,8 @@ impl DeduplicationDataInterface for UploadSessionDataManager {
 
     /// Registers a Xorb of new data that has no deduplication references.
     async fn register_new_xorb(&mut self, xorb: RawXorbData) -> Result<()> {
-        // Add the xorb info to the current shard.  Note that we need to ensure all the xorb
-        // uploads complete correctly before any shards get uploaded.
-        self.session.shard_interface.add_cas_block(xorb.cas_info.clone()).await?;
-
         // Begin the process for upload.
-        self.session.register_new_xorb_for_upload(xorb).await?;
+        self.session.register_new_xorb(xorb).await?;
 
         Ok(())
     }

--- a/data/src/file_upload_session.rs
+++ b/data/src/file_upload_session.rs
@@ -304,9 +304,9 @@ impl FileUploadSession {
         if xorb.num_bytes() > 0 {
             // Add the xorb info to the current shard.
             self.shard_interface.add_cas_block(xorb.cas_info.clone()).await?;
-
-            self.register_new_xorb_for_upload(xorb).await?;
         }
+
+        self.register_new_xorb_for_upload(xorb).await?;
 
         // Now, we need to scan all the file dependencies for dependencies on this xorb, as
         // these would not have been registered yet.
@@ -315,7 +315,7 @@ impl FileUploadSession {
 
         {
             for (file_id, fi, bytes_in_xorb) in new_files {
-                if xorb_hash != MerkleHash::default() && bytes_in_xorb != 0 {
+                if xorb_hash == MerkleHash::default() || bytes_in_xorb != 0 {
                     new_dependencies.push((file_id, xorb_hash, bytes_in_xorb, false));
                 }
 

--- a/data/src/file_upload_session.rs
+++ b/data/src/file_upload_session.rs
@@ -301,6 +301,9 @@ impl FileUploadSession {
         debug_assert_le!(xorb.num_bytes(), *MAX_XORB_BYTES);
         debug_assert_le!(xorb.data.len(), *MAX_XORB_CHUNKS);
 
+        // Add the xorb info to the current shard.
+        self.shard_interface.add_cas_block(xorb.cas_info.clone()).await?;
+
         // Now, we need to scan all the file dependencies for dependencies on this xorb, as
         // these would not have been registered yet.
         self.register_new_xorb_for_upload(xorb).await?;

--- a/data/src/progress_tracking.rs
+++ b/data/src/progress_tracking.rs
@@ -82,10 +82,10 @@ impl CompletionTrackerImpl {
     ) -> Vec<ProgressUpdate> {
         let mut ret = Vec::new();
 
-        for &(file_id, xorb_hash, n_bytes, is_completed) in dependencies {
+        for &(file_id, xorb_hash, n_bytes, is_external_xorb) in dependencies {
             let file_entry = &mut self.files[file_id as usize];
 
-            if is_completed {
+            if is_external_xorb {
                 file_entry.completed_bytes += n_bytes;
                 debug_assert_le!(file_entry.completed_bytes, file_entry.total_bytes);
 


### PR DESCRIPTION
CAS info left in the DataAggregator are not registered to the session shard, and thus will not be added to global dedup. This PR fixes this bug.