### PR TITLE
Replace passed-around threadpool refs with thread local variable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4575,6 +4575,7 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 name = "xet_threadpool"
 version = "0.1.0"
 dependencies = [
+ "lazy_static",
  "thiserror 2.0.11",
  "tokio",
  "tracing",

--- a/cas_client/src/remote_client.rs
+++ b/cas_client/src/remote_client.rs
@@ -775,7 +775,7 @@ mod tests {
         let prefix = PREFIX_DEFAULT;
         let (c, _, data, chunk_boundaries) = build_cas_object(3, ChunkSize::Random(512, 10248), CompressionScheme::LZ4);
 
-        let threadpool = Arc::new(ThreadPool::new().unwrap());
+        let threadpool = ThreadPool::new().unwrap();
         let client = RemoteClient::new(
             threadpool.clone(),
             CAS_ENDPOINT,
@@ -1151,7 +1151,7 @@ mod tests {
     }
 
     fn test_reconstruct_file(test_case: TestCase, endpoint: &str) -> Result<()> {
-        let threadpool = Arc::new(ThreadPool::new()?);
+        let threadpool = ThreadPool::new()?;
 
         // test reconstruct and sequential write
         let test = test_case.clone();

--- a/cas_client/src/remote_client.rs
+++ b/cas_client/src/remote_client.rs
@@ -65,7 +65,6 @@ pub struct RemoteClient {
     authenticated_http_client: Arc<ClientWithMiddleware>,
     conservative_authenticated_http_client: Arc<ClientWithMiddleware>,
     chunk_cache: Option<Arc<dyn ChunkCache>>,
-    threadpool: Arc<ThreadPool>,
     range_download_single_flight: RangeDownloadSingleFlight,
     shard_cache_directory: PathBuf,
 }
@@ -73,7 +72,6 @@ pub struct RemoteClient {
 impl RemoteClient {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        threadpool: Arc<ThreadPool>,
         endpoint: &str,
         compression: Option<CompressionScheme>,
         auth: &Option<AuthConfig>,
@@ -113,7 +111,6 @@ impl RemoteClient {
             ),
             http_client: Arc::new(http_client::build_http_client(RetryConfig::default(), session_id).unwrap()),
             chunk_cache,
-            threadpool,
             range_download_single_flight,
             shard_cache_directory,
         }
@@ -353,14 +350,14 @@ impl RemoteClient {
         // download tasks are enqueued and spawned with the degree of concurrency equal to `num_concurrent_range_gets`.
         // After the above, a task that defines fetching the remainder of the file reconstruction info is enqueued,
         // which will execute after the first of the above term download tasks finishes.
-        let threadpool = self.threadpool.clone();
+        let threadpool = ThreadPool::current();
         let chunk_cache = self.chunk_cache.clone();
         let term_download_client = self.http_client.clone();
         let range_download_single_flight = self.range_download_single_flight.clone();
         let download_scheduler = DownloadScheduler::new(*NUM_CONCURRENT_RANGE_GETS);
         let download_scheduler_clone = download_scheduler.clone();
 
-        let queue_dispatcher: JoinHandle<Result<()>> = self.threadpool.spawn(async move {
+        let queue_dispatcher: JoinHandle<Result<()>> = threadpool.clone().spawn(async move {
             let mut remaining_total_len = total_len;
             while let Some(item) = task_rx.recv().await {
                 match item {
@@ -776,16 +773,8 @@ mod tests {
         let (c, _, data, chunk_boundaries) = build_cas_object(3, ChunkSize::Random(512, 10248), CompressionScheme::LZ4);
 
         let threadpool = ThreadPool::new().unwrap();
-        let client = RemoteClient::new(
-            threadpool.clone(),
-            CAS_ENDPOINT,
-            Some(CompressionScheme::LZ4),
-            &None,
-            &None,
-            "".into(),
-            "",
-            false,
-        );
+
+        let client = RemoteClient::new(CAS_ENDPOINT, Some(CompressionScheme::LZ4), &None, &None, "".into(), "", false);
         // Act
         let result = threadpool
             .external_run_async_task(async move { client.put(prefix, &c.info.cashash, data, chunk_boundaries).await })
@@ -1155,7 +1144,7 @@ mod tests {
 
         // test reconstruct and sequential write
         let test = test_case.clone();
-        let client = RemoteClient::new(threadpool.clone(), endpoint, None, &None, &None, "".into(), "", false);
+        let client = RemoteClient::new(endpoint, None, &None, &None, "".into(), "", false);
         let provider = BufferProvider::default();
         let buf = provider.buf.clone();
         let writer = OutputProvider::Buffer(provider);
@@ -1173,7 +1162,7 @@ mod tests {
 
         // test reconstruct and parallel write
         let test = test_case;
-        let client = RemoteClient::new(threadpool.clone(), endpoint, None, &None, &None, "".into(), "", false);
+        let client = RemoteClient::new(endpoint, None, &None, &None, "".into(), "", false);
         let provider = BufferProvider::default();
         let buf = provider.buf.clone();
         let writer = OutputProvider::Buffer(provider);

--- a/data/src/bin/example.rs
+++ b/data/src/bin/example.rs
@@ -88,9 +88,7 @@ async fn clean(mut reader: impl Read, mut writer: impl Write, size: u64) -> Resu
 
     let mut read_buf = vec![0u8; READ_BLOCK_SIZE];
 
-    let translator =
-        FileUploadSession::new(TranslatorConfig::local_config(std::env::current_dir()?)?, get_threadpool(), None)
-            .await?;
+    let translator = FileUploadSession::new(TranslatorConfig::local_config(std::env::current_dir()?)?, None).await?;
 
     let mut size_read = 0;
     let mut handle = translator.start_clean(None, size).await;
@@ -135,8 +133,7 @@ async fn smudge(name: Arc<str>, mut reader: impl Read, writer: &OutputProvider) 
     let xet_file: XetFileInfo = serde_json::from_str(&input)
         .map_err(|_| anyhow::anyhow!("Failed to parse xet file info. Please check the format."))?;
 
-    let downloader =
-        FileDownloader::new(TranslatorConfig::local_config(std::env::current_dir()?)?, get_threadpool()).await?;
+    let downloader = FileDownloader::new(TranslatorConfig::local_config(std::env::current_dir()?)?).await?;
 
     downloader
         .smudge_file_from_hash(

--- a/data/src/bin/example.rs
+++ b/data/src/bin/example.rs
@@ -60,7 +60,7 @@ impl Command {
 fn get_threadpool() -> Arc<ThreadPool> {
     static THREADPOOL: OnceLock<Arc<ThreadPool>> = OnceLock::new();
     THREADPOOL
-        .get_or_init(|| Arc::new(ThreadPool::new().expect("Error starting multithreaded runtime.")))
+        .get_or_init(|| ThreadPool::new().expect("Error starting multithreaded runtime."))
         .clone()
 }
 

--- a/data/src/bin/xtool.rs
+++ b/data/src/bin/xtool.rs
@@ -172,7 +172,7 @@ fn is_git_special_files(path: &str) -> bool {
 
 fn main() -> Result<()> {
     let cli = XCommand::parse();
-    let threadpool = Arc::new(ThreadPool::new()?);
+    let threadpool = ThreadPool::new()?;
     let threadpool_internal = threadpool.clone();
     threadpool.external_run_async_task(async move { cli.run(threadpool_internal).await })??;
 

--- a/data/src/file_downloader.rs
+++ b/data/src/file_downloader.rs
@@ -7,7 +7,6 @@ use merklehash::MerkleHash;
 use tracing::instrument;
 use ulid::Ulid;
 use utils::progress::{ItemProgressUpdater, SimpleProgressUpdater, TrackingProgressUpdater};
-use xet_threadpool::ThreadPool;
 
 use crate::configurations::TranslatorConfig;
 use crate::errors::*;
@@ -27,13 +26,13 @@ pub struct FileDownloader {
 
 /// Smudge operations
 impl FileDownloader {
-    pub async fn new(config: Arc<TranslatorConfig>, threadpool: Arc<ThreadPool>) -> Result<Self> {
+    pub async fn new(config: Arc<TranslatorConfig>) -> Result<Self> {
         let session_id = config
             .session_id
             .as_ref()
             .map(Cow::Borrowed)
             .unwrap_or_else(|| Cow::Owned(Ulid::new().to_string()));
-        let client = create_remote_client(&config, threadpool.clone(), &session_id, false)?;
+        let client = create_remote_client(&config, &session_id, false)?;
 
         Ok(Self { config, client })
     }

--- a/data/src/file_upload_session.rs
+++ b/data/src/file_upload_session.rs
@@ -436,7 +436,7 @@ mod tests {
     fn get_threadpool() -> Arc<ThreadPool> {
         static THREADPOOL: OnceLock<Arc<ThreadPool>> = OnceLock::new();
         THREADPOOL
-            .get_or_init(|| Arc::new(ThreadPool::new().expect("Error starting multithreaded runtime.")))
+            .get_or_init(|| ThreadPool::new().expect("Error starting multithreaded runtime."))
             .clone()
     }
 

--- a/data/src/migration_tool/hub_client.rs
+++ b/data/src/migration_tool/hub_client.rs
@@ -6,7 +6,6 @@ use cas_client::{build_http_client, Api, RetryConfig};
 use reqwest_middleware::ClientWithMiddleware;
 use utils::auth::{TokenInfo, TokenRefresher};
 use utils::errors::AuthError;
-use xet_threadpool::ThreadPool;
 
 #[derive(Debug)]
 pub struct HubClient {
@@ -74,7 +73,6 @@ impl HubClient {
 
 #[derive(Debug)]
 pub struct HubClientTokenRefresher {
-    pub threadpool: Arc<ThreadPool>,
     pub token_type: String,
     pub client: Arc<HubClient>,
 }

--- a/data/src/migration_tool/migrate.rs
+++ b/data/src/migration_tool/migrate.rs
@@ -36,7 +36,7 @@ pub async fn migrate_with_external_runtime(
 ) -> Result<()> {
     let hub_client = HubClient::new(hub_endpoint, hub_token, repo_type, repo_id)?;
 
-    let threadpool = Arc::new(ThreadPool::from_external(handle));
+    let threadpool = ThreadPool::from_external(handle);
 
     migrate_files_impl(file_paths, false, hub_client, cas_endpoint, threadpool, None, false).await?;
 

--- a/data/src/remote_client_interface.rs
+++ b/data/src/remote_client_interface.rs
@@ -2,14 +2,12 @@ use std::sync::Arc;
 
 pub use cas_client::Client;
 use cas_client::{LocalClient, RemoteClient};
-use xet_threadpool::ThreadPool;
 
 use crate::configurations::*;
 use crate::errors::Result;
 
 pub(crate) fn create_remote_client(
     config: &TranslatorConfig,
-    threadpool: Arc<ThreadPool>,
     session_id: &str,
     dry_run: bool,
 ) -> Result<Arc<dyn Client + Send + Sync>> {
@@ -17,7 +15,6 @@ pub(crate) fn create_remote_client(
 
     match cas_storage_config.endpoint {
         Endpoint::Server(ref endpoint) => Ok(Arc::new(RemoteClient::new(
-            threadpool,
             endpoint,
             cas_storage_config.compression,
             &cas_storage_config.auth,

--- a/data/tests/test_clean_smudge.rs
+++ b/data/tests/test_clean_smudge.rs
@@ -127,7 +127,7 @@ async fn dehydrate_directory(cas_dir: &Path, src_dir: &Path, ptr_dir: &Path) {
 
     create_dir_all(ptr_dir).unwrap();
 
-    let upload_session = FileUploadSession::new(config.clone(), ThreadPool::from_current_runtime(), None)
+    let upload_session = FileUploadSession::new(config.clone(), ThreadPool::current(), None)
         .await
         .unwrap();
 
@@ -155,7 +155,7 @@ async fn hydrate_directory(cas_dir: &Path, ptr_dir: &Path, dest_dir: &Path) {
 
     create_dir_all(dest_dir).unwrap();
 
-    let downloader = FileDownloader::new(config, ThreadPool::from_current_runtime()).await.unwrap();
+    let downloader = FileDownloader::new(config, ThreadPool::current()).await.unwrap();
 
     for entry in read_dir(ptr_dir).unwrap() {
         let entry = entry.unwrap();
@@ -210,7 +210,7 @@ async fn dehydrate_directory_sequential(cas_dir: &Path, src_dir: &Path, ptr_dir:
     let config = TranslatorConfig::local_config(cas_dir).unwrap();
     std::fs::create_dir_all(ptr_dir).unwrap();
 
-    let upload_session = FileUploadSession::new(config.clone(), ThreadPool::from_current_runtime(), None)
+    let upload_session = FileUploadSession::new(config.clone(), ThreadPool::current(), None)
         .await
         .unwrap();
 

--- a/data/tests/test_clean_smudge.rs
+++ b/data/tests/test_clean_smudge.rs
@@ -11,7 +11,6 @@ use rand::prelude::*;
 use tempfile::TempDir;
 use tokio::task::JoinSet;
 use utils::test_set_globals;
-use xet_threadpool::ThreadPool;
 
 // Runs this test suite with small chunks and xorbs so that we can make sure that all the different edge
 // cases are hit.
@@ -127,9 +126,7 @@ async fn dehydrate_directory(cas_dir: &Path, src_dir: &Path, ptr_dir: &Path) {
 
     create_dir_all(ptr_dir).unwrap();
 
-    let upload_session = FileUploadSession::new(config.clone(), ThreadPool::current(), None)
-        .await
-        .unwrap();
+    let upload_session = FileUploadSession::new(config.clone(), None).await.unwrap();
 
     let mut upload_tasks = JoinSet::new();
 
@@ -155,7 +152,7 @@ async fn hydrate_directory(cas_dir: &Path, ptr_dir: &Path, dest_dir: &Path) {
 
     create_dir_all(dest_dir).unwrap();
 
-    let downloader = FileDownloader::new(config, ThreadPool::current()).await.unwrap();
+    let downloader = FileDownloader::new(config).await.unwrap();
 
     for entry in read_dir(ptr_dir).unwrap() {
         let entry = entry.unwrap();
@@ -210,9 +207,7 @@ async fn dehydrate_directory_sequential(cas_dir: &Path, src_dir: &Path, ptr_dir:
     let config = TranslatorConfig::local_config(cas_dir).unwrap();
     std::fs::create_dir_all(ptr_dir).unwrap();
 
-    let upload_session = FileUploadSession::new(config.clone(), ThreadPool::current(), None)
-        .await
-        .unwrap();
+    let upload_session = FileUploadSession::new(config.clone(), None).await.unwrap();
 
     // Process files in a simple for-loop (no concurrency)
     for entry in read_dir(src_dir).unwrap() {

--- a/hf_xet/Cargo.lock
+++ b/hf_xet/Cargo.lock
@@ -4078,6 +4078,7 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 name = "xet_threadpool"
 version = "0.1.0"
 dependencies = [
+ "lazy_static",
  "thiserror 2.0.11",
  "tokio",
  "tracing",

--- a/hf_xet/src/lib.rs
+++ b/hf_xet/src/lib.rs
@@ -48,9 +48,8 @@ pub fn upload_bytes(
         .transpose()?
         .map(Arc::new);
 
-    async_run(py, move |thread_pool| async move {
+    async_run(py, async move {
         let out: Vec<PyXetUploadInfo> = data_client::upload_bytes_async(
-            thread_pool,
             file_contents,
             endpoint,
             token_info,
@@ -83,9 +82,8 @@ pub fn upload_files(
         .transpose()?
         .map(Arc::new);
 
-    async_run(py, move |threadpool| async move {
+    async_run(py, async move {
         let out: Vec<PyXetUploadInfo> = data_client::upload_async(
-            threadpool,
             file_paths,
             endpoint,
             token_info,
@@ -115,17 +113,11 @@ pub fn download_files(
     let refresher = token_refresher.map(WrappedTokenRefresher::from_func).transpose()?.map(Arc::new);
     let updaters = progress_updater.map(try_parse_progress_updaters).transpose()?;
 
-    async_run(py, move |threadpool| async move {
-        let out: Vec<String> = data_client::download_async(
-            threadpool,
-            file_infos,
-            endpoint,
-            token_info,
-            refresher.map(|v| v as Arc<_>),
-            updaters,
-        )
-        .await
-        .map_err(convert_data_processing_error)?;
+    async_run(py, async move {
+        let out: Vec<String> =
+            data_client::download_async(file_infos, endpoint, token_info, refresher.map(|v| v as Arc<_>), updaters)
+                .await
+                .map_err(convert_data_processing_error)?;
 
         PyResult::Ok(out)
     })

--- a/hf_xet/src/runtime.rs
+++ b/hf_xet/src/runtime.rs
@@ -111,7 +111,7 @@ pub fn init_threadpool(py: Python) -> PyResult<Arc<ThreadPool>> {
     }
 
     // Create a new Tokio runtime.
-    let runtime = Arc::new(ThreadPool::new().map_err(convert_multithreading_error)?);
+    let runtime = ThreadPool::new().map_err(convert_multithreading_error)?;
 
     // Check the signal handler
     check_sigint_handler()?;

--- a/hf_xet/src/runtime.rs
+++ b/hf_xet/src/runtime.rs
@@ -158,7 +158,7 @@ fn convert_multithreading_error(e: MultithreadedRuntimeError) -> PyErr {
     PyRuntimeError::new_err(format!("Xet Runtime Error: {}", e))
 }
 
-pub fn async_run<Out, F>(py: Python, execution_call: impl FnOnce(Arc<ThreadPool>) -> F + Send) -> PyResult<Out>
+pub fn async_run<Out, F>(py: Python, execution_call: F) -> PyResult<Out>
 where
     F: std::future::Future + Send + 'static,
     F::Output: Into<PyResult<Out>> + Send + Sync,
@@ -170,7 +170,7 @@ where
     // Release the gil
     let runtime_internal = runtime.clone();
     let result: PyResult<Out> = py
-        .allow_threads(move || runtime_internal.external_run_async_task(execution_call(runtime_internal.clone())))
+        .allow_threads(move || runtime_internal.external_run_async_task(execution_call))
         .map_err(convert_multithreading_error)?
         .into();
 

--- a/xet_threadpool/Cargo.toml
+++ b/xet_threadpool/Cargo.toml
@@ -4,9 +4,16 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tokio = { version = "1.44", features = ["sync", "macros", "io-util", "rt", "time"] }
+tokio = { version = "1.44", features = [
+    "sync",
+    "macros",
+    "io-util",
+    "rt",
+    "time",
+] }
 thiserror = "2.0"
 tracing = "0.1.31"
+lazy_static = "1.4"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 tokio = { version = "1.44", features = ["rt-multi-thread"] }

--- a/xet_threadpool/src/threadpool.rs
+++ b/xet_threadpool/src/threadpool.rs
@@ -77,7 +77,7 @@ pub struct ThreadPool {
 // the worker threads in the runtime.  This way, XetRuntime::current() will always refer to
 // the runtime active with that worker thread.
 thread_local! {
-    static THREAD_RUNTIME_REF: RefCell<Option<Arc<ThreadPool>>> = RefCell::new(None);
+    static THREAD_RUNTIME_REF: RefCell<Option<Arc<ThreadPool>>> = const { RefCell::new(None) };
 }
 
 impl ThreadPool {


### PR DESCRIPTION
Currently, we pass references to the threadpool around the code in order to use it.  However, all of this code is currently on a worker thread of the tokio runtime used to create the threadpool.  

This PR simplifies this by using thread local storage; each worker thread sets a reference to the runtime on start that can be accessed at any time using ThreadPool::current().  

Fallback for running within an existing tokio runtime (E.g. with tokio::test) is also handled using the from_external() mechanism.

There should be no functionality change, just code simplification. 