### PR TITLE
Connect detailed upload progress to hub

### DIFF
--- a/hf_xet/Cargo.lock
+++ b/hf_xet/Cargo.lock
@@ -1194,6 +1194,7 @@ dependencies = [
  "ctrlc",
  "data",
  "error_printer",
+ "itertools 0.14.0",
  "lazy_static",
  "parutils",
  "pprof",
@@ -1641,6 +1642,15 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]

--- a/hf_xet/Cargo.toml
+++ b/hf_xet/Cargo.toml
@@ -41,6 +41,7 @@ pprof = { version = "0.14", features = [
     "protobuf-codec",
 ], optional = true }
 async-trait = "0.1.87"
+itertools = "0.14.0"
 
 # Unix-specific dependencies
 [target.'cfg(unix)'.dependencies]

--- a/hf_xet/src/lib.rs
+++ b/hf_xet/src/lib.rs
@@ -43,10 +43,7 @@ pub fn upload_bytes(
     _repo_type: Option<String>,
 ) -> PyResult<Vec<PyXetUploadInfo>> {
     let refresher = token_refresher.map(WrappedTokenRefresher::from_func).transpose()?.map(Arc::new);
-    let updater = progress_updater
-        .map(WrappedProgressUpdater::from_func)
-        .transpose()?
-        .map(Arc::new);
+    let updater = progress_updater.map(WrappedProgressUpdater::new).transpose()?.map(Arc::new);
 
     async_run(py, async move {
         let out: Vec<PyXetUploadInfo> = data_client::upload_bytes_async(
@@ -77,10 +74,7 @@ pub fn upload_files(
     _repo_type: Option<String>,
 ) -> PyResult<Vec<PyXetUploadInfo>> {
     let refresher = token_refresher.map(WrappedTokenRefresher::from_func).transpose()?.map(Arc::new);
-    let updater = progress_updater
-        .map(WrappedProgressUpdater::from_func)
-        .transpose()?
-        .map(Arc::new);
+    let updater = progress_updater.map(WrappedProgressUpdater::new).transpose()?.map(Arc::new);
 
     async_run(py, async move {
         let out: Vec<PyXetUploadInfo> = data_client::upload_async(
@@ -126,7 +120,7 @@ pub fn download_files(
 fn try_parse_progress_updaters(funcs: Vec<Py<PyAny>>) -> PyResult<Vec<Arc<dyn TrackingProgressUpdater>>> {
     let mut updaters = Vec::with_capacity(funcs.len());
     for updater_func in funcs {
-        let wrapped = Arc::new(WrappedProgressUpdater::from_func(updater_func)?);
+        let wrapped = Arc::new(WrappedProgressUpdater::new(updater_func)?);
         updaters.push(wrapped as Arc<dyn TrackingProgressUpdater>);
     }
     Ok(updaters)

--- a/hf_xet/src/progress_update.rs
+++ b/hf_xet/src/progress_update.rs
@@ -1,10 +1,12 @@
 use std::fmt::{Debug, Formatter};
 
 use error_printer::ErrorPrinter;
+use itertools::Itertools;
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::PyAnyMethods;
-use pyo3::{Py, PyAny, PyErr, PyResult, Python};
-use tracing::{error, trace};
+use pyo3::types::{IntoPyDict, PyString};
+use pyo3::{IntoPyObject, Py, PyAny, PyResult, Python};
+use tracing::error;
 use utils::progress::{ProgressUpdate, TrackingProgressUpdater};
 
 /// A wrapper over a passed-in python function to update
@@ -13,11 +15,18 @@ use utils::progress::{ProgressUpdate, TrackingProgressUpdater};
 /// passed around as a ProgressUpdater trait object or
 /// as a template parameter
 pub struct WrappedProgressUpdater {
+    /// Is this enabled?
+    progress_updating_enabled: bool,
+
     /// the function py_func is responsible for passing in the update value
     /// into the python context. Expects 1 int (uint64) parameter that
     /// is a number to increment the progress counter by.
     py_func: Py<PyAny>,
     name: String,
+
+    /// Whether to use the simple incremental progress updating method or
+    /// the more detailed
+    update_with_detailed_progress: bool,
 }
 
 impl Debug for WrappedProgressUpdater {
@@ -26,50 +35,127 @@ impl Debug for WrappedProgressUpdater {
     }
 }
 
-impl WrappedProgressUpdater {
-    pub fn from_func(py_func: Py<PyAny>) -> PyResult<Self> {
-        let name = Self::validate_callable(&py_func)?;
-        Ok(Self { py_func, name })
-    }
+const DETAILED_PROGRESS_ARG_NAMES: [&str; 4] = ["item_id", "bytes_completed", "total_bytes", "update_increment"];
 
-    /// Validate that the inputted python object is callable
-    fn validate_callable(py_func: &Py<PyAny>) -> Result<String, PyErr> {
+impl WrappedProgressUpdater {
+    pub fn new(py_func: Py<PyAny>) -> PyResult<Self> {
+        // Analyze the function to make sure it's the correct form. If it's 4 arguments with
+        // the appropriate names, than we call it using the detailed progress update; if it's
+        // a single function, we assume it's a global increment function and just pass in the update
+        // increment.
         Python::with_gil(|py| {
-            let f = py_func.bind(py);
-            let name = f
+            let func = py_func.bind(py);
+
+            // Test if it's enabled first; if None is passed in, then this is disabled.
+            if py_func.is_none(py) {
+                return Ok(Self {
+                    progress_updating_enabled: false,
+                    py_func,
+                    name: Default::default(),
+                    update_with_detailed_progress: false,
+                });
+            }
+
+            let name = func
                 .repr()
                 .and_then(|repr| repr.extract::<String>())
-                .unwrap_or("unknown".to_string());
-            if !f.is_callable() {
+                .unwrap_or_else(|_| "unknown".to_string());
+
+            if !func.is_callable() {
                 error!("ProgressUpdater func: {name} is not callable");
                 return Err(PyTypeError::new_err(format!("update func: {name} is not callable")));
             }
-            Ok(name)
+
+            let inspect = py.import("inspect")?;
+            let sig = inspect.call_method1("signature", (func,))?;
+            let params = sig.getattr("parameters")?;
+
+            let param_names: Vec<Py<PyString>> = params
+                .call_method0("items")?
+                .try_iter()?
+                .map(|item| {
+                    let (k, _): (Py<PyString>, Py<PyAny>) = item?.extract()?;
+                    Ok(k)
+                })
+                .collect::<PyResult<_>>()?;
+
+            let update_with_detailed_progress = match param_names.len() {
+                1 => false,
+                4 => {
+                    if param_names
+                        .iter()
+                        .zip(DETAILED_PROGRESS_ARG_NAMES.into_iter())
+                        .all(|(v1, v2)| v1.to_string_lossy(py) == v2)
+                    {
+                        true
+                    } else {
+                        return Err(PyTypeError::new_err(format!(
+                            "Function {name} must have either one argument or four named arguments ({})",
+                            DETAILED_PROGRESS_ARG_NAMES.iter().join(", ")
+                        )));
+                    }
+                },
+                _ => {
+                    return Err(PyTypeError::new_err(format!(
+                        "Function {name} must take exactly 1 or 4 arguments, but got {}",
+                        param_names.len()
+                    )))
+                },
+            };
+
+            Ok(Self {
+                progress_updating_enabled: true,
+                py_func,
+                name,
+                update_with_detailed_progress,
+            })
+        })
+    }
+
+    async fn register_updates_impl(&self, updates: &[ProgressUpdate]) -> PyResult<()> {
+        Python::with_gil(|py| {
+            let f = self.py_func.bind(py);
+
+            if self.update_with_detailed_progress {
+                let str2py = |c: &str| -> PyResult<Py<PyAny>> { Ok(c.into_pyobject(py)?.into()) };
+                let int2py = |v: u64| -> PyResult<Py<PyAny>> { Ok(v.into_pyobject(py)?.into()) };
+
+                let args = [
+                    str2py(DETAILED_PROGRESS_ARG_NAMES[0])?,
+                    str2py(DETAILED_PROGRESS_ARG_NAMES[1])?,
+                    str2py(DETAILED_PROGRESS_ARG_NAMES[2])?,
+                    str2py(DETAILED_PROGRESS_ARG_NAMES[3])?,
+                ];
+
+                for update in updates {
+                    let kwargs = [
+                        (args[0].clone_ref(py), str2py(&update.item_name)?),
+                        (args[1].clone_ref(py), int2py(update.completed_count)?),
+                        (args[2].clone_ref(py), int2py(update.total_count)?),
+                        (args[3].clone_ref(py), int2py(update.update_increment)?),
+                    ]
+                    .into_py_dict(py)?;
+
+                    f.call((), Some(&kwargs))?;
+                }
+            } else {
+                let update_increment: u64 = updates.iter().map(|pr| pr.update_increment).sum();
+                let _ = f.call1((update_increment,))?;
+            }
+
+            Ok(())
         })
     }
 }
 
-// TODO: This is now connected via the old interface, which doesn't account for any of the
-// per-file tracking information.  Once the python end exposess an API in which these per-file
-// updates can be tracked properly, this interface here should be changed.
 #[async_trait::async_trait]
 impl TrackingProgressUpdater for WrappedProgressUpdater {
     async fn register_updates(&self, updates: &[ProgressUpdate]) {
-        Python::with_gil(|py| {
-            let f = self.py_func.bind(py);
-            if !f.is_callable() {
-                error!("ProgressUpdater func: {} is not callable", self.name);
-                return;
-            }
-            for update in updates {
-                // TODO: Connect the full information in the ProgressUpdate struct to python.
-                let increment = update.update_increment;
-                trace!("updating progress bar with increment value: {increment}");
-
-                let _ = f
-                    .call1((increment,))
-                    .log_error("python exception trying to update progress bar");
-            }
-        });
+        if self.progress_updating_enabled {
+            let _ = self
+                .register_updates_impl(updates)
+                .await
+                .log_error("Python exception updating progress:");
+        }
     }
 }


### PR DESCRIPTION
This PR connects detailed upload progress to the hub in a backwards compatible way. 

It works by testing the number of arguments and argument names on the progress updating function.  If the progress reporting function takes a single argument, this function calls it using the old method; if it has the appropriate arguments for detailed reporting -- `item_id, completed_bytes, total_bytes, update_increment` -- then it calls it using the new method.   Additionally, if None is passed in, the progress reporting is disabled.