### PR TITLE
Fixed race condition in dependency tracking.

### DIFF
--- a/data/src/file_upload_session.rs
+++ b/data/src/file_upload_session.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use cas_client::Client;
 use deduplication::constants::{MAX_XORB_BYTES, MAX_XORB_CHUNKS};
-use deduplication::{DataAggregator, DeduplicationMetrics, RawXorbData};
+use deduplication::{DataAggregator, DeduplicationMetrics, FileXorbDependency, RawXorbData};
 use jsonwebtoken::{decode, DecodingKey, Validation};
 use mdb_shard::file_structs::MDBFileInfo;
 use merklehash::MerkleHash;
@@ -20,7 +20,7 @@ use crate::configurations::*;
 use crate::constants::MAX_CONCURRENT_UPLOADS;
 use crate::errors::*;
 use crate::file_cleaner::SingleFileCleaner;
-use crate::progress_tracking::{CompletionTracker, CompletionTrackerFileId};
+use crate::progress_tracking::CompletionTracker;
 use crate::prometheus_metrics;
 use crate::remote_client_interface::create_remote_client;
 use crate::shard_interface::SessionShardInterface;
@@ -179,7 +179,7 @@ impl FileUploadSession {
     /// Registers a new xorb for upload, returning true if the xorb was added to the upload queue and false
     /// if it was already in the queue and didn't need to be uploaded again.
     #[instrument(skip_all, name="FileUploadSession::register_new_xorb_for_upload", fields(xorb_len = xorb.num_bytes()))]
-    pub(crate) async fn register_new_xorb_for_upload(self: &Arc<Self>, xorb: RawXorbData) -> Result<bool> {
+    pub(crate) async fn register_new_xorb(self: &Arc<Self>, xorb: RawXorbData) -> Result<bool> {
         // First check the current xorb upload tasks to see if any can be cleaned up.
         {
             let mut upload_tasks = self.xorb_upload_tasks.lock().await;
@@ -195,7 +195,7 @@ impl FileUploadSession {
         //
         // In some circumstances, we can cut to instances of the same xorb, namely when there are two files
         // with the same starting data that get processed simultaneously.  When this happens, we only upload
-        // the first one, returning early
+        // the first one, returning early here.
         let new_xorb = self.session_xorbs.lock().await.insert(xorb_hash);
 
         if !new_xorb {
@@ -208,6 +208,11 @@ impl FileUploadSession {
             self.completion_tracker.register_xorb_upload_completion(xorb_hash).await;
             return Ok(true);
         }
+
+        // This xorb is in the session upload queue, so other threads can go ahead and dedup against it.
+        // No session shard data gets uploaded until all the xorbs have been successfully uploaded, so
+        // this is safe.
+        self.shard_interface.add_cas_block(xorb.cas_info.clone()).await?;
 
         let xorb_data = xorb.to_vec();
         let chunks_and_boundaries = xorb.cas_info.chunks_and_boundaries();
@@ -294,44 +299,35 @@ impl FileUploadSession {
         debug_assert_le!(xorb.data.len(), *MAX_XORB_CHUNKS);
 
         // Now, we need to scan all the file dependencies for dependencies on this xorb, as
-        // these would not have been registered yet.
-        self.register_new_xorb_for_upload(xorb).await?;
-
+        // these would not have been registered yet as we just got the xorb hash.
         let mut new_dependencies = Vec::with_capacity(new_files.len());
 
         {
             for (file_id, fi, bytes_in_xorb) in new_files {
-                if xorb_hash == MerkleHash::default() || bytes_in_xorb != 0 {
-                    new_dependencies.push((file_id, xorb_hash, bytes_in_xorb, false));
-                }
+                new_dependencies.push(FileXorbDependency {
+                    file_id,
+                    xorb_hash,
+                    n_bytes: bytes_in_xorb,
+                    is_external: false,
+                });
 
+                // Record the reconstruction.
                 self.shard_interface.add_file_reconstruction_info(fi).await?;
             }
         }
 
         self.completion_tracker.register_dependencies(&new_dependencies).await;
 
+        // Now we can go ahead and start the upload process; this is spun off into a background thread
+        // but might as well get it started.
+        self.register_new_xorb(xorb).await?;
+
         Ok(())
     }
 
     /// Register a xorb dependencies that is given as part of the dedup process.
-    pub(crate) async fn register_xorb_dependencies(
-        self: &Arc<Self>,
-        file_id: CompletionTrackerFileId,
-        xorb_dependencies: &[(MerkleHash, u64)],
-    ) {
-        // See what dependencies we own:
-        let mut dependencies = Vec::with_capacity(xorb_dependencies.len());
-
-        {
-            let xorb_lookup = self.session_xorbs.lock().await;
-            for &(xorb_hash, n_bytes) in xorb_dependencies {
-                let is_uploaded_out_of_session = !xorb_lookup.contains(&xorb_hash);
-                dependencies.push((file_id, xorb_hash, n_bytes, is_uploaded_out_of_session));
-            }
-        }
-
-        self.completion_tracker.register_dependencies(&dependencies).await;
+    pub(crate) async fn register_xorb_dependencies(self: &Arc<Self>, xorb_dependencies: &[FileXorbDependency]) {
+        self.completion_tracker.register_dependencies(xorb_dependencies).await;
     }
 
     /// Finalize everything.

--- a/data/src/progress_tracking.rs
+++ b/data/src/progress_tracking.rs
@@ -118,7 +118,6 @@ impl CompletionTrackerImpl {
                 } else {
                     // Insert a new xorb entry if needed.
                     entry.file_indices.insert(dep.file_id as usize);
-                    eprintln!("Registering dep: {} -> {}", dep.file_id, dep.xorb_hash);
                     *file_entry.remaining_xorbs_parts.entry(dep.xorb_hash).or_default() += dep.n_bytes;
                 }
             }

--- a/data/src/progress_tracking.rs
+++ b/data/src/progress_tracking.rs
@@ -1,7 +1,8 @@
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::mem::take;
 use std::sync::Arc;
 
+use deduplication::FileXorbDependency;
 use merklehash::MerkleHash;
 use more_asserts::debug_assert_le;
 use tokio::sync::Mutex;
@@ -16,7 +17,7 @@ pub type CompletionTrackerFileId = u64;
 #[derive(Default)]
 struct XorbDependency {
     /// List of file indices that need this xorb.
-    file_indices: Vec<usize>,
+    file_indices: BTreeSet<usize>,
 
     /// True if the xorb has already been updated successfully.
     is_completed: bool,
@@ -76,50 +77,49 @@ impl CompletionTrackerImpl {
 
     /// Registers that all or part of a given file (by `file_id`) depends on one or more
     /// xorbs; Given a list of (xorb_hash, n_bytes, already_uploaded), registers the progress.
-    fn register_dependencies(
-        &mut self,
-        dependencies: &[(CompletionTrackerFileId, MerkleHash, u64, bool)],
-    ) -> Vec<ProgressUpdate> {
+    fn register_dependencies(&mut self, dependencies: &[FileXorbDependency]) -> Vec<ProgressUpdate> {
         let mut ret = Vec::new();
 
-        for &(file_id, xorb_hash, n_bytes, is_completed) in dependencies {
-            let file_entry = &mut self.files[file_id as usize];
+        for dep in dependencies {
+            let file_entry = &mut self.files[dep.file_id as usize];
 
-            if is_completed {
-                file_entry.completed_bytes += n_bytes;
+            if dep.is_external {
+                // This is the freebie case, where we can just increment the progress.
+                file_entry.completed_bytes += dep.n_bytes;
                 debug_assert_le!(file_entry.completed_bytes, file_entry.total_bytes);
 
                 let progress_update = ProgressUpdate {
                     item_name: file_entry.name.clone(),
                     total_count: file_entry.total_bytes,
                     completed_count: file_entry.completed_bytes,
-                    update_increment: n_bytes,
+                    update_increment: dep.n_bytes,
                 };
 
                 ret.push(progress_update);
             } else {
                 // Make sure we aren't putting in an unfinished xorb, which
                 // tracks with MerkleHash::marker().
-                debug_assert_ne!(xorb_hash, MerkleHash::marker());
+                debug_assert_ne!(dep.xorb_hash, MerkleHash::marker());
 
-                let entry = self.xorbs.entry(xorb_hash).or_default();
+                let entry = self.xorbs.entry(dep.xorb_hash).or_default();
 
                 // If the entry has already been completed, then just mark this as completed.
                 if entry.is_completed {
-                    file_entry.completed_bytes += n_bytes;
+                    file_entry.completed_bytes += dep.n_bytes;
                     debug_assert_le!(file_entry.completed_bytes, file_entry.total_bytes);
 
                     let progress_update = ProgressUpdate {
                         item_name: file_entry.name.clone(),
                         total_count: file_entry.total_bytes,
                         completed_count: file_entry.completed_bytes,
-                        update_increment: n_bytes,
+                        update_increment: dep.n_bytes,
                     };
                     ret.push(progress_update);
                 } else {
                     // Insert a new xorb entry if needed.
-                    entry.file_indices.push(file_id as usize);
-                    *file_entry.remaining_xorbs_parts.entry(xorb_hash).or_default() += n_bytes;
+                    entry.file_indices.insert(dep.file_id as usize);
+                    eprintln!("Registering dep: {} -> {}", dep.file_id, dep.xorb_hash);
+                    *file_entry.remaining_xorbs_parts.entry(dep.xorb_hash).or_default() += dep.n_bytes;
                 }
             }
         }
@@ -242,7 +242,7 @@ impl CompletionTracker {
     }
 
     /// Register a list of (file_id, xorb_hash, usize, bool)
-    pub async fn register_dependencies(&self, dependencies: &[(CompletionTrackerFileId, MerkleHash, u64, bool)]) {
+    pub async fn register_dependencies(&self, dependencies: &[FileXorbDependency]) {
         let updates = self.inner.lock().await.register_dependencies(dependencies);
 
         if !updates.is_empty() {
@@ -302,7 +302,14 @@ mod tests {
 
         // fileA depends on x for 100 bytes, already uploaded
         let x = MerkleHash::random_from_seed(1);
-        tracker.register_dependencies(&[(file_a, x, 100, true)]).await;
+        tracker
+            .register_dependencies(&[FileXorbDependency {
+                file_id: file_a,
+                xorb_hash: x,
+                n_bytes: 100,
+                is_external: true,
+            }])
+            .await;
 
         // Now fileA is 100/100, fileB is 0/50 => done=100, total=150
         let (done, total) = tracker.status().await;
@@ -312,7 +319,14 @@ mod tests {
 
         // fileB depends on y for 50 bytes, not yet uploaded
         let y = MerkleHash::random_from_seed(2);
-        tracker.register_dependencies(&[(file_b, y, 50, false)]).await;
+        tracker
+            .register_dependencies(&[FileXorbDependency {
+                file_id: file_b,
+                xorb_hash: y,
+                n_bytes: 50,
+                is_external: false,
+            }])
+            .await;
 
         let (done, total) = tracker.status().await;
         assert_eq!(done, 100);
@@ -353,7 +367,20 @@ mod tests {
         // fileA => xhash 100 bytes (not uploaded)
         // fileB => xhash 200 bytes (already uploaded)
         tracker
-            .register_dependencies(&[(file_a, xhash, 100, false), (file_b, xhash, 200, true)])
+            .register_dependencies(&[
+                FileXorbDependency {
+                    file_id: file_a,
+                    xorb_hash: xhash,
+                    n_bytes: 100,
+                    is_external: false,
+                },
+                FileXorbDependency {
+                    file_id: file_b,
+                    xorb_hash: xhash,
+                    n_bytes: 200,
+                    is_external: true,
+                },
+            ])
             .await;
 
         let (done, total) = tracker.status().await;
@@ -370,14 +397,28 @@ mod tests {
 
         // Suppose fileA is 100/200. We'll "fix" it with x2 => 100 bytes (already uploaded)
         let x2 = MerkleHash::random_from_seed(2);
-        tracker.register_dependencies(&[(file_a, x2, 100, true)]).await;
+        tracker
+            .register_dependencies(&[FileXorbDependency {
+                file_id: file_a,
+                xorb_hash: x2,
+                n_bytes: 100,
+                is_external: true,
+            }])
+            .await;
 
         let (done, total) = tracker.status().await;
         assert_eq!(done, 400); // A:200, B:200
         assert_eq!(total, 500);
 
         // B's remaining 100 bytes also from x2, not uploaded
-        tracker.register_dependencies(&[(file_b, x2, 100, false)]).await;
+        tracker
+            .register_dependencies(&[FileXorbDependency {
+                file_id: file_b,
+                xorb_hash: x2,
+                n_bytes: 100,
+                is_external: false,
+            }])
+            .await;
 
         let (done, total) = tracker.status().await;
         assert_eq!(done, 400);
@@ -413,7 +454,26 @@ mod tests {
         // x2 => 100 bytes, already uploaded
         // x3 => 100 bytes, not uploaded
         tracker
-            .register_dependencies(&[(f, x1, 100, false), (f, x2, 100, true), (f, x3, 100, false)])
+            .register_dependencies(&[
+                FileXorbDependency {
+                    file_id: f,
+                    xorb_hash: x1,
+                    n_bytes: 100,
+                    is_external: false,
+                },
+                FileXorbDependency {
+                    file_id: f,
+                    xorb_hash: x2,
+                    n_bytes: 100,
+                    is_external: true,
+                },
+                FileXorbDependency {
+                    file_id: f,
+                    xorb_hash: x3,
+                    n_bytes: 100,
+                    is_external: false,
+                },
+            ])
             .await;
 
         let (done, total) = tracker.status().await;
@@ -456,7 +516,14 @@ mod tests {
 
         // Now we register that file depends on x for 50 bytes, "already_uploaded=false"
         // but the tracker sees x is completed => immediate credit.
-        tracker.register_dependencies(&[(file_id, x, 50, false)]).await;
+        tracker
+            .register_dependencies(&[FileXorbDependency {
+                file_id,
+                xorb_hash: x,
+                n_bytes: 50,
+                is_external: false,
+            }])
+            .await;
 
         let (done, total) = tracker.status().await;
         assert_eq!(done, 50);
@@ -484,7 +551,14 @@ mod tests {
 
         // Then register a dependency with "already_uploaded=false"
         // The code sees x.is_completed==true => immediate credit for 100 bytes
-        tracker.register_dependencies(&[(file_id, x, 100, false)]).await;
+        tracker
+            .register_dependencies(&[FileXorbDependency {
+                file_id,
+                xorb_hash: x,
+                n_bytes: 100,
+                is_external: false,
+            }])
+            .await;
 
         let (done, total) = tracker.status().await;
         assert_eq!(done, 100);

--- a/data/tests/test_clean_smudge.rs
+++ b/data/tests/test_clean_smudge.rs
@@ -339,7 +339,7 @@ mod tests {
     /// 1) Several identical files, each smaller than MAX_XORB_BYTES.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_several_identical_multipart() {
-        // Let's make 16 identical files, each identical
+        // Let's make 16 files, each identical and smaller than a xorb
         let file_specs: Vec<(String, Vec<(u64, u64)>)> = (0..16)
             .map(|i| (format!("identical_{i}"), vec![(123, *MAX_XORB_BYTES as u64 / 2)]))
             .collect();

--- a/deduplication/src/interface.rs
+++ b/deduplication/src/interface.rs
@@ -6,6 +6,13 @@ use merklehash::MerkleHash;
 
 use crate::raw_xorb_data::RawXorbData;
 
+pub struct FileXorbDependency {
+    pub file_id: u64,
+    pub xorb_hash: MerkleHash,
+    pub n_bytes: u64,
+    pub is_external: bool,
+}
+
 /// The interface needed for the deduplication routines to run.  To use the deduplication code,
 /// define a struct that implements these methods.  This struct must be given by value to the FileDeduper
 /// struct on creation.
@@ -23,7 +30,7 @@ pub trait DeduplicationDataInterface: Send + Sync + 'static {
     async fn chunk_hash_dedup_query(
         &self,
         query_hashes: &[MerkleHash],
-    ) -> std::result::Result<Option<(usize, FileDataSequenceEntry)>, Self::ErrorType>;
+    ) -> std::result::Result<Option<(usize, FileDataSequenceEntry, bool)>, Self::ErrorType>;
 
     /// Registers a new query for more information about the
     /// global deduplication.  This is expected to run in the background.  Simply return Ok(()) to
@@ -41,5 +48,5 @@ pub trait DeduplicationDataInterface: Send + Sync + 'static {
     /// process with a list of (xorb hash, n_bytes).  As the final bit may get
     /// returned as a partial xorb without a hash yet, it is not gauranteed that the
     /// sum of the n_bytes across all the dependencies will equal the size of the file.
-    async fn register_xorb_dependencies(&mut self, _dependencies: &[(MerkleHash, u64)]) {}
+    async fn register_xorb_dependencies(&mut self, dependencies: &[FileXorbDependency]);
 }

--- a/deduplication/src/lib.rs
+++ b/deduplication/src/lib.rs
@@ -11,5 +11,5 @@ pub use chunking::{Chunk, Chunker};
 pub use data_aggregator::DataAggregator;
 pub use dedup_metrics::DeduplicationMetrics;
 pub use file_deduplication::FileDeduper;
-pub use interface::DeduplicationDataInterface;
+pub use interface::{DeduplicationDataInterface, FileXorbDependency};
 pub use raw_xorb_data::RawXorbData;


### PR DESCRIPTION
Testing discovered two dependency tracking issues: 

The first is when a file references a new xorb multiple times in non-contiguous locations.  In this case, the logic will cause an assertion failure when debug_assertions are enabled, though likely the underlying logic is actually correct.

The second is that tracking which xorbs are part of a given session and which xorbs have been uploaded previously was done by recording the xorb hashes when they are registered for upload.  However, it turns out this needs to happen before registering the xorb as available for dedup; otherwise a race condition could cause a xorb to be incorrectly registered as already uploaded when in reality the xorb hash was in the queue and not actually added to the session registry yet.  This causes the progress to be incorrectly counted as already completed. 

A clean fix for this is to actually get that information directly from the shard_manager instead of tracking it separately by returning whether it's deduped against the session data or the cache.  This fix allows newly cut xorbs to immediately be used for dedup by other threads and correctly tracks all the information across threads. 