### PR TITLE
Added opt-test profile option to hf_xet

### DIFF
--- a/hf_xet/Cargo.toml
+++ b/hf_xet/Cargo.toml
@@ -58,3 +58,8 @@ profiling = ["pprof"]
 [profile.release]
 debug = true
 opt-level = 3
+
+[profile.opt-test]
+inherits = "dev"
+debug = true
+opt-level = 3


### PR DESCRIPTION
This adds the opt-test profile option to building hf_xet.  This compiles hf_xet in release mode, but keeps all the debug_assertion checks active.  

Why is this important?  The debug assertions enable a lot of internal sanity checks, catch overflows or underflows, and test conditions in code that may not otherwise be very easy to properly test.   For example, they recently caught a race condition in the progress tracking code that would have otherwise appeared to the user as an incorrectly incomplete file upload. 

When developing with hf_xet, and you want to run in release mode, compile with 

```
maturin develop --profile=opt-test
```

to enable this. 