### PR TITLE
Changed debug to minimal for python wheel.

### DIFF
--- a/hf_xet/Cargo.toml
+++ b/hf_xet/Cargo.toml
@@ -56,5 +56,10 @@ openssl_vendored = ["data/openssl_vendored"]
 profiling = ["pprof"]
 
 [profile.release]
-debug = true
+debug = "line-tables-only"
 opt-level = 3
+
+# Uncomment the below for lto + Os
+# opt-level = "s"
+# lto = true
+


### PR DESCRIPTION
Currently at O3 + minimal debug info; changing to Os + lto drops to 35mb. 