### PR TITLE
Fixing the sdist install and adding better project information

### DIFF
--- a/hf_xet/pyproject.toml
+++ b/hf_xet/pyproject.toml
@@ -5,16 +5,26 @@ build-backend = "maturin"
 [project]
 name = "hf-xet"
 requires-python = ">=3.8"
+description = "Fast transfer of large files with the Hugging Face Hub."
+license = { file = "../LICENSE" }
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dynamic = ["version"]
+
 [project.optional-dependencies]
 tests = [
     "pytest",
 ]
+
+[project.urls]
+Homepage = "https://github.com/huggingface/xet-core"
+Documentation = "https://huggingface.co/docs/hub/en/storage-backends#using-xet-storage"
+Issues = "https://github.com/huggingface/xet-core/issues"
+Repository = "https://github.com/huggingface/xet-core.git"
+
 [tool.maturin]
 python-source = "hf_xet/python"
 features = ["pyo3/extension-module"]

--- a/hf_xet/pyproject.toml
+++ b/hf_xet/pyproject.toml
@@ -16,5 +16,5 @@ tests = [
     "pytest",
 ]
 [tool.maturin]
-python-source = "python"
+python-source = "hf_xet/python"
 features = ["pyo3/extension-module"]


### PR DESCRIPTION
Attempting to address the `sdist` problems. For an sdist build, the pyproject.toml gets copied to the root directory of the repo and edited to include the manifest location. We need to refer to the `python` directory from the context of the root directory of the repo.

Note: this doesn't appear to have any affect on the wheel behavior or setup.

Local testing with the following now works:
```
cd hf_xet
maturin sdist

cd <anywhere>
cp <xet-core dir>/hf_xet/target/wheels/hf_xet-1.1.1.tar.gz .
tar -xvzf hf_xet-1.1.1.tar.gz
cd hf_xet-1.1.1
maturin build
```