### PR TITLE
don't bump num concurrent downloads live

### DIFF
--- a/cas_client/src/download_utils.rs
+++ b/cas_client/src/download_utils.rs
@@ -266,12 +266,10 @@ impl DownloadScheduler {
             if *num_range_in_segment > 1 {
                 *num_range_in_segment -= 1;
             }
-            self.n_concurrent_download_task.forget_permits(1);
         } else {
             // TODO: check download speed and consider if we should increase or decrease
             debug!("expanding segment size by one range");
             *self.n_range_in_segment.lock()? += 1;
-            self.n_concurrent_download_task.add_permits(1);
         }
 
         Ok(())


### PR DESCRIPTION
Removing the ability of the number of concurrent downloads to grow fixes the error for "Too many open files" see #311 .

Tracking how many download tasks are running concurrently over the download of a long and fragmented file showed a steady growth in the number of allowed concurrent downloads (we grow by 1 for every successful download without 403's). This causes the total number of allowed concurrent downloads to reach ~1K and then we hit "Too many open files" in my repro. Notably, my soft ulimit is 1024, and at ~1K (could be a bit more or less, my tracking is not exactly accurate), for each task we have 1 fd for a connection CF, so this is roughly when we reach the ulimit.

We leave the constant number of concurrent downloads user configurable, but constant. We can add a different live updating mechanism later.