### PR TITLE
add retry on range download

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,6 +509,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.11",
  "tokio",
+ "tokio-retry",
  "tracing",
  "tracing-test",
  "url",
@@ -3800,6 +3801,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project",
+ "rand 0.8.5",
  "tokio",
 ]
 

--- a/cas_client/Cargo.toml
+++ b/cas_client/Cargo.toml
@@ -38,6 +38,7 @@ heed = "0.11"
 futures = "0.3.31"
 derivative = "2.2.0"
 more-asserts = "0.3.1"
+tokio-retry = "0.3.0"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/cas_client/src/download_utils.rs
+++ b/cas_client/src/download_utils.rs
@@ -439,9 +439,9 @@ pub(crate) async fn get_one_fetch_term_data(
     Ok(term_download_output)
 }
 
-struct RetryCondition;
+struct ChunkRangeDeserializeFromBytesStreamRetryCondition;
 
-impl tokio_retry::Condition<CasClientError> for RetryCondition {
+impl tokio_retry::Condition<CasClientError> for ChunkRangeDeserializeFromBytesStreamRetryCondition {
     fn should_retry(&mut self, err: &CasClientError) -> bool {
         // we only care about retrying some error yielded by trying to deserialize the stream
         let CasClientError::CasObjectError(CasObjectError::InternalIOError(cas_object_io_err)) = err else {
@@ -512,7 +512,7 @@ async fn download_fetch_term_data(
                 chunk_range: fetch_term.range,
             }))
         },
-        RetryCondition,
+        ChunkRangeDeserializeFromBytesStreamRetryCondition,
     )
     .await
 }

--- a/cas_client/src/download_utils.rs
+++ b/cas_client/src/download_utils.rs
@@ -3,6 +3,7 @@ use std::io::Write;
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
+use cas_object::error::CasObjectError;
 use cas_types::{CASReconstructionFetchInfo, CASReconstructionTerm, ChunkRange, FileRange, HexMerkleHash, Key};
 use chunk_cache::{CacheRange, ChunkCache};
 use deduplication::constants::MAX_XORB_BYTES;
@@ -14,12 +15,13 @@ use http::StatusCode;
 use merklehash::MerkleHash;
 use reqwest_middleware::ClientWithMiddleware;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio_retry::strategy::ExponentialBackoff;
 use tracing::{debug, error, info, trace};
 use url::Url;
 use utils::singleflight::Group;
 
 use crate::error::{CasClientError, Result};
-use crate::http_client::Api;
+use crate::http_client::{Api, BASE_RETRY_DELAY_MS, BASE_RETRY_MAX_DURATION_MS, NUM_RETRIES};
 use crate::remote_client::{get_reconstruction_with_endpoint_and_client, PREFIX_DEFAULT};
 use crate::OutputProvider;
 
@@ -437,6 +439,25 @@ pub(crate) async fn get_one_fetch_term_data(
     Ok(term_download_output)
 }
 
+struct RetryCondition;
+
+impl tokio_retry::Condition<CasClientError> for RetryCondition {
+    fn should_retry(&mut self, err: &CasClientError) -> bool {
+        // we only care about retrying some error yielded by trying to deserialize the stream
+        let CasClientError::CasObjectError(CasObjectError::InternalIOError(cas_object_io_err)) = err else {
+            return false;
+        };
+        let Some(inner) = cas_object_io_err.get_ref() else {
+            return false;
+        };
+        let Some(inner_reqwest_err) = inner.downcast_ref::<reqwest::Error>() else {
+            return false;
+        };
+        // errors that indicate reading the body failed
+        inner_reqwest_err.is_body() || inner_reqwest_err.is_decode() || inner_reqwest_err.is_timeout()
+    }
+}
+
 /// use the provided http_client to make requests to S3/blob store using the url and url_range
 /// parts of a CASReconstructionFetchInfo. The url_range part is used directly in a http Range header
 /// value (see fn `range_header`).
@@ -448,46 +469,52 @@ async fn download_fetch_term_data(
     trace!("{hash},{},{}", fetch_term.range.start, fetch_term.range.end);
 
     let url = Url::parse(fetch_term.url.as_str())?;
-    let response = match http_client
-        .get(url)
-        .header(RANGE, fetch_term.url_range.range_header())
-        .with_extension(Api("s3::get_range"))
-        .send()
-        .await
-        .map_err(CasClientError::from)
-        .log_error("error downloading range")?
-        .error_for_status()
-    {
-        Ok(response) => response,
-        Err(e) => {
-            return match e.status() {
-                Some(StatusCode::FORBIDDEN) => {
-                    info!("error code {} for hash {hash}, will re-fetch reconstruction", StatusCode::FORBIDDEN,);
-                    Ok(DownloadRangeResult::Forbidden)
-                },
-                _ => Err(e.into()),
+
+    tokio_retry::RetryIf::spawn(
+        ExponentialBackoff::from_millis(BASE_RETRY_DELAY_MS)
+            .max_delay(Duration::from_millis(BASE_RETRY_MAX_DURATION_MS))
+            .take(NUM_RETRIES as usize),
+        || async {
+            let response = match http_client
+                .get(url.clone())
+                .header(RANGE, fetch_term.url_range.range_header())
+                .with_extension(Api("s3::get_range"))
+                .send()
+                .await
+                .map_err(CasClientError::from)
+                .log_error("error downloading range")?
+                .error_for_status()
+            {
+                Ok(response) => response,
+                Err(e) => return match e.status() {
+                    Some(StatusCode::FORBIDDEN) => {
+                        info!("error code {} for hash {hash}, will re-fetch reconstruction", StatusCode::FORBIDDEN,);
+                        Ok(DownloadRangeResult::Forbidden)
+                    },
+                    _ => Err(e.into()),
+                }
+                .log_error("error code"),
+            };
+            if let Some(content_length) = response.content_length() {
+                let expected_len = fetch_term.url_range.length();
+                if content_length != expected_len {
+                    error!("got back a smaller byte range ({content_length}) than requested ({expected_len}) from s3");
+                    return Err(CasClientError::InvalidRange);
+                }
             }
-            .log_error("error code")
+            let (data, chunk_byte_indices) = cas_object::deserialize_async::deserialize_chunks_from_stream(
+                response.bytes_stream().map_err(std::io::Error::other),
+            )
+            .await?;
+            Ok(DownloadRangeResult::Data(TermDownloadOutput {
+                data,
+                chunk_byte_indices,
+                chunk_range: fetch_term.range,
+            }))
         },
-    };
-
-    if let Some(content_length) = response.content_length() {
-        let expected_len = fetch_term.url_range.length();
-        if content_length != expected_len {
-            error!("got back a smaller byte range ({content_length}) than requested ({expected_len}) from s3");
-            return Err(CasClientError::InvalidRange);
-        }
-    }
-
-    let (data, chunk_byte_indices) = cas_object::deserialize_async::deserialize_chunks_from_stream(
-        response.bytes_stream().map_err(std::io::Error::other),
+        RetryCondition,
     )
-    .await?;
-    Ok(DownloadRangeResult::Data(TermDownloadOutput {
-        data,
-        chunk_byte_indices,
-        chunk_range: fetch_term.range,
-    }))
+    .await
 }
 
 #[cfg(test)]

--- a/cas_client/src/http_client.rs
+++ b/cas_client/src/http_client.rs
@@ -19,9 +19,9 @@ use utils::auth::{AuthConfig, TokenProvider};
 
 use crate::{error, CasClientError};
 
-const NUM_RETRIES: u32 = 5;
-const BASE_RETRY_DELAY_MS: u64 = 3000; // 3s
-const BASE_RETRY_MAX_DURATION_MS: u64 = 6 * 60 * 1000; // 6m
+pub(crate) const NUM_RETRIES: u32 = 5;
+pub(crate) const BASE_RETRY_DELAY_MS: u64 = 3000; // 3s
+pub(crate) const BASE_RETRY_MAX_DURATION_MS: u64 = 6 * 60 * 1000; // 6m
 
 /// A strategy that doesn't retry on 429, and defaults to `DefaultRetryableStrategy` otherwise.
 pub struct No429RetryStrategy;

--- a/hf_xet/Cargo.lock
+++ b/hf_xet/Cargo.lock
@@ -306,6 +306,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.11",
  "tokio",
+ "tokio-retry",
  "tracing",
  "url",
  "utils",
@@ -2481,7 +2482,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3370,6 +3371,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project",
+ "rand 0.8.5",
  "tokio",
 ]
 


### PR DESCRIPTION
fix XET-567

This PR adds the retry mechanism on downloading a range from CF/S3 for when an error occurs reading or parsing the body.
The upload is handled by reverting a change to reintroduce retries on a clonable body PR #328.