### PR TITLE
add retries on body read errors during download

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,6 +509,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.11",
  "tokio",
+ "tokio-retry",
  "tracing",
  "tracing-test",
  "url",
@@ -3812,6 +3813,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project",
+ "rand 0.8.5",
  "tokio",
 ]
 

--- a/cas_client/Cargo.toml
+++ b/cas_client/Cargo.toml
@@ -38,6 +38,7 @@ heed = "0.11"
 futures = "0.3.31"
 derivative = "2.2.0"
 more-asserts = "0.3.1"
+tokio-retry = "0.3.0"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/cas_client/src/download_utils.rs
+++ b/cas_client/src/download_utils.rs
@@ -377,7 +377,10 @@ impl tokio_retry::Condition<CasClientError> for ChunkRangeDeserializeFromBytesSt
             return false;
         };
         // errors that indicate reading the body failed
-        inner_reqwest_err.is_body() || inner_reqwest_err.is_decode() || inner_reqwest_err.is_timeout()
+        inner_reqwest_err.is_body()
+            || inner_reqwest_err.is_decode()
+            || inner_reqwest_err.is_timeout()
+            || inner_reqwest_err.is_request()
     }
 }
 

--- a/cas_client/src/download_utils.rs
+++ b/cas_client/src/download_utils.rs
@@ -2,10 +2,6 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
-use crate::error::{CasClientError, Result};
-use crate::http_client::{Api, BASE_RETRY_DELAY_MS, BASE_RETRY_MAX_DURATION_MS, NUM_RETRIES};
-use crate::remote_client::{get_reconstruction_with_endpoint_and_client, PREFIX_DEFAULT};
-use crate::OutputProvider;
 use cas_object::error::CasObjectError;
 use cas_types::{CASReconstructionFetchInfo, CASReconstructionTerm, ChunkRange, FileRange, HexMerkleHash, Key};
 use chunk_cache::ChunkCache;
@@ -22,6 +18,11 @@ use tokio_retry::strategy::ExponentialBackoff;
 use tracing::{debug, error, info, trace};
 use url::Url;
 use utils::singleflight::Group;
+
+use crate::error::{CasClientError, Result};
+use crate::http_client::{Api, BASE_RETRY_DELAY_MS, BASE_RETRY_MAX_DURATION_MS, NUM_RETRIES};
+use crate::remote_client::{get_reconstruction_with_endpoint_and_client, PREFIX_DEFAULT};
+use crate::OutputProvider;
 
 #[derive(Clone, Debug)]
 pub(crate) enum DownloadRangeResult {

--- a/cas_client/src/http_client.rs
+++ b/cas_client/src/http_client.rs
@@ -19,9 +19,9 @@ use utils::auth::{AuthConfig, TokenProvider};
 
 use crate::{error, CasClientError};
 
-const NUM_RETRIES: u32 = 5;
-const BASE_RETRY_DELAY_MS: u64 = 3000; // 3s
-const BASE_RETRY_MAX_DURATION_MS: u64 = 6 * 60 * 1000; // 6m
+pub(crate) const NUM_RETRIES: u32 = 5;
+pub(crate) const BASE_RETRY_DELAY_MS: u64 = 3000; // 3s
+pub(crate) const BASE_RETRY_MAX_DURATION_MS: u64 = 6 * 60 * 1000; // 6m
 
 /// A strategy that doesn't retry on 429, and defaults to `DefaultRetryableStrategy` otherwise.
 pub struct No429RetryStratey;

--- a/hf_xet/Cargo.lock
+++ b/hf_xet/Cargo.lock
@@ -306,6 +306,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.11",
  "tokio",
+ "tokio-retry",
  "tracing",
  "url",
  "utils",
@@ -3438,6 +3439,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project",
+ "rand 0.8.5",
  "tokio",
 ]
 


### PR DESCRIPTION
fix XET-567

This PR adds the retry mechanism on downloading a range from CF/S3 for when an error occurs reading or parsing the body.
The upload is handled by reverting a change to reintroduce retries on a clonable body PR https://github.com/huggingface/xet-core/pull/328.