### PR TITLE
Fix release build issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,7 +258,7 @@ jobs:
       - name: Patch sdist
         run: |
           pushd hf_xet/dist
-          DISTFILE=$(ls -tr1 hf-xet-*.tar.gz | tail -n 1)
+          DISTFILE=$(ls -tr1 hf_xet-*.tar.gz | tail -n 1)
           DISTNAME=${DISTFILE%.tar.gz}
           # maturin sdist will overwrite an edited pyproject.toml in the repo root, so we need to 
           # update the python path in the built pyproject.toml to account for that.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,7 @@ jobs:
           objcopy --add-gnu-debuglink=hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so.dbg hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so
           mv hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so.dbg ../hf_xet/dbg/hf_xet.abi3.so.dbg
           wheel pack hf_xet-${WHEEL_VERSION} 
+          rm -rf hf_xet-${WHEEL_VERSION}
       - name: Upload debug symbols
         uses: actions/upload-artifact@v4
         with:
@@ -97,7 +98,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: wheels-linux-${{ matrix.platform.target }}
-          path: hf_xet/dist
+          path: dist
 
   musllinux:
     runs-on: ${{ matrix.platform.runner }}
@@ -156,6 +157,7 @@ jobs:
           objcopy --add-gnu-debuglink=hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so.dbg hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so
           mv hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so.dbg ../hf_xet/dbg/hf_xet.abi3.so.dbg
           wheel pack hf_xet-${WHEEL_VERSION} 
+          rm -rf hf_xet-${WHEEL_VERSION}
       - name: Upload debug symbols
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches: 
       - main
+      - brian/test-release-builds
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ on:
   push:
     branches: 
       - main
-      - brian/test-release-builds
   workflow_dispatch:
     inputs:
       tag:
@@ -70,15 +69,24 @@ jobs:
             fi
       - name: Strip debug symbols into a separate file
         run: |
+          shopt -s expand_aliases 
+          if [[ ${{ matrix.platform.target }} == "aarch64" ]]
+          then
+            sudo apt-get install -y binutils-aarch64-linux-gnu
+            alias objcopy=aarch64-linux-gnu-objcopy
+          fi
+
           mkdir hf_xet/dbg
-          pushd hf_xet/dist
+          mkdir dist
+          pushd dist 
+          cp ../hf_xet/dist/* .
           LATEST_WHEEL=$(ls -tr1 *.whl | tail -n 1)
           WHEEL_VERSION=$(echo $LATEST_WHEEL | cut -d '-' -f 2)
           wheel unpack $LATEST_WHEEL 
           objcopy --only-keep-debug hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so.dbg
           objcopy --strip-debug hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so
           objcopy --add-gnu-debuglink=hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so.dbg hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so
-          mv hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so.dbg ../../dbg/hf_xet.abi3.so.dbg
+          mv hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so.dbg ../hf_xet/dbg/hf_xet.abi3.so.dbg
           wheel pack hf_xet-${WHEEL_VERSION} 
       - name: Upload debug symbols
         uses: actions/upload-artifact@v4
@@ -129,26 +137,35 @@ jobs:
           working-directory: hf_xet
       - name: Strip debug symbols into a separate file
         run: |
+          shopt -s expand_aliases 
+          if [[ ${{ matrix.platform.target }} == "aarch64" ]]
+          then
+            sudo apt-get install -y binutils-aarch64-linux-gnu
+            alias objcopy=aarch64-linux-gnu-objcopy
+          fi
+        
           mkdir hf_xet/dbg
-          pushd hf_xet/dist
+          mkdir dist
+          pushd dist 
+          cp ../hf_xet/dist/* .
           LATEST_WHEEL=$(ls -tr1 *.whl | tail -n 1)
           WHEEL_VERSION=$(echo $LATEST_WHEEL | cut -d '-' -f 2)
           wheel unpack $LATEST_WHEEL 
           objcopy --only-keep-debug hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so.dbg
           objcopy --strip-debug hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so
           objcopy --add-gnu-debuglink=hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so.dbg hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so
-          mv hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so.dbg ../dbg/hf_xet.abi3.so.dbg
+          mv hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so.dbg ../hf_xet/dbg/hf_xet.abi3.so.dbg
           wheel pack hf_xet-${WHEEL_VERSION} 
       - name: Upload debug symbols
         uses: actions/upload-artifact@v4
         with:
-          path: dbg-musllinux-${{ matrix.platform.target }}
-          name: hf_xet/dbg
+          name: dbg-musllinux-${{ matrix.platform.target }}
+          path: hf_xet/dbg
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
           name: wheels-musllinux-${{ matrix.platform.target }}
-          path: hf_xet/dist
+          path: dist
 
   windows:
     runs-on: ${{ matrix.platform.runner }}
@@ -157,6 +174,7 @@ jobs:
         platform:
           - runner: windows-latest
             target: x64
+            rust_target: x86_64-pc-windows-msvc
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -179,9 +197,10 @@ jobs:
           sccache: 'true'
           working-directory: hf_xet
       - name: Copy debug symbols
+        shell: bash
         run: |
           mkdir hf_xet/dbg
-          cp hf_xet/target/release/hf_xet.pdb hf_xet/dbg/ 
+          cp hf_xet/target/${{ matrix.platform.rust_target }}/release/hf_xet.pdb hf_xet/dbg/ 
       - name: Upload debug symbols
         uses: actions/upload-artifact@v4
         with:
@@ -200,8 +219,10 @@ jobs:
         platform:
           - runner: macos-13
             target: x86_64
+            rust_target: x86_64-apple-darwin
           - runner: macos-14
             target: aarch64
+            rust_target: aarch64-apple-darwin
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -225,9 +246,9 @@ jobs:
         run: |
           TARGET=${{ matrix.platform.target }}
           mkdir hf_xet/dbg
-          pushd hf_xet/target/release-dbgsymbols/deps
+          pushd hf_xet/target/${{ matrix.platform.rust_target}}/release-dbgsymbols/deps
           sed -i '' "s/binary-path:.*/binary-path: '.\/hf_xet.abi3.so'/" libhf_xet.dylib.dSYM/Contents/Resources/Relocations/${TARGET}/libhf_xet.dylib.yml
-          cp -r libhf_xet.dylib.dSYM ../../../dbg/
+          cp -r libhf_xet.dylib.dSYM ../../../../dbg/
       - name: Upload debug symbols
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Upload debug symbols
         uses: actions/upload-artifact@v4
         with:
-          name: dbg-manylinux-${{ matrix.platform.target }}
+          name: dbg-linux-${{ matrix.platform.target }}
           path: hf_xet/dbg
       - name: Upload wheels
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
There were a number of issues with #330 that didn't show up in local dev testing that showed up in github actions:

1. Mac, Win: building with a target on mac and windows placed the debug symbols in a different place (rust quirk)
2. Linux: the output folder by maturin didn't have write permissions for the user (maturin runs as sudo)
3. Linux: objcopy does not work on aarch64 (you need to install an aarch64 version of binutils) 
4. sdist: the path was broken (the path for `ls` was wrong)