### PR TITLE
Incremental progress on upload_xorb with retry_wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,6 +495,7 @@ dependencies = [
  "futures",
  "heed",
  "http 1.2.0",
+ "http-body 1.0.1",
  "httpmock",
  "itertools 0.10.5",
  "mdb_shard",

--- a/cas_client/Cargo.toml
+++ b/cas_client/Cargo.toml
@@ -38,6 +38,7 @@ heed = "0.11"
 futures = "0.3.31"
 derivative = "2.2.0"
 more-asserts = "0.3.1"
+http-body = "1"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/cas_client/src/lib.rs
+++ b/cas_client/src/lib.rs
@@ -16,4 +16,5 @@ mod http_client;
 mod interface;
 mod local_client;
 pub mod remote_client;
+mod retry_utils;
 mod upload_progress_stream;

--- a/cas_client/src/retry_utils.rs
+++ b/cas_client/src/retry_utils.rs
@@ -1,0 +1,73 @@
+use std::future::Future;
+use std::time::SystemTime;
+
+use reqwest_middleware::Error;
+use reqwest_retry::{RetryDecision, RetryPolicy, Retryable, RetryableStrategy};
+
+use crate::http_client::get_retry_policy_and_strategy;
+use crate::RetryConfig;
+
+/// Executes a request-generating function with retry logic using a provided strategy and backoff policy.
+///
+/// This wrapper is intended for use around requests that cannot use the retry middleware for
+/// whatever reason (E.g. reading data from streams).  It replicates the exact same logic in the
+/// retry middleware by using the same policy and strategy structs used there.
+///
+/// # Parameters
+///
+/// - `create_request`: A closure that creates and executes the request, returning a future that resolves to a
+///   `Result<reqwest::Response, reqwest_middleware::Error>`.
+/// - `retry_config`: Configuration that defines retry behavior, including maximum retries, timing, and the retry
+///   strategy.
+///
+/// # Returns
+///
+/// Returns `Ok(reqwest::Response)` on success, or the final `Err(reqwest_middleware::Error)` if
+/// no further retries are allowed or the error is non-retryable.
+///
+/// # Example
+/// ```rust
+/// let result = reqwest_retry_wrapper(
+///     || client.get("https://example.com").send(),
+///     RetryConfig<DefaultRetryableStrategy>::default()
+/// )
+/// .await;
+/// ```
+pub async fn reqwest_retry_wrapper<R, F, Fut>(
+    create_request: F,
+    retry_config: RetryConfig<R>,
+) -> Result<reqwest::Response, Error>
+where
+    R: RetryableStrategy + Send + Sync,
+    F: Fn() -> Fut,
+    Fut: Future<Output = Result<reqwest::Response, Error>>,
+{
+    let (retry_policy, strategy) = get_retry_policy_and_strategy(retry_config);
+    let start_time = SystemTime::now();
+
+    for attempt in 0.. {
+        let result = create_request().await;
+
+        // If all is ok, then return.
+        if result.is_ok() {
+            return result;
+        }
+
+        // Do we retry?
+        let Some(Retryable::Transient) = strategy.handle(&result) else {
+            return result;
+        };
+
+        match retry_policy.should_retry(start_time, attempt) {
+            RetryDecision::Retry { execute_after } => {
+                // Retry after system time is a specific value.
+                if let Ok(wait_dur) = execute_after.duration_since(SystemTime::now()) {
+                    tokio::time::sleep(wait_dur).await;
+                }
+            },
+            RetryDecision::DoNotRetry => return result,
+        }
+    }
+
+    unreachable!("Retry loop should exit via return on success or final failure");
+}

--- a/cas_client/src/upload_progress_stream.rs
+++ b/cas_client/src/upload_progress_stream.rs
@@ -1,24 +1,52 @@
 use std::pin::Pin;
+use std::sync::atomic::AtomicUsize;
+use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use bytes::Bytes;
 use futures::Stream;
 use more_asserts::*;
 
+struct ProgressCallbackWrapper<F>
+where
+    F: Fn(u64) + Send + Unpin + 'static,
+{
+    progress_callback: F,
+    bytes_sent_already_reported: AtomicUsize,
+}
+
+impl<F> ProgressCallbackWrapper<F>
+where
+    F: Fn(u64) + Send + Unpin + 'static,
+{
+    fn update(&self, new_completed: usize) {
+        // We strictly increment here; that way, if there's been a clone and a restart of the stream, we only
+        // report new bytes sent as progress.
+        let old_completed = self
+            .bytes_sent_already_reported
+            .fetch_max(new_completed, std::sync::atomic::Ordering::Relaxed);
+
+        if old_completed < new_completed {
+            (self.progress_callback)((new_completed - old_completed) as u64)
+        }
+    }
+}
+
 pub struct UploadProgressStream<F>
 where
-    F: FnMut(u64) + Send + 'static,
+    F: Fn(u64) + Send + Unpin + 'static,
 {
     data: Bytes,
+    progress_callback: Arc<ProgressCallbackWrapper<F>>,
     block_size: usize,
-    progress_callback: F,
+
+    /// Number of bytes that have been sent already
     bytes_sent: usize,
-    last_update: usize,
 }
 
 impl<F> Stream for UploadProgressStream<F>
 where
-    F: FnMut(u64) + Send + Unpin + 'static,
+    F: Fn(u64) + Send + Unpin + 'static,
 {
     type Item = std::result::Result<Bytes, std::io::Error>;
 
@@ -34,15 +62,13 @@ where
         // the previous data has
         // successfully completed uploading.
 
-        if self.last_update != 0 {
-            let update = self.last_update;
-            (self.progress_callback)(update as u64);
+        if self.bytes_sent != 0 {
+            self.progress_callback.update(self.bytes_sent);
         }
 
         let slice_start = self.bytes_sent;
         let slice_end = (self.bytes_sent + self.block_size).min(self.data.len());
 
-        self.last_update = slice_end - slice_start;
         self.bytes_sent = slice_end;
 
         Poll::Ready(Some(Ok(self.data.slice(slice_start..slice_end))))
@@ -51,15 +77,130 @@ where
 
 impl<F> UploadProgressStream<F>
 where
-    F: FnMut(u64) + Send + 'static,
+    F: Fn(u64) + Send + Unpin + 'static,
 {
     pub fn new(data: impl Into<Bytes>, block_size: usize, progress_callback: F) -> Self {
         Self {
             data: data.into(),
+            progress_callback: Arc::new(ProgressCallbackWrapper {
+                progress_callback,
+                bytes_sent_already_reported: 0.into(),
+            }),
             block_size,
-            progress_callback,
             bytes_sent: 0,
-            last_update: 0,
         }
+    }
+
+    /// Creates a duplicate of the stream with the location tracker reset.  Progress updates are only
+    /// reported after new progress is achieved
+    pub fn clone_with_reset(&self) -> Self {
+        Self {
+            data: self.data.clone(),
+            block_size: self.block_size,
+            progress_callback: self.progress_callback.clone(),
+
+            // This resets the position of the stream on clone as this is just used
+            // for retries within reqwest.
+            bytes_sent: 0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use futures::executor::block_on;
+    use futures::stream::StreamExt;
+
+    use super::*;
+
+    #[test]
+    fn test_basic_streaming_and_progress() {
+        let data = Bytes::from("abcdefghij"); // 10 bytes
+        let block_size = 3;
+
+        let progress_reported = Arc::new(Mutex::new(Vec::new()));
+        let callback = {
+            let progress_reported = progress_reported.clone();
+            move |v| progress_reported.lock().unwrap().push(v)
+        };
+
+        let mut stream = UploadProgressStream::new(data.clone(), block_size, callback);
+
+        let mut result = Vec::new();
+        block_on(async {
+            while let Some(chunk) = stream.next().await {
+                result.push(chunk.unwrap());
+            }
+        });
+
+        assert_eq!(
+            result,
+            vec![
+                Bytes::from("abc"),
+                Bytes::from("def"),
+                Bytes::from("ghi"),
+                Bytes::from("j"),
+            ]
+        );
+
+        // Progress callback is only called *after* a chunk has been confirmed sent (on the *next* poll).
+        // So it only fires for second and later chunks.
+        assert_eq!(*progress_reported.lock().unwrap(), vec![3, 3, 3]);
+    }
+
+    #[test]
+    fn test_clone_with_reset_does_not_duplicate_progress() {
+        let data = Bytes::from("abcdef"); // 6 bytes
+        let block_size = 3;
+
+        let progress_reported = Arc::new(Mutex::new(Vec::new()));
+        let callback = {
+            let progress_reported = progress_reported.clone();
+            move |v| progress_reported.lock().unwrap().push(v)
+        };
+
+        let mut stream = UploadProgressStream::new(data.clone(), block_size, callback);
+        block_on(async {
+            assert_eq!(stream.next().await.unwrap().unwrap(), Bytes::from("abc"));
+            assert_eq!(stream.next().await.unwrap().unwrap(), Bytes::from("def"));
+            assert!(stream.next().await.is_none());
+        });
+
+        let mut cloned = stream.clone_with_reset();
+        block_on(async {
+            assert_eq!(cloned.next().await.unwrap().unwrap(), Bytes::from("abc"));
+            assert_eq!(cloned.next().await.unwrap().unwrap(), Bytes::from("def"));
+            assert!(cloned.next().await.is_none());
+        });
+
+        // The progress callback only fires after the *first* stream reports new bytes sent.
+        // The cloned stream starts from zero, but those bytes were already reported, so only the new delta is recorded.
+        // Since the clone sends the same total bytes as the original, and no new progress is made, nothing is reported.
+        assert_eq!(*progress_reported.lock().unwrap(), vec![3]);
+    }
+
+    #[test]
+    fn test_partial_progress_reporting() {
+        let data = Bytes::from("abcdef"); // 6 bytes
+        let block_size = 2;
+
+        let progress_reported = Arc::new(Mutex::new(Vec::new()));
+        let callback = {
+            let progress_reported = progress_reported.clone();
+            move |v| progress_reported.lock().unwrap().push(v)
+        };
+
+        let mut stream = UploadProgressStream::new(data.clone(), block_size, callback);
+
+        block_on(async {
+            assert_eq!(stream.next().await.unwrap().unwrap(), Bytes::from("ab")); // nothing reported yet
+            assert_eq!(stream.next().await.unwrap().unwrap(), Bytes::from("cd")); // +2 reported
+            assert_eq!(stream.next().await.unwrap().unwrap(), Bytes::from("ef")); // +2 reported
+            assert!(stream.next().await.is_none()); // last call triggers +6
+        });
+
+        assert_eq!(*progress_reported.lock().unwrap(), vec![2, 2]);
     }
 }

--- a/data/src/file_upload_session.rs
+++ b/data/src/file_upload_session.rs
@@ -203,7 +203,7 @@ impl FileUploadSession {
         // In some circumstances, we can cut to instances of the same xorb, namely when there are two files
         // with the same starting data that get processed simultaneously.  When this happens, we only upload
         // the first one, returning early here.
-        let xorb_already_completed = self
+        let xorb_is_new = self
             .completion_tracker
             .register_new_xorb(xorb_hash, xorb.num_bytes() as u64)
             .await;
@@ -212,7 +212,7 @@ impl FileUploadSession {
         // we start the upload.
         self.completion_tracker.register_dependencies(file_dependencies).await;
 
-        if xorb_already_completed {
+        if !xorb_is_new {
             return Ok(false);
         }
 

--- a/hf_xet/Cargo.lock
+++ b/hf_xet/Cargo.lock
@@ -294,6 +294,7 @@ dependencies = [
  "futures",
  "heed",
  "http 1.1.0",
+ "http-body 1.0.1",
  "itertools 0.10.5",
  "mdb_shard",
  "merkledb",

--- a/hf_xet/src/log.rs
+++ b/hf_xet/src/log.rs
@@ -15,7 +15,7 @@ use crate::log_buffer::{get_telemetry_task, LogBufferLayer, TelemetryTaskInfo, T
 const DEFAULT_LOG_LEVEL: &str = "warn";
 
 #[cfg(debug_assertions)]
-const DEFAULT_LOG_LEVEL: &str = "info";
+const DEFAULT_LOG_LEVEL: &str = "warn";
 
 fn init_global_logging(py: Python) -> Option<TelemetryTaskInfo> {
     let fmt_layer = tracing_subscriber::fmt::layer()

--- a/mdb_shard/src/shard_file_manager.rs
+++ b/mdb_shard/src/shard_file_manager.rs
@@ -274,7 +274,7 @@ impl ShardFileManager {
         }
 
         if num_shards != 0 {
-            info!("Registered {num_shards} new shards.");
+            debug!("Registered {num_shards} new shards.");
         }
 
         Ok(())

--- a/progress_tracking/src/upload_tracking.rs
+++ b/progress_tracking/src/upload_tracking.rs
@@ -71,6 +71,9 @@ struct CompletionTrackerImpl {
     xorbs: HashMap<MerkleHash, XorbDependency>,
 
     /// Keep track of the totals across all xorbs.
+    total_upload_bytes: u64,
+    total_upload_bytes_completed: u64,
+
     total_bytes: u64,
     total_bytes_completed: u64,
 }
@@ -83,7 +86,11 @@ pub struct CompletionTracker {
 impl CompletionTrackerImpl {
     /// Registers a new file for tracking and returns an ID (its index in `files`).
     /// `n_bytes` is the total size of the file.
-    fn register_new_file(&mut self, name: impl Into<Arc<str>>, n_bytes: u64) -> CompletionTrackerFileId {
+    fn register_new_file(
+        &mut self,
+        name: impl Into<Arc<str>>,
+        n_bytes: u64,
+    ) -> (ProgressUpdate, CompletionTrackerFileId) {
         // The file's ID is simply its index in the internal `files` vector.
         let file_id = self.files.len() as CompletionTrackerFileId;
 
@@ -98,14 +105,33 @@ impl CompletionTrackerImpl {
         // Insert it into our files vector.
         self.files.push(file_dependency);
 
-        // Return the file ID so the caller can register dependencies on this file.
-        file_id
+        // We have more to process now.
+        self.total_bytes += n_bytes;
+
+        // Register that the total bytes known has changed, and return the file ID so the caller can register
+        // dependencies on this file.
+        (
+            ProgressUpdate {
+                item_updates: vec![],
+                total_bytes: self.total_bytes,
+                total_bytes_increment: n_bytes,
+                total_bytes_completed: self.total_bytes_completed,
+                total_bytes_completion_increment: 0,
+                total_transfer_bytes: self.total_upload_bytes,
+                total_transfer_bytes_increment: 0,
+                total_transfer_bytes_completed: self.total_upload_bytes_completed,
+                total_transfer_bytes_completion_increment: 0,
+            },
+            file_id,
+        )
     }
 
     /// Registers that all or part of a given file (by `file_id`) depends on one or more
     /// xorbs; Given a list of (xorb_hash, n_bytes, already_uploaded), registers the progress.
     fn register_dependencies(&mut self, dependencies: &[FileXorbDependency]) -> ProgressUpdate {
         let mut item_updates = Vec::new();
+
+        let mut file_bytes_processed = 0;
 
         for dep in dependencies {
             let file_entry = &mut self.files[dep.file_id as usize];
@@ -117,10 +143,12 @@ impl CompletionTrackerImpl {
 
                 let progress_update = ItemProgressUpdate {
                     item_name: file_entry.name.clone(),
-                    total_count: file_entry.total_bytes,
-                    completed_count: file_entry.completed_bytes,
-                    update_increment: dep.n_bytes,
+                    total_bytes: file_entry.total_bytes,
+                    bytes_completed: file_entry.completed_bytes,
+                    bytes_completion_increment: dep.n_bytes,
                 };
+
+                file_bytes_processed += dep.n_bytes;
 
                 item_updates.push(progress_update);
             } else {
@@ -137,11 +165,12 @@ impl CompletionTrackerImpl {
 
                     let progress_update = ItemProgressUpdate {
                         item_name: file_entry.name.clone(),
-                        total_count: file_entry.total_bytes,
-                        completed_count: file_entry.completed_bytes,
-                        update_increment: dep.n_bytes,
+                        total_bytes: file_entry.total_bytes,
+                        bytes_completed: file_entry.completed_bytes,
+                        bytes_completion_increment: dep.n_bytes,
                     };
                     item_updates.push(progress_update);
+                    file_bytes_processed += dep.n_bytes;
                 } else {
                     // Set the reference here to this file
                     entry.file_indices.insert(dep.file_id as usize);
@@ -152,23 +181,33 @@ impl CompletionTrackerImpl {
             }
         }
 
+        // Register that this much has been completed already
+        self.total_bytes_completed += file_bytes_processed;
+
+        debug_assert_le!(self.total_bytes_completed, self.total_bytes);
+
         // There may be a lot of per-file updates, but these don't actually count against the new byte total;
         // this is counted only using xorbs.
         ProgressUpdate {
             item_updates,
             total_bytes: self.total_bytes,
+            total_bytes_increment: 0,
             total_bytes_completed: self.total_bytes_completed,
-            total_bytes_completion_increment: 0,
+            total_bytes_completion_increment: file_bytes_processed,
+            total_transfer_bytes: self.total_upload_bytes,
+            total_transfer_bytes_increment: 0,
+            total_transfer_bytes_completed: self.total_upload_bytes_completed,
+            total_transfer_bytes_completion_increment: 0,
         }
     }
 
-    /// Register a new xorb.  Returns true if the xorb is already in the queue, and false
-    /// if not.
-    fn register_new_xorb(&mut self, xorb_hash: MerkleHash, xorb_size: u64) -> bool {
+    /// Register a new xorb.  Returns true if the xorb is new and now registered for upload, and false
+    /// if it's already been uploaded and registered.
+    fn register_new_xorb(&mut self, xorb_hash: MerkleHash, xorb_size: u64) -> (ProgressUpdate, bool) {
         match self.xorbs.entry(xorb_hash) {
             HashMapEntry::Occupied(occupied_entry) => {
                 debug_assert_eq!(occupied_entry.get().xorb_size, xorb_size);
-                true
+                (ProgressUpdate::default(), false)
             },
             HashMapEntry::Vacant(vacant_entry) => {
                 vacant_entry.insert(XorbDependency {
@@ -178,9 +217,22 @@ impl CompletionTrackerImpl {
                     is_completed: false,
                 });
 
-                self.total_bytes += xorb_size;
+                self.total_upload_bytes += xorb_size;
 
-                false
+                (
+                    ProgressUpdate {
+                        item_updates: vec![],
+                        total_bytes: self.total_bytes,
+                        total_bytes_increment: 0,
+                        total_bytes_completed: self.total_bytes_completed,
+                        total_bytes_completion_increment: 0,
+                        total_transfer_bytes: self.total_upload_bytes,
+                        total_transfer_bytes_increment: xorb_size,
+                        total_transfer_bytes_completed: self.total_upload_bytes_completed,
+                        total_transfer_bytes_completion_increment: 0,
+                    },
+                    true,
+                )
             },
         }
     }
@@ -210,6 +262,8 @@ impl CompletionTrackerImpl {
         // Mark all the relevant files as completed
         let mut item_updates = Vec::with_capacity(file_indices.len());
 
+        let mut file_bytes_processed = 0;
+
         // For each file that depends on this xorb, remove the relevant
         // part from `remaining_xorbs_parts` and add to `completed_bytes`.
         for file_id in file_indices {
@@ -228,23 +282,33 @@ impl CompletionTrackerImpl {
 
                 let progress_update = ItemProgressUpdate {
                     item_name: file_entry.name.clone(),
-                    total_count: file_entry.total_bytes,
-                    completed_count: file_entry.completed_bytes,
-                    update_increment: n_bytes_remaining,
+                    total_bytes: file_entry.total_bytes,
+                    bytes_completed: file_entry.completed_bytes,
+                    bytes_completion_increment: n_bytes_remaining,
                 };
+
+                file_bytes_processed += n_bytes_remaining;
 
                 item_updates.push(progress_update);
             }
         }
 
-        debug_assert_le!(self.total_bytes_completed + byte_completion_increment, self.total_bytes);
-        self.total_bytes_completed += byte_completion_increment;
+        debug_assert_le!(self.total_upload_bytes_completed + byte_completion_increment, self.total_upload_bytes);
+        self.total_upload_bytes_completed += byte_completion_increment;
+
+        self.total_bytes_completed += file_bytes_processed;
+        debug_assert_le!(self.total_bytes_completed, self.total_bytes);
 
         ProgressUpdate {
             item_updates,
             total_bytes: self.total_bytes,
+            total_bytes_increment: 0,
             total_bytes_completed: self.total_bytes_completed,
-            total_bytes_completion_increment: byte_completion_increment,
+            total_bytes_completion_increment: file_bytes_processed,
+            total_transfer_bytes: self.total_upload_bytes,
+            total_transfer_bytes_completed: self.total_upload_bytes_completed,
+            total_transfer_bytes_completion_increment: byte_completion_increment,
+            total_transfer_bytes_increment: 0,
         }
     }
 
@@ -271,8 +335,13 @@ impl CompletionTrackerImpl {
             return ProgressUpdate {
                 item_updates: vec![],
                 total_bytes: self.total_bytes,
+                total_bytes_increment: 0,
                 total_bytes_completed: self.total_bytes_completed,
                 total_bytes_completion_increment: 0,
+                total_transfer_bytes: self.total_upload_bytes,
+                total_transfer_bytes_increment: 0,
+                total_transfer_bytes_completed: self.total_upload_bytes_completed,
+                total_transfer_bytes_completion_increment: 0,
             };
         }
 
@@ -288,6 +357,8 @@ impl CompletionTrackerImpl {
 
         // Mark all the relevant files as completed
         let mut item_updates = Vec::with_capacity(entry.file_indices.len());
+
+        let mut file_bytes_processed = 0;
 
         // For each file that depends on this xorb, update a proportion of that remove the relevant
         // part from `remaining_xorbs_parts` and add to `completed_bytes`.
@@ -323,22 +394,31 @@ impl CompletionTrackerImpl {
 
                 let progress_update = ItemProgressUpdate {
                     item_name: file_entry.name.clone(),
-                    total_count: file_entry.total_bytes,
-                    completed_count: file_entry.completed_bytes,
-                    update_increment: incremental_update,
+                    total_bytes: file_entry.total_bytes,
+                    bytes_completed: file_entry.completed_bytes,
+                    bytes_completion_increment: incremental_update,
                 };
-
+                file_bytes_processed += incremental_update;
                 item_updates.push(progress_update);
             }
         }
 
-        self.total_bytes_completed += new_byte_progress;
+        self.total_upload_bytes_completed += new_byte_progress;
+        debug_assert_le!(self.total_upload_bytes_completed, self.total_upload_bytes);
+
+        self.total_bytes_completed += file_bytes_processed;
+        debug_assert_le!(self.total_bytes_completed, self.total_bytes);
 
         ProgressUpdate {
             item_updates,
+            total_transfer_bytes: self.total_upload_bytes,
+            total_transfer_bytes_increment: 0,
+            total_transfer_bytes_completed: self.total_upload_bytes_completed,
+            total_transfer_bytes_completion_increment: new_byte_progress,
             total_bytes: self.total_bytes,
+            total_bytes_increment: 0,
             total_bytes_completed: self.total_bytes_completed,
-            total_bytes_completion_increment: new_byte_progress,
+            total_bytes_completion_increment: file_bytes_processed,
         }
     }
 
@@ -407,11 +487,27 @@ impl CompletionTracker {
     }
 
     pub async fn register_new_file(&self, name: impl Into<Arc<str>>, n_bytes: u64) -> CompletionTrackerFileId {
-        self.inner.lock().await.register_new_file(name, n_bytes)
+        let mut update_lock = self.inner.lock().await;
+
+        let (updates, ret) = update_lock.register_new_file(name, n_bytes);
+
+        if !updates.is_empty() {
+            self.progress_reporter.register_updates(updates).await;
+        }
+
+        ret
     }
 
     pub async fn register_new_xorb(&self, xorb_hash: MerkleHash, xorb_size: u64) -> bool {
-        self.inner.lock().await.register_new_xorb(xorb_hash, xorb_size)
+        let mut update_lock = self.inner.lock().await;
+
+        let (updates, ret) = update_lock.register_new_xorb(xorb_hash, xorb_size);
+
+        if !updates.is_empty() {
+            self.progress_reporter.register_updates(updates).await;
+        }
+
+        ret
     }
 
     /// Register a list of (file_id, xorb_hash, usize, bool)
@@ -420,7 +516,7 @@ impl CompletionTracker {
 
         let updates = update_lock.register_dependencies(dependencies);
 
-        if updates.total_bytes_completion_increment != 0 || !updates.item_updates.is_empty() {
+        if !updates.is_empty() {
             self.progress_reporter.register_updates(updates).await;
         }
     }
@@ -430,7 +526,7 @@ impl CompletionTracker {
 
         let updates = update_lock.register_xorb_upload_completion(xorb_hash);
 
-        if updates.total_bytes_completion_increment != 0 || !updates.item_updates.is_empty() {
+        if !updates.is_empty() {
             self.progress_reporter.register_updates(updates).await;
         }
     }
@@ -458,7 +554,7 @@ impl CompletionTracker {
 
         let updates = update_lock.register_xorb_upload_progress(xorb_hash, new_byte_progress, check_ordering);
 
-        if updates.total_bytes_completion_increment != 0 || !updates.item_updates.is_empty() {
+        if !updates.is_empty() {
             self.progress_reporter.register_updates(updates).await;
         }
     }


### PR DESCRIPTION
This PR implements incremental progress reporting on the upload_xorb function, reporting progress every 512KB of data uploaded.  

In addition, errors are retried using the same retry policy as the other clients.  To get around Body::wrap_stream preventing retries due to cloning failing, this PR adds a simple retry wrapper utility that allows the entire request to be retried instead of doing it as part of the middleware layer.  

