### PR TITLE
Updates out-of-sync Cargo.lock in hf_xet/

### DIFF
--- a/hf_xet/Cargo.lock
+++ b/hf_xet/Cargo.lock
@@ -1195,7 +1195,7 @@ checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hf_xet"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "async-trait",
  "bipbuffer",


### PR DESCRIPTION
The version in hf_xet/Cargo.lock was not updated in the current main/