### PR TITLE
upload xorb head call

### DIFF
--- a/data/src/file_upload_session.rs
+++ b/data/src/file_upload_session.rs
@@ -278,7 +278,9 @@ impl FileUploadSession {
 
         // Check if the xorb already exists in the CAS.  If it does, we don't need to upload it again.
         // only check if configured to check
-        if *PREUPLOAD_CHECK_XORB_EXISTS && session.client.exists(&cas_prefix, &xorb_hash).await? {
+        if *PREUPLOAD_CHECK_XORB_EXISTS
+            && session.client.exists(&cas_prefix, &xorb_hash).await.is_ok_and(|exists| exists)
+        {
             // update tracker and return early
             debug!("Xorb {cas_prefix}/{xorb_hash} already exists in CAS, skipping upload");
             session.completion_tracker.register_xorb_upload_completion(xorb_hash).await;

--- a/data/src/file_upload_session.rs
+++ b/data/src/file_upload_session.rs
@@ -17,7 +17,7 @@ use progress_tracking::verification_wrapper::ProgressUpdaterVerificationWrapper;
 use progress_tracking::{NoOpProgressUpdater, TrackingProgressUpdater};
 use tokio::sync::{Mutex, OwnedSemaphorePermit, Semaphore};
 use tokio::task::JoinSet;
-use tracing::{info_span, instrument, Instrument};
+use tracing::{debug, info_span, instrument, Instrument};
 use ulid::Ulid;
 use utils::constant_declarations::GlobalConfigMode::HighPerformanceOption;
 
@@ -280,6 +280,7 @@ impl FileUploadSession {
         // only check if configured to check
         if *PREUPLOAD_CHECK_XORB_EXISTS && session.client.exists(&cas_prefix, &xorb_hash).await? {
             // update tracker and return early
+            debug!("Xorb {cas_prefix}/{xorb_hash} already exists in CAS, skipping upload");
             session.completion_tracker.register_xorb_upload_completion(xorb_hash).await;
             return Ok(true);
         }


### PR DESCRIPTION
fix XET-583

Adds a head call on a xorb before uploading a xorb to save time of transmitting a whole xorb. Only enabled when high performance mode is not enabled, users of high performance mode may suffer worse performance with an additional RTT per xorb than by transmitting 64MB.