### PR TITLE
Resume capability for interrupted upload file sessions.

### DIFF
--- a/cas_client/src/local_client.rs
+++ b/cas_client/src/local_client.rs
@@ -643,7 +643,7 @@ mod tests {
         )
         .unwrap();
 
-        let new_shard_path = shard_in.write_to_directory(&shard_dir_1).unwrap();
+        let new_shard_path = shard_in.write_to_directory(&shard_dir_1, None).unwrap();
 
         let shard_hash = parse_shard_filename(&new_shard_path).unwrap();
 

--- a/data/src/constants.rs
+++ b/data/src/constants.rs
@@ -39,4 +39,11 @@ utils::configurable_constants! {
     /// How often to send updates on file progress, in milliseconds
     ref PROGRESS_UPDATE_INTERVAL_MS : u64 = 500;
 
+    /// How often do we flush new xorb data to disk on a long running upload session?
+    ref SESSION_XORB_METADATA_FLUSH_INTERVAL_SECS : u64 = 20;
+
+    /// Force a flush of the xorb metadata every this many xorbs, if more are created
+    /// in this time window.
+    ref SESSION_XORB_METADATA_FLUSH_MAX_COUNT : usize = 64;
+
 }

--- a/data/src/shard_interface.rs
+++ b/data/src/shard_interface.rs
@@ -38,10 +38,10 @@ pub struct SessionShardInterface {
     // A place to write out shards that can help a future session resume.
     xorb_metadata_staging_dir: PathBuf,
 
-    // We can remove thes shards on final upload success.
+    // We can remove these shards on final upload success.
     staged_shards_to_remove_on_success: Vec<PathBuf>,
 
-    // The last time we flushed xorb metadata to disk, and the current state.
+    // The last time we flushed xorb metadata to disk and the current state of xorb metadata.
     xorb_metadata_staging: Mutex<(SystemTime, MDBInMemoryShard)>,
 
     _shard_session_dir: TempDir,

--- a/data/src/shard_interface.rs
+++ b/data/src/shard_interface.rs
@@ -159,7 +159,7 @@ impl SessionShardInterface {
         }
 
         let mut lg = self.xorb_metadata_staging.lock().await;
-        let (ref mut last_flush, ref mut xorb_shard) = *lg;
+        let (last_flush, xorb_shard) = &mut *lg;
 
         xorb_shard.add_cas_block(cas_block_contents)?;
 
@@ -174,10 +174,10 @@ impl SessionShardInterface {
                 &self.xorb_metadata_staging_dir,
                 Some(Duration::from_secs(*MDB_SHARD_LOCAL_CACHE_EXPIRATION_SECS)),
             )?;
-        }
 
-        *last_flush = time_now + flush_interval;
-        *xorb_shard = MDBInMemoryShard::default();
+            *last_flush = time_now + flush_interval;
+            *xorb_shard = MDBInMemoryShard::default();
+        }
 
         Ok(())
     }

--- a/mdb_shard/src/shard_benchmark.rs
+++ b/mdb_shard/src/shard_benchmark.rs
@@ -62,7 +62,7 @@ async fn run_shard_benchmark(
     for (n_shards, target_size) in shard_sizes {
         for i in 0..n_shards {
             let shard = make_shard(target_size, &mut seed);
-            let path = shard.write_to_directory(dir)?;
+            let path = shard.write_to_directory(dir, None)?;
 
             eprintln!(
                 "-> Target size {target_size:?}: Created shard {:?} / {n_shards:?} with {} CAS blocks and {} chunks",

--- a/mdb_shard/src/shard_file_handle.rs
+++ b/mdb_shard/src/shard_file_handle.rs
@@ -26,6 +26,8 @@ pub struct MDBShardFile {
     pub last_modified_time: SystemTime,
 }
 
+pub type MDBShardFileVec = Vec<Arc<MDBShardFile>>;
+
 impl Default for MDBShardFile {
     fn default() -> Self {
         Self {
@@ -48,6 +50,10 @@ impl MDBShardFile {
 
         s.verify_shard_integrity_debug_only();
         Ok(s)
+    }
+
+    pub fn copy_into_target_directory(&self, target_directory: impl AsRef<Path>) -> Result<Arc<Self>> {
+        Self::write_out_from_reader(target_directory, &mut self.get_reader()?)
     }
 
     pub fn write_out_from_reader<R: Read>(target_directory: impl AsRef<Path>, reader: &mut R) -> Result<Arc<Self>> {

--- a/mdb_shard/src/utils.rs
+++ b/mdb_shard/src/utils.rs
@@ -1,6 +1,7 @@
 use std::ffi::OsStr;
 use std::ops::Deref;
 use std::path::Path;
+use std::time::Duration;
 
 use lazy_static::lazy_static;
 use merklehash::MerkleHash;
@@ -46,6 +47,16 @@ pub fn is_temp_shard_file(p: &Path) -> bool {
         .to_str()
         .unwrap_or("")
         .ends_with("mdb_temp")
+}
+
+pub fn shard_expiry_time(shard_valid_for: Duration) -> u64 {
+    use std::ops::Add;
+
+    std::time::SystemTime::now()
+        .add(shard_valid_for)
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Currently, the metadata for uploaded data is only registered at the end of an upload session, and it's discarded if the session is interrupted before it completes.  This means that if an upload session is interrupted, a session resuming that won't take advantage of the previous data. 

With this PR, we cache the metadata for all of the successfully uploaded Xorbs in a persistent directory separate from the cache.  All the metadata in this directory gets pulled in to the temporary session directory at the start, allowing it to be used for deduplication.  Upon successful upload of all the data, it's registered on the server side along with the rest of the session metadata as before.  If that upload is successful, the intermediate xorb metadata along with the rest of the session metadata is merged into the persistent cache.

The user experience now is that when an upload session resumes from a previously interrupted session, all the data is still processed but the data that was uploaded previously is rapidly deduped against the previously uploaded xorbs, effectively meaning the session quickly resumes where it left off.  