### PR TITLE
Allow disabling progress aggregation.

### DIFF
--- a/data/src/constants.rs
+++ b/data/src/constants.rs
@@ -36,7 +36,8 @@ utils::configurable_constants! {
     /// The maximum block size from a file to process at once.
     ref INGESTION_BLOCK_SIZE : usize = 8 * 1024 * 1024;
 
-    /// How often to send updates on file progress, in milliseconds
+    /// How often to send updates on file progress, in milliseconds.  If zero, then
+    /// disable aggregation.
     ref PROGRESS_UPDATE_INTERVAL_MS : u64 = 500;
 
     /// How often do we flush new xorb data to disk on a long running upload session?

--- a/data/src/file_upload_session.rs
+++ b/data/src/file_upload_session.rs
@@ -118,8 +118,12 @@ impl FileUploadSession {
         let progress_updater: Arc<dyn TrackingProgressUpdater> = {
             match upload_progress_updater {
                 Some(updater) => {
-                    let update_interval = Duration::from_millis(*PROGRESS_UPDATE_INTERVAL_MS);
-                    AggregatingProgressUpdater::new(updater, update_interval)
+                    let update_seconds = *PROGRESS_UPDATE_INTERVAL_MS;
+                    if update_seconds != 0 {
+                        AggregatingProgressUpdater::new(updater, Duration::from_millis(update_seconds))
+                    } else {
+                        updater
+                    }
                 },
                 None => Arc::new(NoOpProgressUpdater),
             }


### PR DESCRIPTION
For testing, it's sometimes helpful to disable progress aggregation to check results accurately during the processing.  This PR enables this to be done by setting the PROGRESS_UPDATE_INTERVAL_MS config to 0. 