### PR TITLE
Debug Symbol cleanup and instructions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,12 @@ jobs:
         platform:
           - runner: ubuntu-22.04
             target: x86_64
+            python-target: x86_64
             manylinux: auto
             features: "--features openssl_vendored"
           - runner: ubuntu-22.04
             target: aarch64
+            python-target: arm64
             manylinux: manylinux_2_28
             features: "--features openssl_vendored"
     steps:
@@ -82,16 +84,14 @@ jobs:
           cp ../hf_xet/dist/* .
           LATEST_WHEEL=$(ls -tr1 *.whl | tail -n 1)
           WHEEL_VERSION=$(echo $LATEST_WHEEL | cut -d '-' -f 2)
+          SYMBOL_FILE=hf_xet-manylinux-${{ matrix.platform.python-target}}.abi3.so.dbg
           wheel unpack $LATEST_WHEEL 
-          objcopy --only-keep-debug hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so.dbg
+          objcopy --only-keep-debug hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so hf_xet-${WHEEL_VERSION}/hf_xet/${SYMBOL_FILE}
           objcopy --strip-debug hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so
-          objcopy --add-gnu-debuglink=hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so.dbg hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so
-          mv hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so.dbg ../hf_xet/dbg/hf_xet.abi3.so.dbg
+          objcopy --add-gnu-debuglink=hf_xet-${WHEEL_VERSION}/hf_xet/${SYMBOL_FILE} hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so
+          mv hf_xet-${WHEEL_VERSION}/hf_xet/${SYMBOL_FILE} ../hf_xet/dbg/${SYMBOL_FILE}
           wheel pack hf_xet-${WHEEL_VERSION} 
           rm -rf hf_xet-${WHEEL_VERSION}
-          zip -r hf_xet.abi3.so.dbg.linux-${{ matrix.platform.target }}.zip ../hf_xet/dbg/hf_xet.abi3.so.dbg
-          rm ../hf_xet/dbg/hf_xet.abi3.so.dbg
-          mv hf_xet.abi3.so.dbg.linux-${{ matrix.platform.target }}.zip ../hf_xet/dbg/
       - name: Upload debug symbols
         uses: actions/upload-artifact@v4
         with:
@@ -110,9 +110,11 @@ jobs:
         platform:
           - runner: ubuntu-22.04
             target: x86_64
+            python-target: x86_64
             features: "--features openssl_vendored"
           - runner: ubuntu-22.04
             target: aarch64
+            python-target: arm64 
             features: "--features openssl_vendored"
     steps:
       - uses: actions/checkout@v4
@@ -154,16 +156,14 @@ jobs:
           cp ../hf_xet/dist/* .
           LATEST_WHEEL=$(ls -tr1 *.whl | tail -n 1)
           WHEEL_VERSION=$(echo $LATEST_WHEEL | cut -d '-' -f 2)
+          SYMBOL_FILE=hf_xet-musllinux-${{ matrix.platform.python-target }}.abi3.so.dbg
           wheel unpack $LATEST_WHEEL 
-          objcopy --only-keep-debug hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so.dbg
+          objcopy --only-keep-debug hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so hf_xet-${WHEEL_VERSION}/hf_xet/${SYMBOL_FILE}
           objcopy --strip-debug hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so
-          objcopy --add-gnu-debuglink=hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so.dbg hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so
-          mv hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so.dbg ../hf_xet/dbg/hf_xet.abi3.so.dbg
+          objcopy --add-gnu-debuglink=hf_xet-${WHEEL_VERSION}/hf_xet/${SYMBOL_FILE} hf_xet-${WHEEL_VERSION}/hf_xet/hf_xet.abi3.so
+          mv hf_xet-${WHEEL_VERSION}/hf_xet/${SYMBOL_FILE} ../hf_xet/dbg/${SYMBOL_FILE}
           wheel pack hf_xet-${WHEEL_VERSION} 
           rm -rf hf_xet-${WHEEL_VERSION}
-          zip -r hf_xet.abi3.so.dbg.musllinux-${{ matrix.platform.target }}.zip ../hf_xet/dbg/hf_xet.abi3.so.dbg
-          rm ../hf_xet/dbg/hf_xet.abi3.so.dbg
-          mv hf_xet.abi3.so.dbg.musllinux-${{ matrix.platform.target }}.zip ../hf_xet/dbg/
       - name: Upload debug symbols
         uses: actions/upload-artifact@v4
         with:
@@ -256,8 +256,7 @@ jobs:
           mkdir hf_xet/dbg
           pushd hf_xet/target/${{ matrix.platform.rust_target}}/release-dbgsymbols/deps
           sed -i '' "s/binary-path:.*/binary-path: '.\/hf_xet.abi3.so'/" libhf_xet.dylib.dSYM/Contents/Resources/Relocations/${TARGET}/libhf_xet.dylib.yml
-          zip -r libhf_xet.dylib.dSYM.macos-${TARGET}.zip libhf_xet.dylib.dSYM
-          cp libhf_xet.dylib.dSYM.macos-${TARGET}.zip ../../../../dbg/
+          cp -r libhf_xet.dylib.dSYM ../../../../dbg/libhf_xet-macosx-${TARGET}.dylib.dSYM
       - name: Upload debug symbols
         uses: actions/upload-artifact@v4
         with:
@@ -345,6 +344,10 @@ jobs:
           ls -l
           echo "wheels"
           ls -l wheels-*/*
+          mkdir dbg-symbols
           echo "dbg"
           ls -l dbg-*/*
-          gh release create ${{ github.event.inputs.tag}} wheels-*/* dbg-*/* --generate-notes --prerelease --target ${{github.sha}}
+          cp -r dbg-*/* dbg-symbols/
+          echo "zipping debug symbols"
+          zip -r dbg-symbols.zip dbg-symbols
+          gh release create ${{ github.event.inputs.tag}} wheels-*/* dbg-symbols.zip --generate-notes --prerelease --target ${{github.sha}}

--- a/README.md
+++ b/README.md
@@ -122,6 +122,21 @@ Unit-tests are run with `cargo test`, benchmarks are run with `cargo bench`. Som
 
 Please join us in making xet-core better. We value everyone's contributions. Code is not the only way to help. Answering questions, helping each other, improving documentation, filing issues all help immensely. If you are interested in contributing (please do!), check out the [contribution guide](https://github.com/huggingface/xet-core/blob/main/CONTRIBUTING.md) for this repository.
 
+## Debugging
+
+To limit the size our our built binaries, we are releasing python wheels with binaries that are stripped of debugging symbols. If you encounter a panic while running hf-xet, you can use the debug symbols to help identify the part of the library that failed. 
+
+Here are the recommended steps:
+
+1. Download and unzip our [debug symbols package](https://github.com/huggingface/xet-core/releases/download/latest/dbg-symbols.zip).
+2. Determine the location of the hf-xet package using `pip show hf-xet`. The `Location` field will show the location of all the site packages. The `hf_xet` package will be within that directory.
+3. Determine the symbols to copy based on the system you are running:
+   * Windows: use `hf_xet.pdb`
+   * Mac: use `libhf_xet-macosx-x86_64.dylib.dSYM` for Intel based Macs and `libhf_xet-macosx-aarch64.dylib.dSYM` for Apple Silicon.
+   * Linux: the choice will depend on the architecture and wheel distribution used. To get this information, `cat` the `WHEEL` file name within the `hf_xet.dist-info` directory in your site packages. The wheel file will have the linux build and architecture in the file name. Eg: `cat /home/ubuntu/.venv/lib/python3.12/site-packages/hf_xet-*.dist-info/WHEEL`. You will use the file named `hf_xet-<manylinux | musllinux>-<x86_64 | arm64>.abi3.so.dbg` choosing the distribution and platform that matches your wheel. Eg: `hf_xet-manylinux-x86_64.abi3.so.dbg`.
+4. Copy the symbols to the site package path from step 2 above + `hf_xet`. Eg: `cp -r hf_xet-1.1.2-manylinux-x86_64.abi3.so.dbg /home/ubuntu/.venv/lib/python3.12/site-packages/hf_xet`
+5. Run your python binary with `RUST_BACKTRACE=full` and recreate your failure.
+
 ## References & History
 
 * [Technical Blog posts](https://xethub.com/)


### PR DESCRIPTION
A few adjustments to the debug symbol build and release process:

1. Consolidating the debug symbols into a single zip file to clean up the release asset list and the contents of each zip. 
2. Baking the platforms into the names, so we don't have heterogenous layers of zip files. 
3. Added instructions for how to use the debug symbols to the top-level readme.

Note: for Linux, since we use the fully qualified platform name in the symbol linking phase, this will work. Mac doesn't do any name matching for dSYM files, it only matters that the relocation file is correct. Windows is unchanged.

Resolves XET-582 and XET-571.