### PR TITLE
Drop unnecessarily strict check causing intermittent test failure.

### DIFF
--- a/file_utils/src/file_metadata.rs
+++ b/file_utils/src/file_metadata.rs
@@ -142,7 +142,6 @@ mod tests {
 
         // Check that timestamps have been updated
         let updated_metadata = file.metadata().unwrap();
-        assert_eq!(updated_metadata.accessed().unwrap(), src_metadata.accessed().unwrap());
         assert_eq!(updated_metadata.modified().unwrap(), src_metadata.modified().unwrap());
     }
 


### PR DESCRIPTION
This test fails intermittently; accessed time doesn't need to be checked for any of our purposes. 