### PR TITLE
Fix for abort-on-quit issue.

### DIFF
--- a/data/src/constants.rs
+++ b/data/src/constants.rs
@@ -38,7 +38,7 @@ utils::configurable_constants! {
 
     /// How often to send updates on file progress, in milliseconds.  Disables batching
     /// if set to 0.
-    ref PROGRESS_UPDATE_INTERVAL_MS : u64 = 500;
+    ref PROGRESS_UPDATE_INTERVAL_MS : u64 = 200;
 
     /// How often do we flush new xorb data to disk on a long running upload session?
     ref SESSION_XORB_METADATA_FLUSH_INTERVAL_SECS : u64 = 20;

--- a/data/src/file_upload_session.rs
+++ b/data/src/file_upload_session.rs
@@ -69,6 +69,9 @@ pub struct FileUploadSession {
     /// Tracking upload completion between xorbs and files.
     pub(crate) completion_tracker: Arc<CompletionTracker>,
 
+    /// Session aggregation
+    progress_aggregator: Option<Arc<AggregatingProgressUpdater>>,
+
     /// Deduplicated data shared across files.
     current_session_data: Mutex<DataAggregator>,
 
@@ -109,17 +112,19 @@ impl FileUploadSession {
             .map(Cow::Borrowed)
             .unwrap_or_else(|| Cow::Owned(Ulid::new().to_string()));
 
-        let progress_updater: Arc<dyn TrackingProgressUpdater> = {
+        let (progress_updater, progress_aggregator): (Arc<dyn TrackingProgressUpdater>, Option<_>) = {
             match upload_progress_updater {
                 Some(updater) => {
                     let update_seconds = *PROGRESS_UPDATE_INTERVAL_MS;
                     if update_seconds != 0 {
-                        AggregatingProgressUpdater::new(updater, Duration::from_millis(update_seconds))
+                        let aggregator =
+                            AggregatingProgressUpdater::new(updater, Duration::from_millis(update_seconds));
+                        (aggregator.clone(), Some(aggregator))
                     } else {
-                        updater
+                        (updater, None)
                     }
                 },
-                None => Arc::new(NoOpProgressUpdater),
+                None => (Arc::new(NoOpProgressUpdater), None),
             }
         };
 
@@ -161,6 +166,7 @@ impl FileUploadSession {
             repo_id,
             config,
             completion_tracker,
+            progress_aggregator,
             current_session_data: Mutex::new(DataAggregator::default()),
             deduplication_metrics: Mutex::new(DeduplicationMetrics::default()),
             xorb_upload_tasks: Mutex::new(JoinSet::new()),
@@ -403,6 +409,11 @@ impl FileUploadSession {
 
         // Make sure all the updates have been flushed through.
         self.completion_tracker.flush().await;
+
+        // Clear this out so the background aggregation session fully finishes.
+        if let Some(pa) = &self.progress_aggregator {
+            pa.finalize().await;
+        }
 
         Ok((metrics, all_file_info))
     }

--- a/data/src/file_upload_session.rs
+++ b/data/src/file_upload_session.rs
@@ -413,6 +413,7 @@ impl FileUploadSession {
         // Clear this out so the background aggregation session fully finishes.
         if let Some(pa) = &self.progress_aggregator {
             pa.finalize().await;
+            debug_assert!(pa.is_finished().await);
         }
 
         Ok((metrics, all_file_info))

--- a/progress_tracking/src/aggregator.rs
+++ b/progress_tracking/src/aggregator.rs
@@ -125,7 +125,6 @@ impl AggregatingProgressUpdater {
     }
 
     // Ensure everything is completed.
-    #[cfg(debug_assertions)]
     pub async fn is_finished(&self) -> bool {
         self.state.lock().await.finished && self.bg_update_loop_handle.lock().await.is_none()
     }

--- a/progress_tracking/src/aggregator.rs
+++ b/progress_tracking/src/aggregator.rs
@@ -28,13 +28,14 @@ use crate::{ProgressUpdate, TrackingProgressUpdater};
 pub struct AggregatingProgressUpdater {
     inner: Option<Arc<dyn TrackingProgressUpdater>>,
     state: Arc<Mutex<AggregationState>>,
-    _bg_update_loop: Option<JoinHandle<()>>,
+    bg_update_loop_handle: Mutex<Option<JoinHandle<()>>>,
 }
 
 #[derive(Debug, Default)]
 struct AggregationState {
     pending: ProgressUpdate,
     item_lookup: HashMap<Arc<str>, usize>,
+    finish_on_next_flush: bool,
 }
 
 impl AggregationState {
@@ -63,18 +64,23 @@ impl AggregatingProgressUpdater {
         let inner_clone = Arc::clone(&inner);
 
         let bg_update_loop = tokio::spawn(async move {
+            // Wake up every 100ms to check to see if we're complete.
             let mut interval = tokio::time::interval_at(Instant::now() + flush_interval, flush_interval);
 
             loop {
                 interval.tick().await;
-                Self::flush_impl(&inner_clone, &state_clone).await;
+                let is_complete = Self::flush_impl(&inner_clone, &state_clone).await;
+
+                if is_complete {
+                    break;
+                }
             }
         });
 
         Arc::new(Self {
             inner: Some(inner),
             state,
-            _bg_update_loop: Some(bg_update_loop),
+            bg_update_loop_handle: Mutex::new(Some(bg_update_loop)),
         })
     }
 
@@ -84,15 +90,15 @@ impl AggregatingProgressUpdater {
         Arc::new(Self {
             inner: None,
             state: Arc::new(Mutex::new(AggregationState::default())),
-            _bg_update_loop: None,
+            bg_update_loop_handle: Mutex::new(None),
         })
     }
 
-    async fn get_aggregated_state_impl(state: &Arc<Mutex<AggregationState>>) -> ProgressUpdate {
+    async fn get_aggregated_state_impl(state: &Arc<Mutex<AggregationState>>) -> (ProgressUpdate, bool) {
         let mut state_guard = state.lock().await;
 
         if state_guard.pending.is_empty() {
-            return ProgressUpdate::default();
+            return (ProgressUpdate::default(), state_guard.finish_on_next_flush);
         }
 
         let flushed = std::mem::take(&mut state_guard.pending);
@@ -103,16 +109,25 @@ impl AggregatingProgressUpdater {
         // Clear out the lookup table.
         state_guard.item_lookup.clear();
 
-        flushed
+        (flushed, state_guard.finish_on_next_flush)
     }
 
-    async fn flush_impl(inner: &Arc<dyn TrackingProgressUpdater>, state: &Arc<Mutex<AggregationState>>) {
-        let flushed = Self::get_aggregated_state_impl(state).await;
+    async fn flush_impl(inner: &Arc<dyn TrackingProgressUpdater>, state: &Arc<Mutex<AggregationState>>) -> bool {
+        let (flushed, is_complete) = Self::get_aggregated_state_impl(state).await;
         inner.register_updates(flushed).await;
+        is_complete
     }
 
     pub async fn get_aggregated_state(&self) -> ProgressUpdate {
-        Self::get_aggregated_state_impl(&self.state).await
+        Self::get_aggregated_state_impl(&self.state).await.0
+    }
+
+    pub async fn finalize(&self) {
+        self.state.lock().await.finish_on_next_flush = true;
+
+        if let Some(bg_jh) = self.bg_update_loop_handle.lock().await.take() {
+            let _ = bg_jh.await;
+        }
     }
 }
 


### PR DESCRIPTION
This PR resolves the intermittent failure in the build caused by an abort-on-quit after running the python tests.  

The root issue is caused by the progress aggregation update loop attempting to acquire the GIL after the python process has initialized shutdown.  Now, the file upload process forces the aggregator to fully finish before finalizing everything. 