### PR TITLE
limit concurrent gets and update segment size tuner config

### DIFF
--- a/cas_client/src/download_utils.rs
+++ b/cas_client/src/download_utils.rs
@@ -14,9 +14,8 @@ use http::header::RANGE;
 use http::StatusCode;
 use merklehash::MerkleHash;
 use reqwest_middleware::ClientWithMiddleware;
-use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio_retry::strategy::ExponentialBackoff;
-use tracing::{debug, error, info, trace};
+use tracing::{debug, error, info, trace, warn};
 use url::Url;
 use utils::singleflight::Group;
 
@@ -24,6 +23,31 @@ use crate::error::{CasClientError, Result};
 use crate::http_client::{Api, BASE_RETRY_DELAY_MS, BASE_RETRY_MAX_DURATION_MS, NUM_RETRIES};
 use crate::remote_client::{get_reconstruction_with_endpoint_and_client, PREFIX_DEFAULT};
 use crate::OutputProvider;
+
+utils::configurable_constants! {
+    // Env (HF_XET_NUM_RANGE_IN_SEGMENT_BASE) base value for the approx number of ranges in the initial
+    // segment size used to download, where a segment is a range of a file that is downloaded
+    // setting this value to 0 causes no segments to be downloaded, this will cause downloads to fail/hang
+    ref NUM_RANGE_IN_SEGMENT_BASE: usize = GlobalConfigMode::HighPerformanceOption {
+        standard: 16, // 16 * ~64MB -> ~1GB initial segment size
+        high_performance: 256, // 128 * ~64MB -> ~16GB initial segment size
+    };
+
+    // Env (HF_XET_NUM_RANGE_IN_SEGMENT_DELTA) delta value for the approx number of ranges in a segment size
+    // used to increase/decrease the segment size by this many approximate ranges
+    // setting this value to 0 causes no segment size change, i.e. will remain constant
+    ref NUM_RANGE_IN_SEGMENT_DELTA: usize = GlobalConfigMode::HighPerformanceOption {
+        standard: 8, // increase/decrease segment size by 8 range ~512MB
+        high_performance: 64, // increase/decrease segment size by 8 ranges ~4GB
+    };
+
+    // Env (HF_XET_NUM_RANGE_IN_SEGMENT_MAX) max value for the approx number of ranges in a segment size
+    // setting this value to 0 will be ignored and the max size will be set to usize::MAX
+    ref NUM_RANGE_IN_SEGMENT_MAX: usize = GlobalConfigMode::HighPerformanceOption {
+        standard: 1024 * 2, // * ~64MB -> max at 128GB segment
+        high_performance: 1024 * 16, // * ~64MB -> max at 1TB segment
+    };
+}
 
 #[derive(Clone, Debug)]
 pub(crate) enum DownloadRangeResult {
@@ -339,25 +363,43 @@ pub(crate) enum DownloadQueueItem<T> {
     Metadata(FetchInfo),
 }
 
-pub struct DownloadScheduler {
+/// A utility to tune the segment size for downloading terms in a reconstruction.
+/// Yields a segment size based on an approximate number of ranges in a segment,
+pub struct DownloadSegmentLengthTuner {
     n_range_in_segment: Mutex<usize>, // number of range in a segment to fetch file reconstruction info
-    n_concurrent_download_task: Arc<Semaphore>,
+    max_segments: usize,
+    delta: usize,
 }
 
-impl DownloadScheduler {
-    pub fn new(n_concurrent_range_get: usize) -> Arc<Self> {
+impl DownloadSegmentLengthTuner {
+    pub fn new(n_range_in_segment_base: usize, max_segments: usize, delta: usize) -> Arc<Self> {
+        if *NUM_RANGE_IN_SEGMENT_BASE == 0 {
+            warn!(
+                "NUM_RANGE_IN_SEGMENT_BASE is set to 0, which means no segments will be downloaded.
+                   This is likely a misconfiguration. Please check your environment variables."
+            );
+        }
         Arc::new(Self {
-            n_range_in_segment: Mutex::new(n_concurrent_range_get),
-            n_concurrent_download_task: Arc::new(Semaphore::new(n_concurrent_range_get)),
+            n_range_in_segment: Mutex::new(n_range_in_segment_base),
+            max_segments,
+            delta,
         })
     }
 
-    pub async fn download_permit(&self) -> Result<OwnedSemaphorePermit> {
-        self.n_concurrent_download_task
-            .clone()
-            .acquire_owned()
-            .await
-            .map_err(CasClientError::from)
+    pub fn from_configurable_constants() -> Arc<Self> {
+        if *NUM_RANGE_IN_SEGMENT_BASE == 0 {
+            warn!(
+                "NUM_RANGE_IN_SEGMENT_BASE is set to 0, which means no segments will be downloaded.
+                   This is likely a misconfiguration. Please check your environment variables."
+            );
+        }
+        let max_num_segments = if *NUM_RANGE_IN_SEGMENT_MAX == 0 {
+            usize::MAX
+        } else {
+            *NUM_RANGE_IN_SEGMENT_MAX
+        };
+
+        Self::new(*NUM_RANGE_IN_SEGMENT_BASE, max_num_segments, *NUM_RANGE_IN_SEGMENT_DELTA)
     }
 
     pub fn next_segment_size(&self) -> Result<u64> {
@@ -365,16 +407,24 @@ impl DownloadScheduler {
     }
 
     pub fn tune_on<T>(&self, metrics: TermDownloadResult<T>) -> Result<()> {
+
+        let mut num_range_in_segment = self.n_range_in_segment.lock()?;
+        debug_assert!(*num_range_in_segment <= self.max_segments);
         if metrics.n_retries_on_403 > 0 {
-            info!("detected retries on 403, shrinking segment size by one range");
-            let mut num_range_in_segment = self.n_range_in_segment.lock()?;
             if *num_range_in_segment > 1 {
-                *num_range_in_segment -= 1;
+                let delta = NUM_RANGE_IN_SEGMENT_DELTA.min(*num_range_in_segment - 1);
+                info!("detected retries on 403, shrinking segment size by {delta} ranges");
+                *num_range_in_segment -= delta;
+            } else {
+                info!(
+                    "detected retries on 403, but segment size is already at minimum (1 range), not shrinking further"
+                );
             }
-        } else {
+        } else if *num_range_in_segment != self.max_segments {
             // TODO: check download speed and consider if we should increase or decrease
-            debug!("expanding segment size by one range");
-            *self.n_range_in_segment.lock()? += 1;
+            let delta = NUM_RANGE_IN_SEGMENT_DELTA.min(self.max_segments - *num_range_in_segment);
+            debug!("expanding segment size by {delta} approx ranges");
+            *num_range_in_segment += delta;
         }
 
         Ok(())

--- a/cas_client/src/remote_client.rs
+++ b/cas_client/src/remote_client.rs
@@ -24,7 +24,7 @@ use progress_tracking::item_tracking::SingleItemProgressUpdater;
 use progress_tracking::upload_tracking::CompletionTracker;
 use reqwest::{Body, StatusCode, Url};
 use reqwest_middleware::ClientWithMiddleware;
-use tokio::sync::{mpsc, OwnedSemaphorePermit};
+use tokio::sync::{mpsc, OwnedSemaphorePermit, Semaphore};
 use tokio::task::{JoinHandle, JoinSet};
 use tracing::{debug, info, instrument};
 use utils::auth::AuthConfig;
@@ -44,10 +44,13 @@ pub const CAS_ENDPOINT: &str = "http://localhost:8080";
 pub const PREFIX_DEFAULT: &str = "default";
 
 utils::configurable_constants! {
+// Env (HF_XET_NUM_CONCURRENT_RANGE_GETS) to set the number of concurrent range gets.
+// setting this value to 0 disables the limit, this is not recommended as it may lead to errors
     ref NUM_CONCURRENT_RANGE_GETS: usize = GlobalConfigMode::HighPerformanceOption {
         standard: 16,
         high_performance: 100,
     };
+
 
     // Send a report of successful partial upload every 512kb.
     ref UPLOAD_REPORTING_BLOCK_SIZE : usize = 512 * 1024;
@@ -71,6 +74,7 @@ pub struct RemoteClient {
     conservative_authenticated_http_client: Arc<ClientWithMiddleware>,
     chunk_cache: Option<Arc<dyn ChunkCache>>,
     range_download_single_flight: RangeDownloadSingleFlight,
+    concurrent_gets_semaphore: Arc<Semaphore>,
     shard_cache_directory: PathBuf,
 }
 
@@ -102,6 +106,12 @@ impl RemoteClient {
             None
         };
         let range_download_single_flight = Arc::new(Group::new());
+        let num_range_gets = if *NUM_CONCURRENT_RANGE_GETS == 0 {
+            Semaphore::MAX_PERMITS // virtually no limit
+        } else {
+            *NUM_CONCURRENT_RANGE_GETS
+        };
+        let concurrent_gets_semaphore = Arc::new(Semaphore::new(num_range_gets));
 
         Self {
             endpoint: endpoint.to_string(),
@@ -118,6 +128,7 @@ impl RemoteClient {
             http_client: Arc::new(http_client::build_http_client(RetryConfig::default(), session_id).unwrap()),
             chunk_cache,
             range_download_single_flight,
+            concurrent_gets_semaphore,
             shard_cache_directory,
         }
     }
@@ -376,8 +387,10 @@ impl RemoteClient {
         let chunk_cache = self.chunk_cache.clone();
         let term_download_client = self.http_client.clone();
         let range_download_single_flight = self.range_download_single_flight.clone();
-        let download_scheduler = DownloadScheduler::new(*NUM_CONCURRENT_RANGE_GETS);
+        // min 1
+        let download_scheduler = DownloadSegmentLengthTuner::from_configurable_constants();
         let download_scheduler_clone = download_scheduler.clone();
+        let concurrent_gets_semaphore = self.concurrent_gets_semaphore.clone();
 
         let queue_dispatcher: JoinHandle<Result<()>> = tokio::spawn(async move {
             let mut remaining_total_len = total_len;
@@ -392,7 +405,7 @@ impl RemoteClient {
                     DownloadQueueItem::DownloadTask(term_download) => {
                         // acquire the permit before spawning the task, so that there's limited
                         // number of active downloads.
-                        let permit = download_scheduler_clone.download_permit().await?;
+                        let permit = concurrent_gets_semaphore.clone().acquire_owned().await?;
                         debug!("spawning 1 download task");
                         let future: JoinHandle<Result<(TermDownloadResult<Vec<u8>>, OwnedSemaphorePermit)>> =
                             tokio::spawn(async move {
@@ -525,11 +538,12 @@ impl RemoteClient {
         // After the above, a task that defines fetching the remainder of the file reconstruction info is enqueued,
         // which will execute after the first of the above term download tasks finishes.
         let term_download_client = self.http_client.clone();
-        let download_scheduler = DownloadScheduler::new(*NUM_CONCURRENT_RANGE_GETS);
+        let download_scheduler = DownloadSegmentLengthTuner::from_configurable_constants();
+        let concurrent_gets_semaphore = self.concurrent_gets_semaphore.clone();
 
         let process_result = move |result: TermDownloadResult<u64>,
                                    total_written: &mut u64,
-                                   download_scheduler: &DownloadScheduler|
+                                   download_scheduler: &DownloadSegmentLengthTuner|
               -> Result<u64> {
             let write_len = result.payload;
             *total_written += write_len;
@@ -558,7 +572,7 @@ impl RemoteClient {
                 DownloadQueueItem::DownloadTask(term_download) => {
                     // acquire the permit before spawning the task, so that there's limited
                     // number of active downloads.
-                    let permit = download_scheduler.download_permit().await?;
+                    let permit = concurrent_gets_semaphore.clone().acquire_owned().await?;
                     debug!("spawning 1 download task");
                     running_downloads.spawn(async move {
                         let data = term_download.run().await?;

--- a/hf_xet/Cargo.lock
+++ b/hf_xet/Cargo.lock
@@ -316,6 +316,7 @@ dependencies = [
  "mdb_shard",
  "merkledb",
  "merklehash",
+ "more-asserts",
  "rand 0.9.1",
  "serde",
  "thiserror 2.0.12",
@@ -1057,6 +1058,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
+name = "heapify"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0049b265b7f201ca9ab25475b22b47fe444060126a51abe00f77d986fc5cc52e"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1591,6 +1598,7 @@ dependencies = [
  "clap",
  "futures-io",
  "futures-util",
+ "heapify",
  "itertools 0.14.0",
  "lazy_static",
  "merklehash",


### PR DESCRIPTION
fixes XET-605

Updates the semaphore used to limit concurrent downloads to be used across all uses of a remote client which is just 1 for a session.

As a side effect renames the DownloadScheduler to DownloadSegmentLengthTuner since that's all it does now and adds configuration values for it.