### PR TITLE
Report completion speed with progress updates

### DIFF
--- a/data/src/constants.rs
+++ b/data/src/constants.rs
@@ -40,11 +40,16 @@ utils::configurable_constants! {
     /// if set to 0.
     ref PROGRESS_UPDATE_INTERVAL_MS : u64 = 200;
 
+    /// How large of a time window to use for aggregating the progress speed results.
+    ref PROGRESS_UPDATE_SPEED_SAMPLING_WINDOW_MS: u64 = 10 * 1000;
+
+
     /// How often do we flush new xorb data to disk on a long running upload session?
     ref SESSION_XORB_METADATA_FLUSH_INTERVAL_SECS : u64 = 20;
 
     /// Force a flush of the xorb metadata every this many xorbs, if more are created
     /// in this time window.
     ref SESSION_XORB_METADATA_FLUSH_MAX_COUNT : usize = 64;
+
 
 }

--- a/data/src/file_upload_session.rs
+++ b/data/src/file_upload_session.rs
@@ -21,7 +21,7 @@ use tracing::{info_span, instrument, Instrument};
 use ulid::Ulid;
 
 use crate::configurations::*;
-use crate::constants::{MAX_CONCURRENT_UPLOADS, PROGRESS_UPDATE_INTERVAL_MS};
+use crate::constants::{MAX_CONCURRENT_UPLOADS, PROGRESS_UPDATE_INTERVAL_MS, PROGRESS_UPDATE_SPEED_SAMPLING_WINDOW_MS};
 use crate::errors::*;
 use crate::file_cleaner::SingleFileCleaner;
 use crate::prometheus_metrics;
@@ -115,10 +115,13 @@ impl FileUploadSession {
         let (progress_updater, progress_aggregator): (Arc<dyn TrackingProgressUpdater>, Option<_>) = {
             match upload_progress_updater {
                 Some(updater) => {
-                    let update_seconds = *PROGRESS_UPDATE_INTERVAL_MS;
-                    if update_seconds != 0 {
-                        let aggregator =
-                            AggregatingProgressUpdater::new(updater, Duration::from_millis(update_seconds));
+                    let update_ms = *PROGRESS_UPDATE_INTERVAL_MS;
+                    if update_ms != 0 {
+                        let aggregator = AggregatingProgressUpdater::new(
+                            updater,
+                            Duration::from_millis(update_ms),
+                            Duration::from_millis(*PROGRESS_UPDATE_SPEED_SAMPLING_WINDOW_MS),
+                        );
                         (aggregator.clone(), Some(aggregator))
                     } else {
                         (updater, None)

--- a/hf_xet/Cargo.lock
+++ b/hf_xet/Cargo.lock
@@ -316,6 +316,7 @@ dependencies = [
  "mdb_shard",
  "merkledb",
  "merklehash",
+ "more-asserts",
  "rand 0.9.1",
  "serde",
  "thiserror 2.0.12",
@@ -1057,6 +1058,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
+name = "heapify"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0049b265b7f201ca9ab25475b22b47fe444060126a51abe00f77d986fc5cc52e"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1591,6 +1598,7 @@ dependencies = [
  "clap",
  "futures-io",
  "futures-util",
+ "heapify",
  "itertools 0.14.0",
  "lazy_static",
  "merklehash",

--- a/hf_xet/src/progress_update.rs
+++ b/hf_xet/src/progress_update.rs
@@ -89,6 +89,10 @@ pub struct PyTotalProgressUpdate {
     #[pyo3(get)]
     pub total_bytes_completion_increment: u64,
 
+    /// If known, the current completion speed.
+    #[pyo3(get)]
+    pub total_bytes_completion_rate: Option<f64>,
+
     /// The total bytes scheduled for transfer; also contained in total_bytes.
     #[pyo3(get)]
     pub total_transfer_bytes: u64,
@@ -104,6 +108,10 @@ pub struct PyTotalProgressUpdate {
     /// The change in total_transfer_bytes_completed since the last update.
     #[pyo3(get)]
     pub total_transfer_bytes_completion_increment: u64,
+
+    /// If known, the current completion speed for bytes transferred.
+    #[pyo3(get)]
+    pub total_transfer_bytes_completion_rate: Option<f64>,
 }
 
 /// A wrapper over a passed-in python function to update
@@ -225,11 +233,13 @@ impl WrappedProgressUpdaterImpl {
                             total_bytes_increment: updates.total_bytes_increment,
                             total_bytes_completed: updates.total_bytes_completed,
                             total_bytes_completion_increment: updates.total_bytes_completion_increment,
+                            total_bytes_completion_rate: updates.total_bytes_completion_rate,
                             total_transfer_bytes: updates.total_transfer_bytes,
                             total_transfer_bytes_increment: updates.total_transfer_bytes_increment,
                             total_transfer_bytes_completed: updates.total_transfer_bytes_completed,
                             total_transfer_bytes_completion_increment: updates
                                 .total_transfer_bytes_completion_increment,
+                            total_transfer_bytes_completion_rate: updates.total_transfer_bytes_completion_rate,
                         },
                     )?
                     .into_py_any(py)?;

--- a/progress_tracking/src/item_tracking.rs
+++ b/progress_tracking/src/item_tracking.rs
@@ -7,7 +7,6 @@ use crate::progress_info::{ItemProgressUpdate, ProgressUpdate};
 use crate::TrackingProgressUpdater;
 
 /// This wraps a TrackingProgressUpdater, translating per-item updates to a full progress report.
-#[derive(Debug)]
 pub struct ItemProgressUpdater {
     total_bytes: AtomicU64,
     total_bytes_completed: AtomicU64,
@@ -64,6 +63,7 @@ impl ItemProgressUpdater {
                 total_transfer_bytes_increment: 0,
                 total_transfer_bytes_completed: total_bytes_completed,
                 total_transfer_bytes_completion_increment: update_increment,
+                ..Default::default()
             })
             .await;
     }
@@ -85,6 +85,7 @@ impl ItemProgressUpdater {
                 total_transfer_bytes_increment: increase_byte_total,
                 total_transfer_bytes_completed: total_bytes_completed,
                 total_transfer_bytes_completion_increment: 0,
+                ..Default::default()
             })
             .await;
     }
@@ -92,7 +93,6 @@ impl ItemProgressUpdater {
 
 /// This struct allows us to wrap the larger progress updater in a simple form for
 /// specific items.
-#[derive(Debug)]
 pub struct SingleItemProgressUpdater {
     item_name: Arc<str>,
     n_bytes: AtomicU64,

--- a/progress_tracking/src/lib.rs
+++ b/progress_tracking/src/lib.rs
@@ -11,7 +11,7 @@ pub use progress_info::{ItemProgressUpdate, ProgressUpdate};
 
 /// The trait that a progress updater that reports per-item progress completion.
 #[async_trait]
-pub trait TrackingProgressUpdater: std::fmt::Debug + Send + Sync {
+pub trait TrackingProgressUpdater: Send + Sync {
     /// Register a set of updates as a list of ProgressUpdate instances, which
     /// contain the name and progress information.    
     async fn register_updates(&self, updates: ProgressUpdate);

--- a/progress_tracking/src/progress_info.rs
+++ b/progress_tracking/src/progress_info.rs
@@ -47,6 +47,9 @@ pub struct ProgressUpdate {
     /// How much this update adjusts the total bytes..
     pub total_bytes_completion_increment: u64,
 
+    /// The total bytes that have been processed
+    pub total_bytes_completion_rate: Option<f64>,
+
     /// Total bytes known that need to be uploaded or downloaded.   
     pub total_transfer_bytes: u64,
 
@@ -58,6 +61,9 @@ pub struct ProgressUpdate {
 
     /// How much this update adjusts the total transfer bytes.
     pub total_transfer_bytes_completion_increment: u64,
+
+    /// The total bytes that have been processed
+    pub total_transfer_bytes_completion_rate: Option<f64>,
 }
 
 impl ProgressUpdate {

--- a/progress_tracking/src/upload_tracking.rs
+++ b/progress_tracking/src/upload_tracking.rs
@@ -121,6 +121,7 @@ impl CompletionTrackerImpl {
                 total_transfer_bytes_increment: 0,
                 total_transfer_bytes_completed: self.total_upload_bytes_completed,
                 total_transfer_bytes_completion_increment: 0,
+                ..Default::default()
             },
             file_id,
         )
@@ -198,6 +199,7 @@ impl CompletionTrackerImpl {
             total_transfer_bytes_increment: 0,
             total_transfer_bytes_completed: self.total_upload_bytes_completed,
             total_transfer_bytes_completion_increment: 0,
+            ..Default::default()
         }
     }
 
@@ -230,6 +232,7 @@ impl CompletionTrackerImpl {
                         total_transfer_bytes_increment: xorb_size,
                         total_transfer_bytes_completed: self.total_upload_bytes_completed,
                         total_transfer_bytes_completion_increment: 0,
+                        ..Default::default()
                     },
                     true,
                 )
@@ -309,6 +312,7 @@ impl CompletionTrackerImpl {
             total_transfer_bytes_completed: self.total_upload_bytes_completed,
             total_transfer_bytes_completion_increment: byte_completion_increment,
             total_transfer_bytes_increment: 0,
+            ..Default::default()
         }
     }
 
@@ -342,6 +346,7 @@ impl CompletionTrackerImpl {
                 total_transfer_bytes_increment: 0,
                 total_transfer_bytes_completed: self.total_upload_bytes_completed,
                 total_transfer_bytes_completion_increment: 0,
+                ..Default::default()
             };
         }
 
@@ -411,14 +416,15 @@ impl CompletionTrackerImpl {
 
         ProgressUpdate {
             item_updates,
-            total_transfer_bytes: self.total_upload_bytes,
-            total_transfer_bytes_increment: 0,
-            total_transfer_bytes_completed: self.total_upload_bytes_completed,
-            total_transfer_bytes_completion_increment: new_byte_progress,
             total_bytes: self.total_bytes,
             total_bytes_increment: 0,
             total_bytes_completed: self.total_bytes_completed,
             total_bytes_completion_increment: file_bytes_processed,
+            total_transfer_bytes: self.total_upload_bytes,
+            total_transfer_bytes_increment: 0,
+            total_transfer_bytes_completed: self.total_upload_bytes_completed,
+            total_transfer_bytes_completion_increment: new_byte_progress,
+            ..Default::default()
         }
     }
 

--- a/progress_tracking/src/verification_wrapper.rs
+++ b/progress_tracking/src/verification_wrapper.rs
@@ -30,7 +30,6 @@ pub struct ProgressUpdaterVerificationWrapperImpl {
 /// - `completed_count` must match `last_completed + update_increment`.
 /// - `total_count` must remain consistent (if it changes across updates for the same item, that's an error).
 /// - Final verification (`assert_complete()`) ensures all items reached `completed_count == total_count`.
-#[derive(Debug)]
 pub struct ProgressUpdaterVerificationWrapper {
     inner: Arc<dyn TrackingProgressUpdater>,
     tr: Mutex<ProgressUpdaterVerificationWrapperImpl>,
@@ -243,6 +242,7 @@ mod tests {
                 total_bytes_increment: 200,
                 total_bytes_completed: 100,
                 total_bytes_completion_increment: 100,
+                ..Default::default()
             })
             .await;
 
@@ -271,6 +271,7 @@ mod tests {
                 total_bytes_increment: 0,
                 total_bytes_completed: 200,
                 total_bytes_completion_increment: 100,
+                ..Default::default()
             })
             .await;
 


### PR DESCRIPTION
Estimating completion speed turns out to be a bit annoying on the python side; it is much easier to do it as part of the aggregation stage of the progress updater.   This PR adds two option fields that report the average speed over the last 10 seconds (configurable) for the total completion speed and the total transfer speed.