### PR TITLE
Move batch file uploads to FileUploadSession.

### DIFF
--- a/data/src/data_client.rs
+++ b/data/src/data_client.rs
@@ -132,7 +132,16 @@ pub async fn upload_bytes_async(
     Ok(files)
 }
 
-#[instrument(skip_all, name = "data_client::upload_files", fields(session_id = tracing::field::Empty, num_files=file_paths.len()))]
+#[instrument(skip_all, name = "data_client::upload_files", 
+    fields(session_id = tracing::field::Empty,
+    num_files=file_paths.len(),
+    new_bytes = tracing::field::Empty,
+    deduped_bytes = tracing::field::Empty,
+    defrag_prevented_dedup_bytes = tracing::field::Empty,
+    new_chunks = tracing::field::Empty,
+    deduped_chunks = tracing::field::Empty,
+    defrag_prevented_dedup_chunks = tracing::field::Empty
+))]
 pub async fn upload_async(
     file_paths: Vec<String>,
     endpoint: Option<String>,
@@ -160,9 +169,9 @@ pub async fn upload_async(
     // Record dedup metrics.
     span.record("new_bytes", metrics.new_bytes);
     span.record("deduped_bytes ", metrics.deduped_bytes);
-    span.record("deduped_chunks", metrics.deduped_chunks);
-    span.record("new_chunks", metrics.new_chunks);
     span.record("defrag_prevented_dedup_bytes", metrics.defrag_prevented_dedup_bytes);
+    span.record("new_chunks", metrics.new_chunks);
+    span.record("deduped_chunks", metrics.deduped_chunks);
     span.record("defrag_prevented_dedup_chunks", metrics.defrag_prevented_dedup_chunks);
 
     Ok(ret)

--- a/data/src/data_client.rs
+++ b/data/src/data_client.rs
@@ -145,31 +145,27 @@ pub async fn upload_async(
     // upload shards and xorbs
     // for each file, return the filehash
     let config = default_config(endpoint.unwrap_or(DEFAULT_CAS_ENDPOINT.clone()), None, token_info, token_refresher)?;
-    Span::current().record("session_id", &config.session_id);
+
+    let span = Span::current();
+
+    span.record("session_id", &config.session_id);
 
     let upload_session = FileUploadSession::new(config, progress_updater).await?;
-    let files_with_spans = add_spans(file_paths, || info_span!("clean_file_task"));
 
-    // for all files, clean them, producing pointer files.
-    let files = tokio_par_for_each(files_with_spans, *MAX_CONCURRENT_FILE_INGESTION, |(f, span), _| {
-        async {
-            let (xf, _metrics) = clean_file(upload_session.clone(), f).await?;
-            Ok(xf)
-        }
-        .instrument(span.unwrap_or_else(|| info_span!("unexpected_span")))
-    })
-    .await
-    .map_err(|e| match e {
-        ParallelError::JoinError => DataProcessingError::InternalError("Join error".to_string()),
-        ParallelError::TaskError(e) => e,
-    })?;
+    let ret = upload_session.upload_files(&file_paths).await?;
 
     // Push the CAS blocks and flush the mdb to disk
-    let _metrics = upload_session.finalize().await?;
+    let metrics = upload_session.finalize().await?;
 
-    // TODO: Report on metrics
+    // Record dedup metrics.
+    span.record("new_bytes", metrics.new_bytes);
+    span.record("deduped_bytes ", metrics.deduped_bytes);
+    span.record("deduped_chunks", metrics.deduped_chunks);
+    span.record("new_chunks", metrics.new_chunks);
+    span.record("defrag_prevented_dedup_bytes", metrics.defrag_prevented_dedup_bytes);
+    span.record("defrag_prevented_dedup_chunks", metrics.defrag_prevented_dedup_chunks);
 
-    Ok(files)
+    Ok(ret)
 }
 
 #[instrument(skip_all, name = "data_client::download", fields(session_id = tracing::field::Empty, num_files=file_infos.len()))]

--- a/data/src/errors.rs
+++ b/data/src/errors.rs
@@ -6,6 +6,7 @@ use cas_object::error::CasObjectError;
 use mdb_shard::error::MDBShardError;
 use merkledb::error::MerkleDBError;
 use thiserror::Error;
+use tokio::sync::AcquireError;
 use tracing::error;
 use utils::errors::{AuthError, SingleflightError};
 
@@ -76,6 +77,9 @@ pub enum DataProcessingError {
 
     #[error("AuthError: {0}")]
     AuthError(#[from] AuthError),
+
+    #[error("Permit Acquisition Error: {0}")]
+    PermitAcquisitionError(#[from] AcquireError),
 }
 
 pub type Result<T> = std::result::Result<T, DataProcessingError>;

--- a/data/src/file_upload_session.rs
+++ b/data/src/file_upload_session.rs
@@ -1,5 +1,8 @@
 use std::borrow::Cow;
+use std::fs::File;
+use std::io::Read;
 use std::mem::{swap, take};
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -16,17 +19,19 @@ use progress_tracking::upload_tracking::{CompletionTracker, FileXorbDependency};
 use progress_tracking::verification_wrapper::ProgressUpdaterVerificationWrapper;
 use progress_tracking::{NoOpProgressUpdater, TrackingProgressUpdater};
 use tokio::sync::{Mutex, OwnedSemaphorePermit, Semaphore};
-use tokio::task::JoinSet;
-use tracing::{info_span, instrument, Instrument};
+use tokio::task::{JoinHandle, JoinSet};
+use tracing::{info_span, instrument, Instrument, Span};
 use ulid::Ulid;
 
 use crate::configurations::*;
-use crate::constants::{MAX_CONCURRENT_UPLOADS, PROGRESS_UPDATE_INTERVAL_MS};
+use crate::constants::{
+    INGESTION_BLOCK_SIZE, MAX_CONCURRENT_FILE_INGESTION, MAX_CONCURRENT_UPLOADS, PROGRESS_UPDATE_INTERVAL_MS,
+};
 use crate::errors::*;
 use crate::file_cleaner::SingleFileCleaner;
-use crate::prometheus_metrics;
 use crate::remote_client_interface::create_remote_client;
 use crate::shard_interface::SessionShardInterface;
+use crate::{prometheus_metrics, XetFileInfo};
 
 lazy_static::lazy_static! {
      static ref UPLOAD_CONCURRENCY_LIMITER: Arc<Semaphore> = Arc::new(Semaphore::new(*MAX_CONCURRENT_UPLOADS));
@@ -174,6 +179,82 @@ impl FileUploadSession {
             #[cfg(debug_assertions)]
             progress_verifier: progress_verification_tracker,
         }))
+    }
+
+    pub async fn upload_files(self: &Arc<Self>, files: &[impl AsRef<Path>]) -> Result<Vec<XetFileInfo>> {
+        let mut cleaning_tasks: Vec<JoinHandle<_>> = Vec::with_capacity(files.len());
+
+        // Use a semaphore to limit the number of files being processed in parallel.
+        let file_parallel_limiter = Arc::new(Semaphore::new(*MAX_CONCURRENT_FILE_INGESTION));
+
+        for f in files {
+            let file_path = f.as_ref().to_owned();
+            let file_name: Arc<str> = Arc::from(file_path.to_string_lossy());
+
+            // Get the file size, and go ahead and register it in the completion tracker so that we know the whole
+            // repo size at the beginning.
+            let file_size = std::fs::metadata(&file_path)?.len();
+
+            // Get a new file id for the completion tracking.  This also registers the size against the total bytes
+            // of the file.
+            let file_id = self.completion_tracker.register_new_file(file_name.clone(), file_size).await;
+
+            // Now, spawn a task
+            let ingestion_concurrancy_limiter = file_parallel_limiter.clone();
+            let session = self.clone();
+
+            let span = info_span!("clean_file_task");
+
+            cleaning_tasks.push(tokio::spawn(
+                async move {
+                    // First, get a permit to process this file.
+                    let _processing_permit = ingestion_concurrancy_limiter.acquire().await?;
+
+                    // Enable tracing to record this file's ingestion speed.
+                    let span = Span::current();
+                    span.record("file.name", file_name.to_string());
+                    span.record("file.len", file_size);
+
+                    let mut buffer = vec![0u8; u64::min(file_size, *INGESTION_BLOCK_SIZE as u64) as usize];
+                    let mut reader = File::open(&file_path)?;
+
+                    // Start the clean process for each file
+                    let mut cleaner = SingleFileCleaner::new(Some(file_name), file_id, session);
+
+                    loop {
+                        let bytes = reader.read(&mut buffer)?;
+                        if bytes == 0 {
+                            break;
+                        }
+
+                        cleaner.add_data(&buffer[0..bytes]).await?;
+                    }
+
+                    // Finish and return the result.
+                    let (xfi, metrics) = cleaner.finish().await?;
+
+                    // Record dedup information.
+                    span.record("file.new_bytes", metrics.new_bytes);
+                    span.record("file.deduped_bytes ", metrics.deduped_bytes);
+                    span.record("file.deduped_chunks", metrics.deduped_chunks);
+                    span.record("file.new_chunks", metrics.new_chunks);
+                    span.record("file.defrag_prevented_dedup_bytes", metrics.defrag_prevented_dedup_bytes);
+                    span.record("file.defrag_prevented_dedup_chunks", metrics.defrag_prevented_dedup_chunks);
+
+                    Result::Ok(xfi)
+                }
+                .instrument(span),
+            ));
+        }
+
+        // Join all the cleaning tasks.
+        let mut ret = Vec::with_capacity(files.len());
+
+        for task in cleaning_tasks {
+            ret.push(task.await??);
+        }
+
+        Ok(ret)
     }
 
     /// Start to clean one file. When cleaning multiple files, each file should


### PR DESCRIPTION
This PR moves the batch file upload code to within the FileUploadSession.  This allows us to scan all of the file sizes and check for their existence on the start of an upload.  With this, we can set the total for the upload progress bar at the start of a session instead of setting it dynamically as new files are added. 