### PR TITLE
Bugfix for issue with shard resume consolidation 

### DIFF
--- a/mdb_shard/src/session_directory.rs
+++ b/mdb_shard/src/session_directory.rs
@@ -84,11 +84,13 @@ pub fn merge_shards(
             if ub_idx == cur_idx + 1 {
                 // We can't consolidate any here.
                 finished_shard_hashes.insert(cur_sfi.shard_hash);
-                finished_shards.push(cur_sfi.clone());
 
                 if copy_preserved_source_shards {
-                    cur_sfi.copy_into_target_directory(&target_directory)?;
+                    let copied_sfi = cur_sfi.copy_into_target_directory(&target_directory)?;
+                    finished_shards.push(copied_sfi);
                     shards_to_remove.push(cur_sfi.clone());
+                } else {
+                    finished_shards.push(cur_sfi.clone());
                 }
             } else {
                 // We have one or more shards to merge, so do this all in memory.

--- a/mdb_shard/src/shard_file_manager.rs
+++ b/mdb_shard/src/shard_file_manager.rs
@@ -224,7 +224,12 @@ impl ShardFileManager {
             s.verify_shard_integrity_debug_only();
 
             // Make sure the shard is in the shard directory
-            debug_assert!(s.path.starts_with(&self.shard_directory));
+            debug_assert!(
+                s.path.starts_with(&self.shard_directory),
+                "{:?} not in {:?}",
+                &s.path,
+                &self.shard_directory
+            );
 
             if sbkp_lg.shard_lookup_by_shard_hash.contains_key(&s.shard_hash) {
                 continue;


### PR DESCRIPTION
This fixes a bug encountered in the session resume path in which a shard is not correctly copied over to the temporary session directory.  A test is also added.

