### PR TITLE
Make shard session resume robust to multiple sessions.

### DIFF
--- a/mdb_shard/src/session_directory.rs
+++ b/mdb_shard/src/session_directory.rs
@@ -1,16 +1,16 @@
 use std::collections::HashSet;
-use std::io::{Cursor, Read};
+use std::io::Cursor;
 use std::mem::swap;
 use std::path::Path;
 use std::sync::Arc;
 
-use merklehash::MerkleHash;
 use tokio::task::JoinHandle;
-use tracing::debug;
+use tracing::{error, info};
 
 use crate::error::Result;
 use crate::set_operations::shard_set_union;
 use crate::shard_file_handle::{MDBShardFile, MDBShardFileVec};
+use crate::{MDBShardFileFooter, MDBShardFileHeader, MDBShardInfo};
 
 /// Merge a collection of shards, deleting the old ones.
 /// After calling this, the passed in shards may be invalid -- i.e. may refer to a shard that doesn't exist.
@@ -20,17 +20,29 @@ use crate::shard_file_handle::{MDBShardFile, MDBShardFileVec};
 pub fn consolidate_shards_in_directory(
     session_directory: impl AsRef<Path>,
     target_max_size: u64,
+    skip_on_error: bool,
 ) -> Result<MDBShardFileVec> {
     let session_directory = session_directory.as_ref();
     // Get the new shards and the shards in the original list to remove.
-    let (new_shards, shards_to_remove) = merge_shards(session_directory, session_directory, target_max_size)?;
+    let shard_merge_result = merge_shards(session_directory, session_directory, target_max_size, skip_on_error)?;
 
     // Now, go through and remove all the shards in the delete list.
-    for sfi in shards_to_remove {
-        std::fs::remove_file(&sfi.path)?;
+    for sfi in shard_merge_result.obsolete_shards {
+        let res = std::fs::remove_file(&sfi.path);
+
+        if !skip_on_error {
+            res?;
+        }
     }
 
-    Ok(new_shards)
+    Ok(shard_merge_result.merged_shards)
+}
+
+#[derive(Default)]
+pub struct ShardMergeResult {
+    pub merged_shards: MDBShardFileVec,
+    pub obsolete_shards: MDBShardFileVec,
+    pub skipped_shards: MDBShardFileVec,
 }
 
 /// Merge a collection of shards, returning the new ones and the ones that can be deleted.
@@ -44,114 +56,95 @@ pub fn merge_shards(
     source_directory: impl AsRef<Path>,
     target_directory: impl AsRef<Path>,
     target_max_size: u64,
-) -> Result<(MDBShardFileVec, MDBShardFileVec)> {
+    skip_on_error: bool,
+) -> Result<ShardMergeResult> {
     let mut shards: Vec<_> = MDBShardFile::load_all_valid(source_directory.as_ref())?;
 
     shards.sort_unstable_by_key(|si| si.last_modified_time);
 
     // Make not mutable
     let shards = shards;
-
-    let copy_preserved_source_shards = source_directory.as_ref() != target_directory.as_ref();
-
-    let mut finished_shards = Vec::<Arc<MDBShardFile>>::with_capacity(shards.len());
-    let mut finished_shard_hashes = HashSet::<MerkleHash>::with_capacity(shards.len());
+    if shards.is_empty() {
+        return Ok(ShardMergeResult::default());
+    }
 
     let mut cur_data = Vec::<u8>::with_capacity(target_max_size as usize);
-    let mut alt_data = Vec::<u8>::with_capacity(target_max_size as usize);
+    let mut next_data = Vec::<u8>::with_capacity(target_max_size as usize);
     let mut out_data = Vec::<u8>::with_capacity(target_max_size as usize);
 
-    let mut shards_to_remove: Vec<Arc<MDBShardFile>> = Vec::with_capacity(shards.len());
+    let mut dest_shards = Vec::<Arc<MDBShardFile>>::with_capacity(shards.len());
+    let mut ingested_shards: Vec<Arc<MDBShardFile>> = Vec::with_capacity(shards.len());
+    let mut skipped_shards = Vec::new();
 
-    let mut cur_idx = 0;
+    let mut cur_si = MDBShardInfo::default();
 
-    {
-        while cur_idx < shards.len() {
-            let cur_sfi = &shards[cur_idx];
-
-            // Now, see how many we can consolidate.
-            let mut ub_idx = cur_idx + 1;
-            let mut current_size = cur_sfi.shard.num_bytes();
-
-            for idx in (cur_idx + 1).. {
-                if idx == shards.len() || shards[idx].shard.num_bytes() + current_size >= target_max_size {
-                    ub_idx = idx;
-                    break;
-                }
-                current_size += shards[idx].shard.num_bytes()
-            }
-
-            if ub_idx == cur_idx + 1 {
-                // We can't consolidate any here.
-                finished_shard_hashes.insert(cur_sfi.shard_hash);
-
-                if copy_preserved_source_shards {
-                    let copied_sfi = cur_sfi.copy_into_target_directory(&target_directory)?;
-                    finished_shards.push(copied_sfi);
-                    shards_to_remove.push(cur_sfi.clone());
-                } else {
-                    finished_shards.push(cur_sfi.clone());
-                }
+    for sfi in shards {
+        // Now, load the new shard data in.  To be resiliant to the possibility of shards
+        // being deleted under us (as can happen in shard session resume with multiple
+        // processes running), always load it all into memory at the start and write it out
+        // at the end.
+        if let Err(e) = sfi.read_into_buffer(&mut next_data) {
+            if skip_on_error {
+                info!("Error encountered reading shard {:?}: {e}; skipping.", &sfi.path);
+                skipped_shards.push(sfi.clone());
+                continue;
             } else {
-                // We have one or more shards to merge, so do this all in memory.
-
-                // Get the current data in a buffer
-                let mut cur_shard_info = cur_sfi.shard.clone();
-
-                cur_data.clear();
-                std::fs::File::open(&cur_sfi.path)?.read_to_end(&mut cur_data)?;
-
-                // Now, merge in everything in memory
-                for i in (cur_idx + 1)..ub_idx {
-                    let sfi = &shards[i];
-
-                    alt_data.clear();
-                    std::fs::File::open(&sfi.path)?.read_to_end(&mut alt_data)?;
-
-                    // Now merge the main shard
-                    out_data.clear();
-
-                    // Merge these in to the current shard.
-                    cur_shard_info = shard_set_union(
-                        &cur_shard_info,
-                        &mut Cursor::new(&cur_data),
-                        &sfi.shard,
-                        &mut Cursor::new(&alt_data),
-                        &mut out_data,
-                    )?;
-
-                    swap(&mut cur_data, &mut out_data);
-                }
-
-                // Write out the shard.
-                let new_sfi = { MDBShardFile::write_out_from_reader(&target_directory, &mut Cursor::new(&cur_data))? };
-
-                debug!(
-                    "Created merged shard {:?} from shards {:?}",
-                    &new_sfi.path,
-                    shards[cur_idx..ub_idx].iter().map(|sfi| &sfi.path)
-                );
-
-                finished_shard_hashes.insert(new_sfi.shard_hash);
-                finished_shards.push(new_sfi);
-
-                for sfi in shards[cur_idx..ub_idx].iter() {
-                    shards_to_remove.push(sfi.clone());
-                }
+                error!("Error encountered reading shard {:?}: {e}.", &sfi.path);
+                return Err(e);
             }
+        };
 
-            cur_idx = ub_idx;
+        ingested_shards.push(sfi.clone());
+
+        if cur_data.is_empty() {
+            // Starting from scratch
+            swap(&mut cur_data, &mut next_data);
+            cur_si = sfi.shard.clone();
+        } else if cur_data.len() + next_data.len() - (size_of::<MDBShardFileHeader>() + size_of::<MDBShardFileFooter>())
+            <= target_max_size as usize
+        {
+            // We have enough size capacity to merge this one in.
+            out_data.clear();
+            cur_si = shard_set_union(
+                &cur_si,
+                &mut Cursor::new(&cur_data),
+                &sfi.shard,
+                &mut Cursor::new(&next_data),
+                &mut out_data,
+            )?;
+
+            // Now swap out the destination data with the current data.
+            swap(&mut out_data, &mut cur_data);
+        } else {
+            // Flush everything out and replace the new.
+            let out_sfi = MDBShardFile::write_out_from_reader(&target_directory, &mut Cursor::new(&cur_data))?;
+            dest_shards.push(out_sfi);
+
+            // Move the loaded data into the current buffer.
+            swap(&mut cur_data, &mut next_data);
+            cur_si = sfi.shard.clone();
         }
     }
 
-    if !copy_preserved_source_shards {
-        // In rare cases, there could be empty shards or shards with
-        // duplicate entries and we don't want to delete any shards
-        // we've already finished
-        shards_to_remove.retain(|sfi| !finished_shard_hashes.contains(&sfi.shard_hash));
+    // If there is any left over at the end, flush that as well.
+    if !cur_data.is_empty() {
+        let out_sfi = MDBShardFile::write_out_from_reader(&target_directory, &mut Cursor::new(&cur_data))?;
+        dest_shards.push(out_sfi);
     }
 
-    Ok((finished_shards, shards_to_remove))
+    // Now the obselete shards are all the source shards that do not refer to the same shard file
+    // as one of the dest shards.
+    if source_directory.as_ref() == target_directory.as_ref() {
+        let dest_shard_hashes: HashSet<_> = dest_shards.iter().map(|s| s.shard_hash).collect();
+
+        ingested_shards.retain(|sfi| !dest_shard_hashes.contains(&sfi.shard_hash));
+    }
+
+    Ok(ShardMergeResult {
+        merged_shards: dest_shards,
+        obsolete_shards: ingested_shards,
+        skipped_shards,
+    })
 }
 
 /// Same as above, but performs it in the background and on a io focused thread.
@@ -159,9 +152,12 @@ pub fn merge_shards_background(
     source_directory: impl AsRef<Path>,
     target_directory: impl AsRef<Path>,
     target_max_size: u64,
-) -> JoinHandle<Result<(MDBShardFileVec, MDBShardFileVec)>> {
+    skip_on_error: bool,
+) -> JoinHandle<Result<ShardMergeResult>> {
     let source_directory = source_directory.as_ref().to_owned();
     let target_directory = target_directory.as_ref().to_owned();
 
-    tokio::task::spawn_blocking(move || merge_shards(source_directory, target_directory, target_max_size))
+    tokio::task::spawn_blocking(move || {
+        merge_shards(source_directory, target_directory, target_max_size, skip_on_error)
+    })
 }

--- a/mdb_shard/src/shard_file_handle.rs
+++ b/mdb_shard/src/shard_file_handle.rs
@@ -292,7 +292,7 @@ impl MDBShardFile {
         let path = path.as_ref();
 
         let mut load_file = |h: MerkleHash, file_name: &Path| -> Result<()> {
-            let s_res = Self::load_from_hash_and_path(h, &file_name);
+            let s_res = Self::load_from_hash_and_path(h, file_name);
 
             let s = match s_res {
                 Ok(s) => s,
@@ -325,12 +325,10 @@ impl MDBShardFile {
                     load_file(h, &path.join(entry.file_name()))?;
                 }
             }
+        } else if let Some(h) = path.file_name().and_then(parse_shard_filename) {
+            load_file(h, path)?;
         } else {
-            if let Some(h) = path.file_name().and_then(parse_shard_filename) {
-                load_file(h, path)?;
-            } else {
-                return Err(MDBShardError::BadFilename(format!("Filename {path:?} not valid shard file name.")));
-            }
+            return Err(MDBShardError::BadFilename(format!("Filename {path:?} not valid shard file name.")));
         }
 
         Ok(())

--- a/mdb_shard/src/shard_file_manager.rs
+++ b/mdb_shard/src/shard_file_manager.rs
@@ -172,8 +172,13 @@ impl ShardFileManager {
     }
 
     pub async fn refresh_shard_dir(&self, prune_expired: bool, prune_cache_to_size: u64) -> Result<()> {
-        let mut shard_files =
-            MDBShardFile::load_managed_directory(&self.shard_directory, false, prune_expired, prune_cache_to_size)?;
+        let mut shard_files = MDBShardFile::load_managed_directory(
+            &self.shard_directory,
+            true,
+            false,
+            prune_expired,
+            prune_cache_to_size,
+        )?;
 
         {
             let shard_read_guard = self.shard_bookkeeper.read().await;
@@ -524,6 +529,7 @@ mod tests {
     use crate::file_structs::FileDataSequenceHeader;
     use crate::session_directory::{consolidate_shards_in_directory, merge_shards};
     use crate::shard_format::test_routines::{gen_random_file_info, rng_hash, simple_hash};
+    use crate::utils::parse_shard_filename;
 
     #[allow(clippy::type_complexity)]
     pub async fn fill_with_specific_shard(
@@ -749,7 +755,7 @@ mod tests {
             verify_mdb_shards_match(&mdb2, &mdb_in_mem, true).await?;
 
             // Now, merge shards in the background.
-            let merged_shards = consolidate_shards_in_directory(tmp_dir.path(), *MDB_SHARD_MIN_TARGET_SIZE)?;
+            let merged_shards = consolidate_shards_in_directory(tmp_dir.path(), *MDB_SHARD_MIN_TARGET_SIZE, false)?;
 
             assert_eq!(merged_shards.len(), 1);
             for si in merged_shards {
@@ -825,7 +831,7 @@ mod tests {
 
             {
                 let merged_shards =
-                    consolidate_shards_in_directory(tmp_dir.path(), *MDB_SHARD_MIN_TARGET_SIZE).unwrap();
+                    consolidate_shards_in_directory(tmp_dir.path(), *MDB_SHARD_MIN_TARGET_SIZE, false).unwrap();
 
                 assert_eq!(merged_shards.len(), 1);
 
@@ -879,7 +885,9 @@ mod tests {
         {
             let tmp_merge_dir = TempDir::new()?;
 
-            let (mut merged_shards, m_del_shards) = merge_shards(tmp_dir.path(), tmp_merge_dir.path(), 8 * T)?;
+            let shard_merge_result = merge_shards(tmp_dir.path(), tmp_merge_dir.path(), 8 * T, false)?;
+            let mut merged_shards = shard_merge_result.merged_shards;
+            let m_del_shards = shard_merge_result.obsolete_shards;
 
             for sfi in merged_shards.iter() {
                 sfi.verify_shard_integrity();
@@ -889,7 +897,7 @@ mod tests {
             assert_eq!(paths.count(), m_del_shards.len());
 
             // This call should be the same, but
-            let mut rv = consolidate_shards_in_directory(tmp_dir.path(), 8 * T)?;
+            let mut rv = consolidate_shards_in_directory(tmp_dir.path(), 8 * T, false)?;
 
             let paths = std::fs::read_dir(tmp_dir.path()).unwrap();
             let n_paths = paths.count();
@@ -952,7 +960,7 @@ mod tests {
             // Make sure it's all in there this round.
             verify_mdb_shards_match(&mdb2, &mdb_in_mem, true).await?;
 
-            let merged_shards = consolidate_shards_in_directory(tmp_dir.path(), target_size)?;
+            let merged_shards = consolidate_shards_in_directory(tmp_dir.path(), target_size, false)?;
 
             for si in merged_shards.iter() {
                 assert!(si.path.exists());
@@ -1234,6 +1242,77 @@ mod tests {
 
             // We set this one to be exact, so we can compare these as equal
             assert_eq!(directory_size, current_size_limit);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_shard_deletion_ok() {
+        let tmp_dir = TempDir::with_prefix("shard_test_deletion").unwrap();
+
+        let tmp_dir_1 = tmp_dir.path().join("src");
+
+        create_random_shard_collection(0, &tmp_dir_1, 4, &[4; 4], &[4; 4])
+            .await
+            .unwrap();
+
+        // Get the size of one of these shards to use as
+        let base_size = 1 + tmp_dir_1.read_dir().unwrap().next().unwrap().unwrap().metadata().unwrap().len();
+
+        for (merge_size, n_merged) in [(1, 3), (2, 2), (4, 1)] {
+            for corrupt_file_index in 0..4 {
+                let work_dir = tmp_dir.path().join(format!("tmp_{merge_size}_{corrupt_file_index}"));
+                let tmp_src_dir = work_dir.join("src");
+                std::fs::create_dir_all(&tmp_src_dir).unwrap();
+
+                let mut bad_shard_hash = Default::default();
+
+                // copy all the shard files in tmp_dir_1 to dir, but delet
+                std::fs::create_dir_all(&tmp_src_dir).unwrap();
+                for (i, p) in std::fs::read_dir(&tmp_dir_1).unwrap().enumerate() {
+                    let p = p.unwrap();
+                    let dest_file_name = tmp_src_dir.join(p.file_name());
+                    std::fs::copy(p.path(), &dest_file_name).unwrap();
+
+                    if i == corrupt_file_index {
+                        // Load this so the metadata gets cached; that will get loaded from cache.
+                        let sfi = MDBShardFile::load_from_file(&dest_file_name).unwrap();
+
+                        // Turn off the typical verification checks on this shard, so it isn't verified
+                        // on loading from the cache.
+                        sfi.disable_verifications.store(true, std::sync::atomic::Ordering::Relaxed);
+
+                        // Replace the file with an empty file.  On read, this will error, and should skip.
+                        std::fs::File::create(&dest_file_name).unwrap();
+
+                        bad_shard_hash = sfi.shard_hash;
+                    }
+                }
+
+                // Now attempt a merge; this should cause an error.
+                let out_dir_1 = work_dir.join("out_err");
+                std::fs::create_dir_all(&out_dir_1).unwrap();
+                let res = merge_shards(&tmp_src_dir, &out_dir_1, base_size * merge_size, false);
+                assert!(res.is_err());
+
+                // Now attempt a merge with error skipping; which should not cause an error.
+                let out_dir_2 = work_dir.join("out_skips");
+                std::fs::create_dir_all(&out_dir_2).unwrap();
+                let res = merge_shards(&tmp_src_dir, &out_dir_2, base_size * merge_size, true).unwrap();
+
+                assert_eq!(res.merged_shards.len(), n_merged);
+
+                assert_eq!(res.obsolete_shards.len(), 3);
+
+                assert_eq!(res.skipped_shards.len(), 1);
+                assert_eq!(
+                    res.skipped_shards
+                        .first()
+                        .map(|s| &s.path)
+                        .and_then(parse_shard_filename)
+                        .unwrap(),
+                    bad_shard_hash
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
Currently, the shard merging algorithm, which is part of the shard resume session, is not robust to shard files being deleted.  This can happen when multiple upload_files are being called, each from the same endpoint.  This PR makes this routine robust to these files disappearing.  

In addition, we add a configurable environment variable, SESSION_RESUME_ENABLE, that can be set to 0 / false to disable session resume behavior.  This is true by default.

