### PR TITLE
remove footer serialized from upload xorb payload on remote_client

### DIFF
--- a/cas_client/src/interface.rs
+++ b/cas_client/src/interface.rs
@@ -32,6 +32,10 @@ pub trait UploadClient {
 
     /// Check if a XORB already exists.
     async fn exists(&self, prefix: &str, hash: &MerkleHash) -> Result<bool>;
+
+    /// Indicates if the serialized cas object should have a written footer.
+    /// This should only be true for testing with LocalClient.
+    fn use_xorb_footer(&self) -> bool;
 }
 
 /// A Client to the CAS (Content Addressed Storage) service to allow reconstructing a

--- a/cas_client/src/local_client.rs
+++ b/cas_client/src/local_client.rs
@@ -308,6 +308,10 @@ impl UploadClient for LocalClient {
             Err(_) => Err(CasClientError::XORBNotFound(*hash)),
         }
     }
+
+    fn use_xorb_footer(&self) -> bool {
+        true
+    }
 }
 
 #[async_trait]

--- a/cas_client/src/remote_client.rs
+++ b/cas_client/src/remote_client.rs
@@ -225,6 +225,10 @@ impl UploadClient for RemoteClient {
             e => Err(CasClientError::internal(format!("unrecognized status code {e}"))),
         }
     }
+
+    fn use_xorb_footer(&self) -> bool {
+        false
+    }
 }
 
 #[async_trait]

--- a/data/src/file_upload_session.rs
+++ b/data/src/file_upload_session.rs
@@ -337,8 +337,10 @@ impl FileUploadSession {
 
         // Serialize the object; this can be relatively expensive, so run it on a compute thread.
         let compression_scheme = self.config.data_config.compression;
+        let with_footer = self.client.use_xorb_footer();
         let cas_object =
-            tokio::task::spawn_blocking(move || SerializedCasObject::from_xorb(xorb, compression_scheme)).await??;
+            tokio::task::spawn_blocking(move || SerializedCasObject::from_xorb(xorb, compression_scheme, with_footer))
+                .await??;
 
         let session = self.clone();
         let upload_permit = acquire_upload_permit().await?;


### PR DESCRIPTION
merging this PR requires updating CAS server first.

Updates the xorb serialized format to not include the xorb footer when specified.

This is not the cleanest solution necessarily, because the cas_object tests still require that we serialize the footer (those tests are useful for the cas server where xorbs will later actually contain the footer) but are not relevant for the remote_client upload path. Likewise the LocalClient relies on the xorb footer being serialized.

We may want to refactor this code to remove the footer from xet-core entirely. We would then have to re-implement LocalClient somehow (might be worth enough reason to keep the footer in xet-core). 