### PR TITLE
Adding issue templates to repo 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,60 @@
+name: "\U0001F41B Bug Report"
+description: Report a bug on xet-core
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is and details about your machine (e.g., network capcity, file system, disk type, etc.).
+      placeholder: Bug description
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Please provide a minimal reproducible code which we can copy/paste and reproduce the issue.
+      placeholder: Reproduction
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: "Please include any printed warnings or errors if you can."
+      render: shell
+  - type: textarea
+    id: system-info
+    attributes:
+      label: System info
+      description: |
+        Please dump your environment info by running the following commands and copy-paste the results here:
+        ```txt
+        huggingface-cli env
+        env | grep HF_XET
+        ```
+
+        If you are working in a notebook, please run it in a code cell:
+        ```py
+        import os
+        from huggingface_hub import dump_environment_info
+        
+        # Dump environment info to the console
+        dump_environment_info()
+
+        # Dump HF_XET environment variables
+        for key, value in os.environ.items():
+          if key.startswith("HF_XET"):
+            print(f"{key}={value}")
+        ```
+      render: shell
+      placeholder: |
+        - huggingface_hub version: 0.11.0.dev0
+        - Platform: Linux-5.15.0-52-generic-x86_64-with-glibc2.35
+        - Python version: 3.10.6
+        ...
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Website Related
+    url: https://github.com/huggingface/hub-docs/issues
+    about: Feature requests and bug reports related to the website
+  - name: Forum
+    url: https://discuss.huggingface.co/
+    about: General usage questions and community discussions

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,32 @@
+name: "\U0001F680 Feature request"
+description: Propose an enhancement.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for this feature request! We appreciate your input and will review it as soon as possible.
+  - type: textarea
+    id: current-limitation
+    attributes:
+      label: Current Limitation
+      description: A clear and concise description of the current limitation you would like to see addressed.
+      placeholder: Current limitation description
+    validations:
+      required: true
+  - type: textarea
+    id: feature-description
+    attributes:
+      label: Feature Description
+      description: A clear and concise description of the feature you would like to see and how it would address your current issues.
+      placeholder: Feature description
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Any additional context or information that may be relevant to the feature request.
+      placeholder: Additional context
+    validations:
+      required: false


### PR DESCRIPTION
This PR adds: 
* bug-report.yml - an issue form for bug reports (will likely need to be extended/changed as new clients are added; for now it is very Python-centric)
* feature-request.yml - an issue form for feature requests 
* config.yml - additional links that people will see when clicking on "New Issue" - see https://github.com/huggingface/huggingface_hub/issues -> `New Issue` for an example

The `.yml` files and directory structure follow the issue form syntax/structure described here https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms

A lot of this was lifted from the way the `huggingface_hub` repository structures these templates - see here: https://github.com/huggingface/huggingface_hub/tree/main/.github/ISSUE_TEMPLATE  - and then modified for some of the more common things we ask (machine info; HF_XET envvars, etc)

This symmetry between `huggingface_hub` and this repo was intentional so community members aren't started by a completely different format for providing information when opening an issue/asking for a feature. 