### PR TITLE
Added rustls-tls-native-roots to fix Reqwest cert errors.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ rand = "0.9"
 rand_chacha = "0.9"
 rayon = "1.5"
 regex = "1"
-reqwest = { version = "0.12", features = ["json", "stream"] }
+reqwest = { version = "0.12", features = ["json", "stream", "rustls-tls-native-roots"] }
 reqwest-middleware = "0.4"
 reqwest-retry = "0.7"
 rustc-hash = "1.1"


### PR DESCRIPTION
Fixes #351 

No default CA hint was defined for Reqwest.  Added one.