### PR TITLE
add ci steps to check cargo.lock is up to date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,10 @@ jobs:
       - name: Build and Test
         run: |
           cargo test --verbose --no-fail-fast --features "strict"
+      - name: Check Cargo.lock has no uncommitted changes
+        run: |
+          # the build and test steps would update Cargo.lock if it is out of date
+          test -z "$(git status --porcelain Cargo.lock)" || (echo "Cargo.lock has uncommitted changes!" && exit 1)
   build_and_test-win:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/hf-xet-tests.yml
+++ b/.github/workflows/hf-xet-tests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # checkout out xet-core
-      - uses: actions/checkout@v4 
+      - uses: actions/checkout@v4
       # checkout out huggingface_hub
       - uses: actions/checkout@v4
         with:
@@ -42,3 +42,7 @@ jobs:
         run: |
           source .venv/bin/activate
           pytest huggingface_hub/tests/test_xet_*.py
+      - name: Check Cargo.lock has no uncommitted changes
+        run: |
+          # the Build wheel step would update hf_xet/Cargo.lock if it is out of date
+          test -z "$(git status --porcelain hf_xet/Cargo.lock)" || (echo "hf_xet/Cargo.lock has uncommitted changes!" && exit 1)

--- a/hf_xet/Cargo.lock
+++ b/hf_xet/Cargo.lock
@@ -614,6 +614,7 @@ version = "0.14.5"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bytes",
  "cas_client",
  "cas_object",
  "cas_types",
@@ -664,6 +665,7 @@ name = "deduplication"
 version = "0.14.5"
 dependencies = [
  "async-trait",
+ "bytes",
  "gearhash",
  "mdb_shard",
  "merkledb",


### PR DESCRIPTION
We keep having out of date hf_xet/Cargo.lock, likely people are not building hf_xet 100% of the time they are pushing to the repo. This PR enforces that hf_xet/Cargo.lock and the root Cargo.lock must be up to date, a CI job will fail if this is not true.
