### PR TITLE
Change download currency limit from local to global.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -496,6 +496,7 @@ dependencies = [
  "http 1.3.1",
  "httpmock",
  "hyper-util",
+ "lazy_static",
  "mdb_shard",
  "merkledb",
  "merklehash",

--- a/cas_client/Cargo.toml
+++ b/cas_client/Cargo.toml
@@ -32,6 +32,7 @@ tokio = { workspace = true }
 tokio-retry = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
+lazy_static = { workspace = true }
 
 reqwest-middleware = "0.4"
 reqwest-retry = "0.7"

--- a/hf_xet/Cargo.lock
+++ b/hf_xet/Cargo.lock
@@ -275,6 +275,7 @@ dependencies = [
  "heed",
  "http",
  "hyper-util",
+ "lazy_static",
  "mdb_shard",
  "merkledb",
  "merklehash",


### PR DESCRIPTION
This PR changes the limit on the number of simultaneous range fetches from a per-file limit to a global limit.  It defaults to 128.

Currently, each TCP connection creates a socket, which uses up a file handle.  On OSX, this is limited to 256 by default, which means that downloading multiple large files would quickly exhaust this.  

This is also the cause of the dns resolver errors in https://github.com/huggingface/xet-core/issues/373. 

The tokio semaphore is fair, which means that permits are released in the order in which they were requested.   Thus this shouldn't have any behavior change from the existing, except for the cap on the number of simultaneous fetches.  