### PR TITLE
Updating chunk and shard cache default sizes

### DIFF
--- a/chunk_cache/src/disk.rs
+++ b/chunk_cache/src/disk.rs
@@ -28,7 +28,7 @@ pub mod test_utils;
 
 // consistently use URL_SAFE (also file path safe) base64 codec
 pub(crate) const BASE64_ENGINE: GeneralPurpose = URL_SAFE;
-pub const DEFAULT_CHUNK_CACHE_CAPACITY: u64 = 10 << 30; // 10 GB
+pub const DEFAULT_CHUNK_CACHE_CAPACITY: u64 = 10_000_000_000; // 10 GB
 const PREFIX_DIR_NAME_LEN: usize = 2;
 
 type OptionResult<T, E> = Result<Option<T>, E>;

--- a/mdb_shard/src/constants.rs
+++ b/mdb_shard/src/constants.rs
@@ -17,7 +17,7 @@ utils::configurable_constants! {
     ///
     /// Note the cache is pruned to below this value at the beginning of a session,
     /// but during a single session new shards may be added such that this limit is exceeded.
-    ref SHARD_CACHE_SIZE_LIMIT : u64 = 16 * 1024 * 1024 * 1024;
+    ref SHARD_CACHE_SIZE_LIMIT : u64 = 16_000_000_000;
 
     /// The amount of time a shard should be expired by before it's deleted, in seconds.
     /// By default set to 7 days.


### PR DESCRIPTION
Updating the chunk and shard cache default size to use powers of 10 instead of powers of 2. See https://github.com/huggingface/huggingface_hub/pull/3190#discussion_r2176840066 for background. 

Note: This is my first real PR to the repo! I didn't do anything outside of: 
1. Change the constants to these new values
2. Verify the existing docs
3. Run `cargo test` and check to make sure there were no failing tests. 

If there were other steps I should've taken to validate the change, let me know!

Sidenote: Noticed while working on this that I need to update the existing huggingface_hub docs as https://linear.app/xet/issue/XET-602/document-hf-xet-shard-cache-size-limit grew out of date with the default shard cache size. 