### PR TITLE
Simplified Client interface.

### DIFF
--- a/cas_client/src/interface.rs
+++ b/cas_client/src/interface.rs
@@ -1,167 +1,80 @@
-#[cfg(not(target_family = "wasm"))]
-use mdb_shard::shard_file_reconstructor::FileReconstructor;
+use std::collections::HashMap;
+use std::sync::Arc;
 
-#[cfg(not(target_family = "wasm"))]
-use crate::CasClientError;
+use bytes::Bytes;
+use cas_object::SerializedCasObject;
+use cas_types::FileRange;
+use mdb_shard::file_structs::MDBFileInfo;
+use merklehash::MerkleHash;
+use progress_tracking::item_tracking::SingleItemProgressUpdater;
+use progress_tracking::upload_tracking::CompletionTracker;
+
+use crate::error::Result;
+use crate::OutputProvider;
 
 /// A Client to the Shard service. The shard service
 /// provides for
 /// 1. upload shard to the shard service
 /// 2. querying of file->reconstruction information
 /// 3. querying of chunk->shard information
-#[cfg(not(target_family = "wasm"))]
-pub trait ShardClientInterface:
-    RegistrationClient + FileReconstructor<CasClientError> + ShardDedupProber + Send + Sync
-{
-}
-// In webassembly environment ShardClientInterface does not include FileReconstructor
-// and does not require Send/Sync'ness
-#[cfg(target_family = "wasm")]
-pub trait ShardClientInterface: RegistrationClient + ShardDedupProber {}
-
-#[cfg(not(target_family = "wasm"))]
-pub trait Client: UploadClient + ReconstructionClient + ShardClientInterface {}
-// in webassembly environment the general "Client" interface does not support the
-// ReconstructionClient download interface.
-#[cfg(target_family = "wasm")]
-pub trait Client: UploadClient + ShardClientInterface {}
-
-// interfaces used on the download path, primarily relating to fetching and using file reconstructions
-// to download file data.
-// not enabled in webassembly
-#[cfg(not(target_family = "wasm"))]
-mod download {
-    use std::collections::HashMap;
-    use std::sync::Arc;
-
-    use cas_types::{FileRange, QueryReconstructionResponse};
-    use merklehash::MerkleHash;
-    use progress_tracking::item_tracking::SingleItemProgressUpdater;
-
-    use crate::error::Result;
-    use crate::output_provider::OutputProvider;
-
-    /// A Client to the CAS (Content Addressed Storage) service to allow reconstructing a
-    /// pointer file based on FileID (MerkleHash).
+#[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
+pub trait Client {
+    /// Get an entire file by file hash with an optional bytes range.
     ///
-    /// To simplify this crate, it is intentional that the client does not create its own http_client or
-    /// spawn its own threads. Instead, it is expected to be given the parallelism harness/threadpool/queue
-    /// on which it is expected to run. This allows the caller to better optimize overall system utilization
-    /// by controlling the number of concurrent requests.
-    #[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
-    #[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
-    pub trait ReconstructionClient {
-        /// Get an entire file by file hash with an optional bytes range.
-        ///
-        /// The http_client passed in is a non-authenticated client. This is used to directly communicate
-        /// with the backing store (S3) to retrieve xorbs.
-        async fn get_file(
-            &self,
-            hash: &MerkleHash,
-            byte_range: Option<FileRange>,
-            output_provider: &OutputProvider,
-            progress_updater: Option<Arc<SingleItemProgressUpdater>>,
-        ) -> Result<u64>;
+    /// The http_client passed in is a non-authenticated client. This is used to directly communicate
+    /// with the backing store (S3) to retrieve xorbs.
+    async fn get_file(
+        &self,
+        hash: &MerkleHash,
+        byte_range: Option<FileRange>,
+        output_provider: &OutputProvider,
+        progress_updater: Option<Arc<SingleItemProgressUpdater>>,
+    ) -> Result<u64>;
 
-        async fn batch_get_file(&self, files: HashMap<MerkleHash, &OutputProvider>) -> Result<u64> {
-            let mut n_bytes = 0;
-            // Provide the basic naive implementation as a default.
-            for (h, w) in files {
-                n_bytes += self.get_file(&h, None, w, None).await?;
-            }
-            Ok(n_bytes)
+    async fn batch_get_file(&self, files: HashMap<MerkleHash, &OutputProvider>) -> Result<u64> {
+        let mut n_bytes = 0;
+        // Provide the basic naive implementation as a default.
+        for (h, w) in files {
+            n_bytes += self.get_file(&h, None, w, None).await?;
         }
+        Ok(n_bytes)
     }
 
-    /// A Client to the CAS (Content Addressed Storage) service that is able to obtain
-    /// the reconstruction info of a file by FileID (MerkleHash). Return
-    /// - Ok(Some(response)) if the query succeeded,
-    /// - Ok(None) if the specified range can't be satisfied,
-    /// - Err(e) for other errors.
-    #[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
-    #[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
-    pub trait Reconstruct {
-        async fn get_reconstruction(
-            &self,
-            hash: &MerkleHash,
-            byte_range: Option<FileRange>,
-        ) -> Result<Option<QueryReconstructionResponse>>;
-    }
+    async fn get_file_reconstruction_info(
+        &self,
+        file_hash: &MerkleHash,
+    ) -> Result<Option<(MDBFileInfo, Option<MerkleHash>)>>;
+
+    async fn query_for_global_dedup_shard(
+        &self,
+        prefix: &str,
+        chunk_hash: &MerkleHash,
+        salt: &[u8; 32],
+    ) -> Result<Option<Bytes>>;
+
+    /// Upload a new shard.
+    async fn upload_shard(
+        &self,
+        prefix: &str,
+        hash: &MerkleHash,
+        force_sync: bool,
+        shard_data: bytes::Bytes,
+        salt: &[u8; 32],
+    ) -> Result<bool>;
+
+    /// Upload a new xorb.
+    async fn upload_xorb(
+        &self,
+        prefix: &str,
+        serialized_cas_object: SerializedCasObject,
+        upload_tracker: Option<Arc<CompletionTracker>>,
+    ) -> Result<u64>;
+
+    /// Check if a XORB already exists.
+    async fn exists(&self, prefix: &str, hash: &MerkleHash) -> Result<bool>;
+
+    /// Indicates if the serialized cas object should have a written footer.
+    /// This should only be true for testing with LocalClient.
+    fn use_xorb_footer(&self) -> bool;
 }
-
-// upload interfaces for operations required for the upload path
-// including global deduplication
-// enabled in standard build environments and web assembly
-mod upload {
-    use std::sync::Arc;
-
-    use cas_object::SerializedCasObject;
-    use merklehash::MerkleHash;
-    use progress_tracking::upload_tracking::CompletionTracker;
-
-    use crate::error::Result;
-
-    #[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
-    #[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
-    pub trait RegistrationClient {
-        async fn upload_shard(
-            &self,
-            prefix: &str,
-            hash: &MerkleHash,
-            force_sync: bool,
-            shard_data: bytes::Bytes,
-            salt: &[u8; 32],
-        ) -> Result<bool>;
-    }
-
-    /// Probes for shards that provide dedup information for a chunk, and, if
-    /// any are found, writes them to disk and returns the path.
-    #[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
-    #[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
-    pub trait ShardDedupProber {
-        #[cfg(not(target_family = "wasm"))]
-        async fn query_for_global_dedup_shard(
-            &self,
-            prefix: &str,
-            chunk_hash: &MerkleHash,
-            salt: &[u8; 32],
-        ) -> Result<Option<std::path::PathBuf>>;
-
-        async fn query_for_global_dedup_shard_in_memory(
-            &self,
-            prefix: &str,
-            chunk_hash: &MerkleHash,
-            salt: &[u8; 32],
-        ) -> Result<Option<Vec<u8>>>;
-    }
-
-    /// A Client to the CAS (Content Addressed Storage) service to allow storage and
-    /// management of XORBs (Xet Object Remote Block). A XORB represents a collection
-    /// of arbitrary bytes. These bytes are hashed according to a Xet Merkle Hash
-    /// producing a Merkle Tree. XORBs in the CAS are identified by a combination of
-    /// a prefix namespacing the XORB and the hash at the root of the Merkle Tree.
-    #[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
-    #[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
-    pub trait UploadClient {
-        /// Insert a serialized XORB into the CAS, returning the number of bytes read.
-        async fn upload_xorb(
-            &self,
-            prefix: &str,
-            serialized_cas_object: SerializedCasObject,
-            upload_tracker: Option<Arc<CompletionTracker>>,
-        ) -> Result<u64>;
-
-        /// Check if a XORB already exists.
-        async fn exists(&self, prefix: &str, hash: &MerkleHash) -> Result<bool>;
-
-        /// Indicates if the serialized cas object should have a written footer.
-        /// This should only be true for testing with LocalClient.
-        fn use_xorb_footer(&self) -> bool;
-    }
-}
-
-// export out interfaces to be referred to directly out of the interface sub-crate
-// users of cas_client interface are unaware of the module level separation between download/upload.
-#[cfg(not(target_family = "wasm"))]
-pub use download::*;
-pub use upload::*;

--- a/cas_client/src/lib.rs
+++ b/cas_client/src/lib.rs
@@ -2,10 +2,7 @@
 
 pub use chunk_cache::{CacheConfig, CHUNK_CACHE_SIZE_BYTES};
 pub use http_client::{build_auth_http_client, build_http_client, Api, RetryConfig};
-use interface::RegistrationClient;
-pub use interface::{Client, UploadClient};
-#[cfg(not(target_family = "wasm"))]
-pub use interface::{Reconstruct, ReconstructionClient};
+pub use interface::Client;
 #[cfg(not(target_family = "wasm"))]
 pub use local_client::LocalClient;
 #[cfg(not(target_family = "wasm"))]
@@ -13,7 +10,6 @@ pub use output_provider::{FileProvider, OutputProvider};
 pub use remote_client::RemoteClient;
 
 pub use crate::error::CasClientError;
-pub use crate::interface::ShardClientInterface;
 
 mod constants;
 #[cfg(not(target_family = "wasm"))]

--- a/data/src/bin/xtool.rs
+++ b/data/src/bin/xtool.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::Result;
-use cas_client::{Reconstruct, RemoteClient};
+use cas_client::RemoteClient;
 use cas_object::CompressionScheme;
 use cas_types::{FileRange, QueryReconstructionResponse};
 use clap::{Args, Parser, Subcommand};

--- a/data/src/remote_client_interface.rs
+++ b/data/src/remote_client_interface.rs
@@ -25,7 +25,7 @@ pub(crate) fn create_remote_client(
         Endpoint::FileSystem(ref path) => {
             #[cfg(not(target_family = "wasm"))]
             {
-                Ok(Arc::new(cas_client::LocalClient::new(path, None)?))
+                Ok(Arc::new(cas_client::LocalClient::new(path)?))
             }
             #[cfg(target_family = "wasm")]
             unimplemented!("Local file system access is not supported in WASM builds")

--- a/data/src/shard_interface.rs
+++ b/data/src/shard_interface.rs
@@ -137,7 +137,7 @@ impl SessionShardInterface {
 
     /// Queries the client for global deduplication metrics.
     pub async fn query_dedup_shard_by_chunk(&self, chunk_hash: &MerkleHash, repo_salt: &RepoSalt) -> Result<bool> {
-        let Ok(Some(new_shard_file)) = self
+        let Ok(Some(new_shard)) = self
             .client
             .query_for_global_dedup_shard(&self.config.shard_config.prefix, chunk_hash, repo_salt)
             .await
@@ -148,7 +148,7 @@ impl SessionShardInterface {
 
         // The above process found something and downloaded it; it should now be in the cache directory and valid
         // for deduplication.  Register it and restart the dedup process at the start of this chunk.
-        self.cache_shard_manager.register_shards_by_path(&[new_shard_file]).await?;
+        self.cache_shard_manager.import_shard_from_bytes(&new_shard).await?;
 
         Ok(true)
     }

--- a/mdb_shard/src/shard_file_manager.rs
+++ b/mdb_shard/src/shard_file_manager.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::io::Cursor;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
@@ -188,6 +189,12 @@ impl ShardFileManager {
         self.register_shards(&shard_files).await?;
 
         Ok(())
+    }
+
+    pub async fn import_shard_from_bytes(&self, shard: &[u8]) -> Result<()> {
+        let new_shard_file = MDBShardFile::write_out_from_reader(&self.shard_directory, &mut Cursor::new(shard))?;
+
+        self.register_shards(&[new_shard_file]).await
     }
 
     pub fn shard_directory(&self) -> &Path {


### PR DESCRIPTION
Currently, the Client trait has numerous small traits underneath it, but only the umbrella Client trait is ever used.  This PR simplifies this interface by dropping the unneeded fine-grained traits.  

It also consolidates  the multiple routes for the global dedup query into a single function that returns an in-memory shard to further reduce the complexity.

There should be no functionality change, just code moving around and trait simplification.  