### PR TITLE
add verification hash and file hash functions

### DIFF
--- a/hf_xet_thin_wasm/Cargo.lock
+++ b/hf_xet_thin_wasm/Cargo.lock
@@ -533,6 +533,7 @@ name = "hf_xet_thin_wasm"
 version = "0.1.0"
 dependencies = [
  "deduplication",
+ "mdb_shard",
  "merklehash",
  "serde",
  "serde-wasm-bindgen",

--- a/hf_xet_thin_wasm/Cargo.toml
+++ b/hf_xet_thin_wasm/Cargo.toml
@@ -13,3 +13,4 @@ serde-wasm-bindgen = "0.6.5"
 
 deduplication = { path = "../deduplication" }
 merklehash = { path = "../merklehash" }
+mdb_shard = { path = "../mdb_shard" }


### PR DESCRIPTION
Adding more functions to the thin wasm export, needed for forming shards in particular

CC @coyotte508

After the first draft, binary size is 97K for me