### PR TITLE
set shard size limit as max, not target min

### DIFF
--- a/data/src/shard_interface.rs
+++ b/data/src/shard_interface.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, SystemTime};
 use cas_client::Client;
 use error_printer::ErrorPrinter;
 use mdb_shard::cas_structs::MDBCASInfo;
-use mdb_shard::constants::MDB_SHARD_MIN_TARGET_SIZE;
+use mdb_shard::constants::MDB_SHARD_MAX_TARGET_SIZE;
 use mdb_shard::file_structs::{FileDataSequenceEntry, MDBFileInfo};
 use mdb_shard::session_directory::{consolidate_shards_in_directory, merge_shards_background, ShardMergeResult};
 use mdb_shard::shard_in_memory::MDBInMemoryShard;
@@ -73,14 +73,14 @@ impl SessionShardInterface {
         std::fs::create_dir_all(&xorb_metadata_staging_dir)?;
 
         // To allow resume from previous session attempts, merge and copy all the valid shards in the xorb metadata
-        // directory into the current session directory. The originals will remain until all the current senssion xorbs
+        // directory into the current session directory. The originals will remain until all the current session xorbs
         // have been uploaded successfully.  (Also, don't do this on a dry run, as it could screw up non-dry runs).
         let shard_merge_jh = {
             if !dry_run {
                 Some(merge_shards_background(
                     &xorb_metadata_staging_dir,
                     &session_dir,
-                    *MDB_SHARD_MIN_TARGET_SIZE,
+                    *MDB_SHARD_MAX_TARGET_SIZE,
                     true,
                 ))
             } else {
@@ -242,7 +242,7 @@ impl SessionShardInterface {
         // First, scan, merge, and fill out any shards in the session directory
         let shard_list = consolidate_shards_in_directory(
             self.session_shard_manager.shard_directory(),
-            *MDB_SHARD_MIN_TARGET_SIZE,
+            *MDB_SHARD_MAX_TARGET_SIZE,
             // Here, we want to error out if some of the information isn't present or corrupt, so set skip_on_error to
             // false.
             false,

--- a/mdb_shard/src/constants.rs
+++ b/mdb_shard/src/constants.rs
@@ -3,8 +3,8 @@ utils::configurable_constants! {
     /// The target shard size; shards.
     ref MDB_SHARD_TARGET_SIZE: u64 = 64 * 1024 * 1024;
 
-    /// Minimum shard size; small shards are aggregated until they are at least this.
-    ref MDB_SHARD_MIN_TARGET_SIZE: u64 = 64 * 1024 * 1024;
+    /// Maximum shard size; small shards are aggregated until they are at most this.
+    ref MDB_SHARD_MAX_TARGET_SIZE: u64 = 64 * 1024 * 1024;
 
     /// The global dedup chunk modulus; a chunk is considered global dedup
     /// eligible if the hash modulus this value is zero.

--- a/mdb_shard/src/session_directory.rs
+++ b/mdb_shard/src/session_directory.rs
@@ -132,7 +132,7 @@ pub fn merge_shards(
         dest_shards.push(out_sfi);
     }
 
-    // Now the obselete shards are all the source shards that do not refer to the same shard file
+    // Now the obsolete shards are all the source shards that do not refer to the same shard file
     // as one of the dest shards.
     if source_directory.as_ref() == target_directory.as_ref() {
         let dest_shard_hashes: HashSet<_> = dest_shards.iter().map(|s| s.shard_hash).collect();

--- a/mdb_shard/src/shard_file_manager.rs
+++ b/mdb_shard/src/shard_file_manager.rs
@@ -77,7 +77,7 @@ pub struct ShardFileManager {
     shard_bookkeeper: RwTaskLock<ShardBookkeeper, MDBShardError>,
     current_state: RwLock<MDBInMemoryShard>,
     shard_directory: PathBuf,
-    target_shard_min_size: u64,
+    target_shard_max_size: u64,
     shard_directory_cleaned: AtomicBool,
 }
 
@@ -115,7 +115,7 @@ impl ShardFileManager {
     async fn new_impl(
         directory: impl AsRef<Path>,
         is_cachable: bool,
-        target_shard_min_size: u64,
+        target_shard_max_size: u64,
         scan_directory: bool,
         prune_cache_to_size: u64, // Set to 0 to disable pruning
     ) -> Result<Arc<Self>> {
@@ -131,7 +131,7 @@ impl ShardFileManager {
                 shard_bookkeeper: RwTaskLock::from_value(ShardBookkeeper::new()),
                 current_state: RwLock::new(MDBInMemoryShard::default()),
                 shard_directory: shard_directory.clone(),
-                target_shard_min_size,
+                target_shard_max_size,
                 shard_directory_cleaned: AtomicBool::new(false),
             })
         };
@@ -152,17 +152,7 @@ impl ShardFileManager {
 
             // Now, create and insert it.
             let mut rw_lg = MDB_SHARD_FILE_MANAGER_CACHE.write().await;
-            let sfm_entry = rw_lg.entry(shard_directory.clone());
-
-            // See if it's in there; insert otherwise
-            match sfm_entry {
-                std::collections::hash_map::Entry::Vacant(sfm_slot) => {
-                    let sfm = create_new_sfm();
-                    sfm_slot.insert(sfm.clone());
-                    sfm
-                },
-                std::collections::hash_map::Entry::Occupied(sfm) => sfm.get().clone(),
-            }
+            rw_lg.entry(shard_directory.clone()).or_insert_with(create_new_sfm).clone()
         };
 
         if scan_directory {
@@ -438,15 +428,23 @@ impl ShardFileManager {
 
     /// Add CAS info to the in-memory state.
     pub async fn add_cas_block(&self, cas_block_contents: impl Into<Arc<MDBCASInfo>>) -> Result<()> {
+        let cas_block_contents = cas_block_contents.into();
         let mut lg = self.current_state.write().await;
 
-        lg.add_cas_block(cas_block_contents)?;
+        // cut a new shard if adding this cas block will take us over the max shard file size
+        let new_shard_path = if lg.shard_file_size() + cas_block_contents.num_bytes() > self.target_shard_max_size {
+            let path = Self::cut_shard(&mut lg, &self.shard_directory)?;
+            Some(path)
+        } else {
+            None
+        };
 
-        // See if this put it over the target minimum size, allowing us to cut a new shard
-        if lg.shard_file_size() >= self.target_shard_min_size {
-            // Drop the lock guard before doing the flush.
-            drop(lg);
-            self.flush().await?;
+        lg.add_cas_block(cas_block_contents)?;
+        drop(lg);
+
+        // if we cut a new shard, register it after dropping the lock guard
+        if let Some(new_shard_path) = new_shard_path {
+            self.register_shards(&[MDBShardFile::load_from_file(&new_shard_path)?]).await?;
         }
 
         Ok(())
@@ -456,16 +454,29 @@ impl ShardFileManager {
     pub async fn add_file_reconstruction_info(&self, file_info: MDBFileInfo) -> Result<()> {
         let mut lg = self.current_state.write().await;
 
-        lg.add_file_reconstruction_info(file_info)?;
+        // cut a new shard if adding this file will take us over the max shard file size
+        let new_shard_path = if lg.shard_file_size() + file_info.num_bytes() > self.target_shard_max_size {
+            let path = Self::cut_shard(&mut lg, &self.shard_directory)?;
+            Some(path)
+        } else {
+            None
+        };
 
-        // See if this put it over the target minimum size, allowing us to cut a new shard
-        if lg.shard_file_size() >= self.target_shard_min_size {
-            // Drop the lock guard before doing the flush.
-            drop(lg);
-            self.flush().await?;
+        lg.add_file_reconstruction_info(file_info)?;
+        drop(lg);
+
+        // if we cut a new shard, register it after dropping the lock guard
+        if let Some(new_shard_path) = new_shard_path {
+            self.register_shards(&[MDBShardFile::load_from_file(&new_shard_path)?]).await?;
         }
 
         Ok(())
+    }
+
+    fn cut_shard(lg: &mut MDBInMemoryShard, shard_directory: &Path) -> Result<PathBuf> {
+        let new_shard_path = lg.write_to_directory(shard_directory, None)?;
+        *lg = MDBInMemoryShard::default();
+        Ok(new_shard_path)
     }
 
     /// Flush the current state of the in-memory lookups to a shard in the session directory,


### PR DESCRIPTION
Enforce that shards are cut at <= target_shard_max_size (64 MiB)

Previously we were enforcing that shards are cut after exceeding this limit. This enabled in theory shards <128MiB, all shards after this PR will be <= 64 MiB