### PR TITLE
use v1 api paths

### DIFF
--- a/cas_client/src/download_utils.rs
+++ b/cas_client/src/download_utils.rs
@@ -571,6 +571,7 @@ mod tests {
     use tokio::time::sleep;
 
     use super::*;
+    use crate::remote_client::API_VERSION;
     use crate::{build_http_client, RetryConfig};
 
     #[tokio::test]
@@ -612,7 +613,7 @@ mod tests {
         let server = MockServer::start();
         server.mock(|when, then| {
             when.method(GET)
-                .path(format!("/reconstruction/{}", MerkleHash::default()))
+                .path(format!("/{API_VERSION}/reconstruction/{}", MerkleHash::default()))
                 .header(RANGE.as_str(), HttpRange::from(file_range).range_header());
             let response = QueryReconstructionResponse {
                 offset_into_first_range: 0,
@@ -659,7 +660,7 @@ mod tests {
         let server = MockServer::start();
         let mock = server.mock(|when, then| {
             when.method(GET)
-                .path(format!("/reconstruction/{}", MerkleHash::default()))
+                .path(format!("/{API_VERSION}/reconstruction/{}", MerkleHash::default()))
                 .header(RANGE.as_str(), HttpRange::from(file_range_to_refresh).range_header());
             let response = QueryReconstructionResponse {
                 offset_into_first_range: 0,
@@ -716,7 +717,7 @@ mod tests {
         // Arrange server
         let mock_fi = server.mock(|when, then| {
             when.method(GET)
-                .path(format!("/reconstruction/{}", MerkleHash::default()))
+                .path(format!("/{API_VERSION}/reconstruction/{}", MerkleHash::default()))
                 .header(RANGE.as_str(), HttpRange::from(file_range).range_header());
             let response = QueryReconstructionResponse {
                 offset_into_first_range: 0,

--- a/cas_client/src/interface.rs
+++ b/cas_client/src/interface.rs
@@ -57,14 +57,7 @@ pub trait Client {
     ) -> Result<Option<Bytes>>;
 
     /// Upload a new shard.
-    async fn upload_shard(
-        &self,
-        prefix: &str,
-        hash: &MerkleHash,
-        force_sync: bool,
-        shard_data: bytes::Bytes,
-        salt: &[u8; 32],
-    ) -> Result<bool>;
+    async fn upload_shard(&self, shard_data: Bytes, force_sync: bool, salt: &[u8; 32]) -> Result<bool>;
 
     /// Upload a new xorb.
     async fn upload_xorb(

--- a/data/src/shard_interface.rs
+++ b/data/src/shard_interface.rs
@@ -40,7 +40,7 @@ pub struct SessionShardInterface {
 
     // If a previous session has been resumed, then we can query against that.  However, this has to
     // be handled differently than the regular session as these xorbs have already been uploaded and are thus
-    // tracked differently by the cempletion tracking.
+    // tracked differently by the completion tracking.
     resumed_session_shard_manager: Option<Arc<ShardFileManager>>,
 
     // We can remove these shards on final upload success.
@@ -282,9 +282,7 @@ impl SessionShardInterface {
                     }
 
                     // Upload the shard.
-                    shard_client
-                        .upload_shard(&shard_prefix, &si.shard_hash, false, data, &salt)
-                        .await?;
+                    shard_client.upload_shard(data, false, &salt).await?;
 
                     // Done with the upload, drop the permit.
                     drop(upload_permit);

--- a/hf_xet_wasm/src/wasm_file_upload_session.rs
+++ b/hf_xet_wasm/src/wasm_file_upload_session.rs
@@ -166,10 +166,8 @@ impl FileUploadSession {
         let _timer = ConsoleTimer::new("upload shard");
         self.client
             .upload_shard(
-                &self.config.shard_config.prefix,
-                &shard_hash,
-                false,
                 shard_data.into(),
+                false,
                 &self.config.shard_config.repo_salt,
             )
             .await?;


### PR DESCRIPTION
Using API paths as specified in new API updates with `/v1` prefix and no shard hash.

https://docs.google.com/document/d/14CkiKiwX_y6m4oboh9rUrRCvVZtNqUTZbGzK8M5fh3o/edit?usp=sharing

