### PR TITLE
Logging improvements

### DIFF
--- a/hf_xet/Cargo.lock
+++ b/hf_xet/Cargo.lock
@@ -311,7 +311,7 @@ dependencies = [
  "mdb_shard",
  "merklehash",
  "more-asserts",
- "rand 0.9.1",
+ "rand 0.9.2",
  "serde",
  "thiserror 2.0.12",
  "tokio",
@@ -384,7 +384,7 @@ dependencies = [
  "merklehash",
  "mockall",
  "once_cell",
- "rand 0.9.1",
+ "rand 0.9.2",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -516,6 +516,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,7 +625,7 @@ dependencies = [
  "parutils",
  "progress_tracking",
  "prometheus",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "regex",
  "serde",
@@ -800,7 +809,7 @@ dependencies = [
  "colored",
  "lazy_static",
  "libc",
- "rand 0.9.1",
+ "rand 0.9.2",
  "tracing",
  "whoami",
  "winapi",
@@ -1084,10 +1093,12 @@ dependencies = [
  "pprof",
  "progress_tracking",
  "pyo3",
+ "rand 0.9.2",
  "serde",
  "serde_json",
  "signal-hook",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "utils",
  "xet_threadpool",
@@ -1571,7 +1582,7 @@ dependencies = [
  "itertools 0.14.0",
  "lazy_static",
  "merklehash",
- "rand 0.9.1",
+ "rand 0.9.2",
  "regex",
  "serde",
  "static_assertions",
@@ -1615,7 +1626,7 @@ dependencies = [
  "blake3",
  "getrandom 0.3.3",
  "heed",
- "rand 0.9.1",
+ "rand 0.9.2",
  "safe-transmute",
  "serde",
 ]
@@ -2259,7 +2270,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
- "rand 0.9.1",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2313,9 +2324,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -3229,6 +3240,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 1.0.69",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3319,7 +3342,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand 0.9.1",
+ "rand 0.9.2",
  "web-time",
 ]
 

--- a/hf_xet/Cargo.toml
+++ b/hf_xet/Cargo.toml
@@ -43,6 +43,8 @@ tracing-subscriber = { version = "0.3", features = [
     "tracing-log",
     "env-filter",
 ] }
+tracing-appender = "0.2"
+rand = "0.9.2"
 
 # Unix-specific dependencies
 [target.'cfg(unix)'.dependencies]

--- a/hf_xet/src/lib.rs
+++ b/hf_xet/src/lib.rs
@@ -292,8 +292,6 @@ pub fn hf_xet(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     // huggingface_hub.
     m.add_class::<PyPointerFile>()?;
 
-    eprintln!("Initializing hf_xet, PID = {}", std::process::id());
-
     // Init the threadpool
     runtime::init_threadpool(py)?;
 

--- a/hf_xet/src/lib.rs
+++ b/hf_xet/src/lib.rs
@@ -10,12 +10,15 @@ use std::sync::Arc;
 
 use data::errors::DataProcessingError;
 use data::{data_client, XetFileInfo};
+use itertools::Itertools;
 use progress_tracking::TrackingProgressUpdater;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use pyo3::pyfunction;
+use rand::Rng;
 use runtime::async_run;
 use token_refresh::WrappedTokenRefresher;
+use tracing::debug;
 
 use crate::progress_update::WrappedProgressUpdater;
 
@@ -76,7 +79,18 @@ pub fn upload_files(
     let refresher = token_refresher.map(WrappedTokenRefresher::from_func).transpose()?.map(Arc::new);
     let updater = progress_updater.map(WrappedProgressUpdater::new).transpose()?.map(Arc::new);
 
-    async_run(py, async move {
+    let x: u64 = rand::rng().random();
+
+    let file_names = file_paths.iter().take(3).join(", ");
+
+    debug!(
+        "Upload call {x:x}: (PID = {}) Uploading {} files {file_names}{}",
+        std::process::id(),
+        file_paths.len(),
+        if file_paths.len() > 3 { "..." } else { "." }
+    );
+
+    let ret = async_run(py, async move {
         let out: Vec<PyXetUploadInfo> = data_client::upload_async(
             file_paths,
             endpoint,
@@ -90,7 +104,11 @@ pub fn upload_files(
         .map(PyXetUploadInfo::from)
         .collect();
         PyResult::Ok(out)
-    })
+    });
+
+    debug!("Upload call {x:x} finished.");
+
+    ret
 }
 
 #[pyfunction]
@@ -103,18 +121,33 @@ pub fn download_files(
     token_refresher: Option<Py<PyAny>>,
     progress_updater: Option<Vec<Py<PyAny>>>,
 ) -> PyResult<Vec<String>> {
-    let file_infos = files.into_iter().map(<(XetFileInfo, DestinationPath)>::from).collect();
+    let file_infos: Vec<_> = files.into_iter().map(<(XetFileInfo, DestinationPath)>::from).collect();
     let refresher = token_refresher.map(WrappedTokenRefresher::from_func).transpose()?.map(Arc::new);
     let updaters = progress_updater.map(try_parse_progress_updaters).transpose()?;
 
-    async_run(py, async move {
+    let x: u64 = rand::rng().random();
+
+    let file_names = file_infos.iter().take(3).map(|(_, p)| p).join(", ");
+
+    debug!(
+        "Download call {x:x}: (PID = {}) Downloading {} files {file_names}{}",
+        std::process::id(),
+        file_infos.len(),
+        if file_infos.len() > 3 { "..." } else { "." }
+    );
+
+    let res = async_run(py, async move {
         let out: Vec<String> =
             data_client::download_async(file_infos, endpoint, token_info, refresher.map(|v| v as Arc<_>), updaters)
                 .await
                 .map_err(convert_data_processing_error)?;
 
         PyResult::Ok(out)
-    })
+    });
+
+    debug!("Download call {x:x}: Completed.");
+
+    res
 }
 
 fn try_parse_progress_updaters(funcs: Vec<Py<PyAny>>) -> PyResult<Vec<Arc<dyn TrackingProgressUpdater>>> {
@@ -258,6 +291,8 @@ pub fn hf_xet(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     // This supports backward compatibility for PyPointerFile with old versions
     // huggingface_hub.
     m.add_class::<PyPointerFile>()?;
+
+    eprintln!("Initializing hf_xet, PID = {}", std::process::id());
 
     // Init the threadpool
     runtime::init_threadpool(py)?;

--- a/hf_xet/src/log.rs
+++ b/hf_xet/src/log.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::path::Path;
 use std::sync::{Arc, OnceLock};
 
 use pyo3::Python;
@@ -17,12 +18,75 @@ const DEFAULT_LOG_LEVEL: &str = "warn";
 #[cfg(debug_assertions)]
 const DEFAULT_LOG_LEVEL: &str = "warn";
 
-fn init_global_logging(py: Python) -> Option<TelemetryTaskInfo> {
-    let fmt_layer = tracing_subscriber::fmt::layer()
+fn use_json() -> bool {
+    env::var("HF_XET_LOG_FORMAT")
+        .unwrap_or_else(|_| "json".to_string())
+        .to_ascii_lowercase()
+        == "json"
+}
+
+fn init_logging_to_file(path: impl AsRef<Path>) {
+    // Set up logging to a file.
+    use std::ffi::OsStr;
+
+    use tracing_appender::{non_blocking, rolling};
+
+    // Make sure the directory for the log exists.
+    let path = path.as_ref();
+    if let Some(parent) = path.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            eprintln!("failed to create log directory {parent:?}: {e}");
+        }
+    }
+
+    // Build a non‑blocking file appender. • `rolling::never` = one static file, no rotation. • Keep the
+    // `WorkerGuard` alive so the background thread doesn’t shut down and drop messages.
+    let file_appender = rolling::never(
+        path.parent().unwrap_or_else(|| Path::new(".")),
+        path.file_name().unwrap_or_else(|| OsStr::new("xet.log")),
+    );
+    let (writer, guard) = non_blocking(file_appender);
+
+    // Store the guard globally so it isn’t dropped.
+    static FILE_GUARD: OnceLock<tracing_appender::non_blocking::WorkerGuard> = OnceLock::new();
+    let _ = FILE_GUARD.set(guard); // ignore error if already initialised
+
+    // Build the fmt layer.
+    let fmt_layer_base = tracing_subscriber::fmt::layer()
         .with_line_number(true)
         .with_file(true)
         .with_target(false)
-        .json();
+        .with_writer(writer);
+
+    // Standard filter layer: RUST_LOG env var or DEFAULT_LOG_LEVEL fallback.
+    let filter_layer = EnvFilter::try_from_default_env()
+        .or_else(|_| EnvFilter::try_new(DEFAULT_LOG_LEVEL))
+        .unwrap_or_default();
+
+    // Initialise the subscriber.
+    if use_json() {
+        tracing_subscriber::registry()
+            .with(fmt_layer_base.json())
+            .with(filter_layer)
+            .init();
+    } else {
+        tracing_subscriber::registry()
+            .with(fmt_layer_base.pretty())
+            .with(filter_layer)
+            .init();
+    }
+}
+
+fn init_global_logging(py: Python) -> Option<TelemetryTaskInfo> {
+    if let Ok(path) = env::var("HF_XET_LOG_FILE") {
+        init_logging_to_file(path);
+        return None;
+    }
+
+    let fmt_layer_base = tracing_subscriber::fmt::layer()
+        .with_line_number(true)
+        .with_file(true)
+        .with_target(false);
 
     let filter_layer = EnvFilter::try_from_default_env()
         .or_else(|_| EnvFilter::try_new(DEFAULT_LOG_LEVEL))
@@ -31,7 +95,14 @@ fn init_global_logging(py: Python) -> Option<TelemetryTaskInfo> {
     // Client-side telemetry, default is OFF
     // To enable telemetry set env var HF_HUB_ENABLE_TELEMETRY
     if env::var("HF_HUB_ENABLE_TELEMETRY").is_err_and(|e| e == env::VarError::NotPresent) {
-        tracing_subscriber::registry().with(fmt_layer).with(filter_layer).init();
+        let tr_sub = tracing_subscriber::registry().with(filter_layer);
+
+        if use_json() {
+            tr_sub.with(fmt_layer_base.json()).init();
+        } else {
+            tr_sub.with(fmt_layer_base.pretty()).init();
+        }
+
         None
     } else {
         let telemetry_buffer_layer = LogBufferLayer::new(py, TELEMETRY_PRE_ALLOC_BYTES);
@@ -42,8 +113,8 @@ fn init_global_logging(py: Python) -> Option<TelemetryTaskInfo> {
             telemetry_buffer_layer.with_filter(FilterFn::new(|meta| meta.target() == "client_telemetry"));
 
         tracing_subscriber::registry()
-            .with(fmt_layer)
             .with(filter_layer)
+            .with(fmt_layer_base.json())
             .with(telemetry_filter_layer)
             .init();
 


### PR DESCRIPTION
Added logging improvements to hf_xet: 
- When HF_XET_LOG_FILE is set to a valid file path, then events are logged to that file in a non-blocking manner.  
- When HF_XET_LOG_FORMAT is set to either "json" or "text", it overrides the log format default.  By default, when done to a file, logging is done in json, and to console it is done using pretty printing.  
- Added in debug log statements in the upload and download paths to help trace activity.