### PR TITLE
Make hf_xet fork-exec safe

### DIFF
--- a/hf_xet/src/lib.rs
+++ b/hf_xet/src/lib.rs
@@ -12,7 +12,7 @@ use data::errors::DataProcessingError;
 use data::{data_client, XetFileInfo};
 use itertools::Itertools;
 use progress_tracking::TrackingProgressUpdater;
-use pyo3::exceptions::PyRuntimeError;
+use pyo3::exceptions::{PyKeyboardInterrupt, PyRuntimeError};
 use pyo3::prelude::*;
 use pyo3::pyfunction;
 use rand::Rng;
@@ -47,8 +47,15 @@ pub fn upload_bytes(
 ) -> PyResult<Vec<PyXetUploadInfo>> {
     let refresher = token_refresher.map(WrappedTokenRefresher::from_func).transpose()?.map(Arc::new);
     let updater = progress_updater.map(WrappedProgressUpdater::new).transpose()?.map(Arc::new);
+    let x: u64 = rand::rng().random();
 
     async_run(py, async move {
+        debug!(
+            "Upload bytes call {x:x}: (PID = {}) Uploading {} files as bytes.",
+            std::process::id(),
+            file_contents.len(),
+        );
+
         let out: Vec<PyXetUploadInfo> = data_client::upload_bytes_async(
             file_contents,
             endpoint,
@@ -61,6 +68,9 @@ pub fn upload_bytes(
         .into_iter()
         .map(PyXetUploadInfo::from)
         .collect();
+
+        debug!("Upload bytes call {x:x} finished.");
+
         PyResult::Ok(out)
     })
 }
@@ -79,18 +89,18 @@ pub fn upload_files(
     let refresher = token_refresher.map(WrappedTokenRefresher::from_func).transpose()?.map(Arc::new);
     let updater = progress_updater.map(WrappedProgressUpdater::new).transpose()?.map(Arc::new);
 
-    let x: u64 = rand::rng().random();
-
     let file_names = file_paths.iter().take(3).join(", ");
 
-    debug!(
-        "Upload call {x:x}: (PID = {}) Uploading {} files {file_names}{}",
-        std::process::id(),
-        file_paths.len(),
-        if file_paths.len() > 3 { "..." } else { "." }
-    );
+    let x: u64 = rand::rng().random();
 
     let ret = async_run(py, async move {
+        debug!(
+            "Upload call {x:x}: (PID = {}) Uploading {} files {file_names}{}",
+            std::process::id(),
+            file_paths.len(),
+            if file_paths.len() > 3 { "..." } else { "." }
+        );
+
         let out: Vec<PyXetUploadInfo> = data_client::upload_async(
             file_paths,
             endpoint,
@@ -103,10 +113,9 @@ pub fn upload_files(
         .into_iter()
         .map(PyXetUploadInfo::from)
         .collect();
+        debug!("Upload call {x:x} finished.");
         PyResult::Ok(out)
     });
-
-    debug!("Upload call {x:x} finished.");
 
     ret
 }
@@ -129,25 +138,32 @@ pub fn download_files(
 
     let file_names = file_infos.iter().take(3).map(|(_, p)| p).join(", ");
 
-    debug!(
-        "Download call {x:x}: (PID = {}) Downloading {} files {file_names}{}",
-        std::process::id(),
-        file_infos.len(),
-        if file_infos.len() > 3 { "..." } else { "." }
-    );
-
     let res = async_run(py, async move {
+        debug!(
+            "Download call {x:x}: (PID = {}) Downloading {} files {file_names}{}",
+            std::process::id(),
+            file_infos.len(),
+            if file_infos.len() > 3 { "..." } else { "." }
+        );
+
         let out: Vec<String> =
             data_client::download_async(file_infos, endpoint, token_info, refresher.map(|v| v as Arc<_>), updaters)
                 .await
                 .map_err(convert_data_processing_error)?;
 
+        debug!("Download call {x:x}: Completed.");
+
         PyResult::Ok(out)
     });
 
-    debug!("Download call {x:x}: Completed.");
-
     res
+}
+
+#[pyfunction]
+pub fn force_sigint_shutdown() -> PyResult<()> {
+    // Force a signint shutdown in the case where it gets intercepted by another process.
+    crate::runtime::perferm_sigint_shutdown();
+    Err(PyKeyboardInterrupt::new_err(()))
 }
 
 fn try_parse_progress_updaters(funcs: Vec<Py<PyAny>>) -> PyResult<Vec<Arc<dyn TrackingProgressUpdater>>> {
@@ -282,6 +298,7 @@ pub fn hf_xet(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(upload_files, m)?)?;
     m.add_function(wrap_pyfunction!(upload_bytes, m)?)?;
     m.add_function(wrap_pyfunction!(download_files, m)?)?;
+    m.add_function(wrap_pyfunction!(perform_sigint_shutdown, m)?)?;
     m.add_class::<PyXetUploadInfo>()?;
     m.add_class::<PyXetDownloadInfo>()?;
     m.add_class::<PyXetUploadInfo>()?;

--- a/hf_xet/src/lib.rs
+++ b/hf_xet/src/lib.rs
@@ -162,7 +162,7 @@ pub fn download_files(
 #[pyfunction]
 pub fn force_sigint_shutdown() -> PyResult<()> {
     // Force a signint shutdown in the case where it gets intercepted by another process.
-    crate::runtime::perferm_sigint_shutdown();
+    crate::runtime::perform_sigint_shutdown();
     Err(PyKeyboardInterrupt::new_err(()))
 }
 
@@ -298,7 +298,7 @@ pub fn hf_xet(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(upload_files, m)?)?;
     m.add_function(wrap_pyfunction!(upload_bytes, m)?)?;
     m.add_function(wrap_pyfunction!(download_files, m)?)?;
-    m.add_function(wrap_pyfunction!(perform_sigint_shutdown, m)?)?;
+    m.add_function(wrap_pyfunction!(force_sigint_shutdown, m)?)?;
     m.add_class::<PyXetUploadInfo>()?;
     m.add_class::<PyXetDownloadInfo>()?;
     m.add_class::<PyXetUploadInfo>()?;

--- a/hf_xet/src/log.rs
+++ b/hf_xet/src/log.rs
@@ -19,7 +19,7 @@ const DEFAULT_LOG_LEVEL: &str = "warn";
 const DEFAULT_LOG_LEVEL: &str = "warn";
 
 fn use_json() -> Option<bool> {
-    env::var("HF_XET_LOG_FORMAT").ok().map(|s| s.to_ascii_lowercase() == "json")
+    env::var("HF_XET_LOG_FORMAT").ok().map(|s| s.eq_ignore_ascii_case("json"))
 }
 
 fn init_logging_to_file(path: impl AsRef<Path>) -> Result<(), std::io::Error> {

--- a/xet_threadpool/src/threadpool.rs
+++ b/xet_threadpool/src/threadpool.rs
@@ -210,13 +210,14 @@ impl ThreadPool {
 
         // When a task is shut down, it will stop running at whichever .await it has yielded at.  All local
         // variables are destroyed by running their destructor.
+        //
+        // If this call fails, then it means that there is a recursive call to this runtime, or that
+        // this process is in the middle of a shutdown, so we can ignore it silently.
         let Ok(mut rt_lock) = self.runtime.write() else {
             return;
         };
-
-        let maybe_runtime = rt_lock.take();
-
-        let Some(runtime) = maybe_runtime else {
+        
+        let Some(runtime) = rt_lock.take() else {
             return;
         };
 

--- a/xet_threadpool/src/threadpool.rs
+++ b/xet_threadpool/src/threadpool.rs
@@ -204,6 +204,28 @@ impl ThreadPool {
         drop(runtime);
     }
 
+    /// Discards the runtime without shutdown; to be used after fork-exec or spawn.
+    pub fn discard_runtime(&self) {
+        // This function makes a best effort attempt to clean everything up.
+
+        // When a task is shut down, it will stop running at whichever .await it has yielded at.  All local
+        // variables are destroyed by running their destructor.
+        let Ok(mut rt_lock) = self.runtime.write() else {
+            return;
+        };
+
+        let maybe_runtime = rt_lock.take();
+
+        let Some(runtime) = maybe_runtime else {
+            return;
+        };
+
+        // In this context, we actually want to simply leak the runtime, as doing anything with it will
+        // likely cause a deadlock.  The memory will be reaped when the child process returns, and it's
+        // likely in the copy-on-write state anyway.
+        std::mem::forget(runtime);
+    }
+
     /// Returns true if we're in the middle of a sigint shutdown,
     /// and false otherwise.
     pub fn in_sigint_shutdown(&self) -> bool {

--- a/xet_threadpool/src/threadpool.rs
+++ b/xet_threadpool/src/threadpool.rs
@@ -216,7 +216,7 @@ impl ThreadPool {
         let Ok(mut rt_lock) = self.runtime.write() else {
             return;
         };
-        
+
         let Some(runtime) = rt_lock.take() else {
             return;
         };


### PR DESCRIPTION
Currently, some environments (e.g. vllm) use spawn or fork-exec to create a child process.  However, this is known to cause issues within the tokio runtime and lead to hangs, as only the calling thread survives across spawns but the runtime assumes these threads exist and are accessible.  This PR detects when a fork-exec has occurred and silently discards the old runtime, creating a new one and reinstalling the signal handlers and restarting the background threads. 

Possible fix for https://github.com/huggingface/xet-core/issues/415; also issue in https://github.com/vllm-project/vllm/pull/21539. 