### PR TITLE
revert use of v1 api paths

### DIFF
--- a/cas_client/src/download_utils.rs
+++ b/cas_client/src/download_utils.rs
@@ -571,7 +571,6 @@ mod tests {
     use tokio::time::sleep;
 
     use super::*;
-    use crate::remote_client::API_VERSION;
     use crate::{build_http_client, RetryConfig};
 
     #[tokio::test]
@@ -613,7 +612,7 @@ mod tests {
         let server = MockServer::start();
         server.mock(|when, then| {
             when.method(GET)
-                .path(format!("/{API_VERSION}/reconstruction/{}", MerkleHash::default()))
+                .path(format!("/reconstruction/{}", MerkleHash::default()))
                 .header(RANGE.as_str(), HttpRange::from(file_range).range_header());
             let response = QueryReconstructionResponse {
                 offset_into_first_range: 0,
@@ -660,7 +659,7 @@ mod tests {
         let server = MockServer::start();
         let mock = server.mock(|when, then| {
             when.method(GET)
-                .path(format!("/{API_VERSION}/reconstruction/{}", MerkleHash::default()))
+                .path(format!("/reconstruction/{}", MerkleHash::default()))
                 .header(RANGE.as_str(), HttpRange::from(file_range_to_refresh).range_header());
             let response = QueryReconstructionResponse {
                 offset_into_first_range: 0,
@@ -717,7 +716,7 @@ mod tests {
         // Arrange server
         let mock_fi = server.mock(|when, then| {
             when.method(GET)
-                .path(format!("/{API_VERSION}/reconstruction/{}", MerkleHash::default()))
+                .path(format!("/reconstruction/{}", MerkleHash::default()))
                 .header(RANGE.as_str(), HttpRange::from(file_range).range_header());
             let response = QueryReconstructionResponse {
                 offset_into_first_range: 0,

--- a/cas_client/src/interface.rs
+++ b/cas_client/src/interface.rs
@@ -52,7 +52,7 @@ pub trait Client {
     async fn query_for_global_dedup_shard(&self, prefix: &str, chunk_hash: &MerkleHash) -> Result<Option<Bytes>>;
 
     /// Upload a new shard.
-    async fn upload_shard(&self, shard_data: Bytes) -> Result<bool>;
+    async fn upload_shard(&self, prefix: &str, hash: &MerkleHash, shard_data: Bytes) -> Result<bool>;
 
     /// Upload a new xorb.
     async fn upload_xorb(

--- a/cas_client/src/local_client.rs
+++ b/cas_client/src/local_client.rs
@@ -272,7 +272,7 @@ impl Client for LocalClient {
         Ok(None)
     }
 
-    async fn upload_shard(&self, shard_data: Bytes) -> Result<bool> {
+    async fn upload_shard(&self, _prefix: &str, _hash: &MerkleHash, shard_data: Bytes) -> Result<bool> {
         // Write out the shard to the shard directory.
         let shard = MDBShardFile::write_out_from_reader(&self.shard_dir, &mut Cursor::new(&shard_data))?;
         let shard_hash = shard.shard_hash;
@@ -603,7 +603,7 @@ mod tests {
         let client = LocalClient::temporary().unwrap();
 
         client
-            .upload_shard(std::fs::read(&new_shard_path).unwrap().into())
+            .upload_shard("default-merkledb", &shard_hash, std::fs::read(&new_shard_path).unwrap().into())
             .await
             .unwrap();
 

--- a/data/src/shard_interface.rs
+++ b/data/src/shard_interface.rs
@@ -294,7 +294,7 @@ impl SessionShardInterface {
                     }
 
                     // Upload the shard.
-                    shard_client.upload_shard(data).await?;
+                    shard_client.upload_shard(&shard_prefix, &si.shard_hash, data).await?;
 
                     // Done with the upload, drop the permit.
                     drop(upload_permit);

--- a/hf_xet_wasm/src/wasm_file_upload_session.rs
+++ b/hf_xet_wasm/src/wasm_file_upload_session.rs
@@ -165,9 +165,7 @@ impl FileUploadSession {
 
         let _timer = ConsoleTimer::new("upload shard");
         self.client
-            .upload_shard(
-                shard_data.into(),
-            )
+            .upload_shard(&self.config.shard_config.prefix, &shard_hash, shard_data.into())
             .await?;
 
         Ok(())


### PR DESCRIPTION
Avoiding using the v1 api paths in the next release until the spec is fixed.

reverting to the old API paths. 