### PR TITLE
Changed default number of parallel downloads from 64 to 48.

### DIFF
--- a/cas_client/src/remote_client.rs
+++ b/cas_client/src/remote_client.rs
@@ -45,7 +45,7 @@ utils::configurable_constants! {
 // Env (HF_XET_NUM_CONCURRENT_RANGE_GETS) to set the number of concurrent range gets.
 // setting this value to 0 disables the limit, sets it to the max, this is not recommended as it may lead to errors
     ref NUM_CONCURRENT_RANGE_GETS: usize = GlobalConfigMode::HighPerformanceOption {
-        standard: 64,
+        standard: 48,
         high_performance: 256,
     };
 


### PR DESCRIPTION
Some more testing found that 64 parallel range gets can still possibly exhaust the existing file handles on OSX; this addressed this issue without (hopefully) impacting the download performance. 