### PR TITLE
fix: singleflight owner task not removing Call from Group if dropped

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3788,6 +3788,7 @@ dependencies = [
  "bytes",
  "ctor",
  "futures",
+ "futures-util",
  "lazy_static",
  "merklehash",
  "pin-project",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3787,6 +3787,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "ctor",
+ "error_printer",
  "futures",
  "futures-util",
  "lazy_static",

--- a/hf_xet/Cargo.lock
+++ b/hf_xet/Cargo.lock
@@ -3430,6 +3430,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "ctor",
+ "error_printer",
  "futures",
  "lazy_static",
  "merklehash",

--- a/hf_xet_thin_wasm/Cargo.lock
+++ b/hf_xet_thin_wasm/Cargo.lock
@@ -680,6 +680,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "libc",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,16 +768,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lock_api"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -828,6 +829,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+dependencies = [
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys",
+]
+
+[[package]]
 name = "more-asserts"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -868,29 +880,6 @@ checksum = "eebde548fbbf1ea81a99b128872779c437752fb99f217c45245e1a61dcd9edcd"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets",
 ]
 
 [[package]]
@@ -1106,12 +1095,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3944826ff8fa8093089aba3acb4ef44b9446a99a16f3bf4e74af3f77d340ab7d"
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1278,12 +1261,16 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.45.0"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
+ "io-uring",
+ "libc",
+ "mio",
  "pin-project-lite",
+ "slab",
  "tokio-macros",
 ]
 
@@ -1368,7 +1355,6 @@ dependencies = [
  "futures",
  "lazy_static",
  "merklehash",
- "parking_lot",
  "pin-project",
  "shellexpand",
  "thiserror",

--- a/hf_xet_thin_wasm/Cargo.lock
+++ b/hf_xet_thin_wasm/Cargo.lock
@@ -366,6 +366,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "error_printer"
+version = "0.14.5"
+dependencies = [
+ "tracing",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1352,6 +1359,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "ctor",
+ "error_printer",
  "futures",
  "lazy_static",
  "merklehash",

--- a/hf_xet_wasm/Cargo.lock
+++ b/hf_xet_wasm/Cargo.lock
@@ -1080,7 +1080,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1205,6 +1205,17 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if 1.0.1",
+ "libc",
 ]
 
 [[package]]
@@ -1485,6 +1496,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "oneshot"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce411919553d3f9fa53a0880544cda985a112117a0444d5ff1e870a893d6ea"
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1520,17 +1537,7 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
-dependencies = [
- "lock_api",
- "parking_lot_core 0.9.11",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1545,19 +1552,6 @@ dependencies = [
  "redox_syscall 0.2.16",
  "smallvec",
  "winapi",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
-dependencies = [
- "cfg-if 1.0.1",
- "libc",
- "redox_syscall 0.5.17",
- "smallvec",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1696,7 +1690,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -1733,7 +1727,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -1939,7 +1933,7 @@ dependencies = [
  "getrandom 0.2.16",
  "http",
  "hyper",
- "parking_lot 0.11.2",
+ "parking_lot",
  "reqwest",
  "reqwest-middleware",
  "retry-policies",
@@ -2234,6 +2228,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2415,18 +2419,20 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "pin-project-lite",
- "socket2",
+ "slab",
+ "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2648,7 +2654,6 @@ dependencies = [
  "futures",
  "lazy_static",
  "merklehash",
- "parking_lot 0.12.4",
  "pin-project",
  "shellexpand",
  "thiserror 2.0.12",
@@ -2830,7 +2835,7 @@ checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
 dependencies = [
  "futures",
  "js-sys",
- "parking_lot 0.11.2",
+ "parking_lot",
  "pin-utils",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -3129,9 +3134,12 @@ checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 name = "xet_threadpool"
 version = "0.1.0"
 dependencies = [
+ "error_printer",
+ "oneshot",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
+ "utils",
 ]
 
 [[package]]

--- a/hf_xet_wasm/Cargo.lock
+++ b/hf_xet_wasm/Cargo.lock
@@ -2651,6 +2651,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "ctor",
+ "error_printer",
  "futures",
  "lazy_static",
  "merklehash",

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -8,6 +8,7 @@ name = "utils"
 path = "src/lib.rs"
 
 [dependencies]
+error_printer = { path = "../error_printer" }
 merklehash = { path = "../merklehash" }
 
 async-trait = { workspace = true }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -17,7 +17,7 @@ futures = { workspace = true }
 lazy_static = { workspace = true }
 pin-project = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["time", "rt", "macros"] }
+tokio = { workspace = true, features = ["time", "rt", "macros", "sync"] }
 tracing = { workspace = true }
 shellexpand = { workspace = true }
 
@@ -30,6 +30,7 @@ web-time = { workspace = true }
 
 [dev-dependencies]
 serial_test = { workspace = true }
+futures-util = { workspace = true }
 
 [features]
 strict = []

--- a/utils/src/errors.rs
+++ b/utils/src/errors.rs
@@ -33,6 +33,9 @@ where
 
     #[error("Owner task panicked")]
     OwnerPanicked,
+
+    #[error("Poisoned Group lock")]
+    GroupLockPoisoned,
 }
 
 #[derive(Debug, Error)]
@@ -61,6 +64,7 @@ impl<E: Send + std::fmt::Debug + Sync> Clone for SingleflightError<E> {
             SingleflightError::WaiterInternalError(s) => SingleflightError::WaiterInternalError(s.clone()),
             SingleflightError::JoinError(e) => SingleflightError::JoinError(e.clone()),
             SingleflightError::OwnerPanicked => SingleflightError::OwnerPanicked,
+            SingleflightError::GroupLockPoisoned => SingleflightError::GroupLockPoisoned,
         }
     }
 }

--- a/utils/src/singleflight.rs
+++ b/utils/src/singleflight.rs
@@ -303,7 +303,7 @@ where
     Waiter,
 }
 
-impl<'a, T, E> Drop for CreateGuard<'a, T, E>
+impl<T, E> Drop for CreateGuard<'_, T, E>
 where
     T: ResultType + 'static,
     E: ResultError + 'static,

--- a/utils/src/singleflight.rs
+++ b/utils/src/singleflight.rs
@@ -45,6 +45,7 @@ use std::sync::atomic::{AtomicBool, AtomicU16, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use std::task::{ready, Context, Poll};
 
+use error_printer::ErrorPrinter;
 use futures::future::Either;
 use pin_project::{pin_project, pinned_drop};
 use tokio::runtime::Handle;
@@ -263,7 +264,7 @@ where
         let mut m = self
             .call_map
             .lock()
-            .inspect_err(|err| error!(?err, "Failed to lock call map"))
+            .log_error("Failed to lock call map")
             .map_err(|_| SingleflightError::GroupLockPoisoned)?;
         if let Some(c) = m.get(key).cloned() {
             Ok((c, CreateGuard::Waiter))
@@ -281,7 +282,7 @@ where
         let mut m = self
             .call_map
             .lock()
-            .inspect_err(|err| error!(?err, "Failed to lock call map"))
+            .log_error("Failed to lock call map")
             .map_err(|_| SingleflightError::GroupLockPoisoned)?;
         m.remove(key).ok_or(SingleflightError::CallMissing)?;
         Ok(())


### PR DESCRIPTION
When a singleflight `Group` is called by many tasks for a particular key, one of these tasks is chosen as the `owner` to actually perform the work. The other tasks are considered `waiters` and will wait until the `owner` completes the work.

In the normal case, the `owner` runs the work, takes the result and provides it to any `waiter` tasks. It is also the responsibility of the `owner` to clean up the state it added to the singleflight `Group`, namely, the `Call` record in the `Group`'s `CallMap`. 

However, if the `owner` is `drop`'ed  while waiting for the work to complete (e.g. by its task being canceled), then the work will still finish and any waiter tasks will be notified (as those actions are part of a separately spawned task), but the state the owner added to the `Group` is not cleaned up (i.e. there is still a lingering mapping of key -> `Call`).

What this means is that if the `owner` is dropped before it can remove the mapping, then the results of the work are permanently "cached" in the singleflight `Group` and any subsequent tasks looking for the key will always get back those results until the `Group` is dropped (usually on process restart).

Since much of the work we use singleflight for is downloading immutable blobs of data, "caching" the `Call` results doesn't sound that terrible (we already cache some stuff outside of singleflight). However, this is caching the `Result`, not just the `Ok(…)` variant, so if the work returned an `Error`, then that becomes what is permanently cached, which, for intermittent networking issues can cause problems. 

This PR fixes the issue by adding a RAII guard struct when the `Call` is added to the `CallMap` so that the `work()` function will remove the `Call` when the owner exits the function (either successfully, due to error/panic, or if it is dropped).

See the `test_dropped_owner` test for an example of how this situation can occur.