### PR TITLE
Cache clients with threadpool for recycling between calls to download_files

### DIFF
--- a/cas_client/src/download_utils.rs
+++ b/cas_client/src/download_utils.rs
@@ -626,7 +626,7 @@ mod tests {
             MerkleHash::default(),
             file_range,
             server.base_url(),
-            Arc::new(build_http_client(RetryConfig::default(), "")?),
+            Arc::new(build_http_client(RetryConfig::default(), "").await?),
         );
 
         fetch_info.query().await?;
@@ -673,7 +673,7 @@ mod tests {
             MerkleHash::default(),
             file_range_to_refresh,
             server.base_url(),
-            Arc::new(build_http_client(RetryConfig::default(), "")?),
+            Arc::new(build_http_client(RetryConfig::default(), "").await?),
         ));
 
         // Spawn multiple tasks each calling into refresh with a different delay in
@@ -742,7 +742,7 @@ mod tests {
             MerkleHash::default(),
             file_range,
             server.base_url(),
-            Arc::new(build_http_client(RetryConfig::default(), "")?),
+            Arc::new(build_http_client(RetryConfig::default(), "").await?),
         );
 
         let (offset_info_first_range, terms) = fetch_info.query().await?.unwrap();
@@ -753,7 +753,7 @@ mod tests {
                 range: x1range[0].range,
                 fetch_info: Arc::new(fetch_info),
                 chunk_cache: None,
-                client: Arc::new(build_http_client(RetryConfig::default(), "")?),
+                client: Arc::new(build_http_client(RetryConfig::default(), "").await?),
                 range_download_single_flight: Arc::new(Group::new()),
             },
             term: terms[0].clone(),

--- a/data/src/bin/xtool.rs
+++ b/data/src/bin/xtool.rs
@@ -53,7 +53,7 @@ impl XCommand {
             .overrides
             .token
             .unwrap_or_else(|| std::env::var("HF_TOKEN").unwrap_or_default());
-        let hub_client = HubClient::new(&endpoint, &token, &self.overrides.repo_type, &self.overrides.repo_id)?;
+        let hub_client = HubClient::new(&endpoint, &token, &self.overrides.repo_type, &self.overrides.repo_id).await?;
 
         self.command.run(hub_client).await
     }
@@ -205,7 +205,8 @@ async fn query_reconstruction(
         Some(config.shard_config.cache_directory.clone()),
         "",
         true,
-    );
+    )
+    .await;
 
     remote_client
         .get_reconstruction(&file_hash, bytes_range)

--- a/data/src/file_downloader.rs
+++ b/data/src/file_downloader.rs
@@ -32,7 +32,7 @@ impl FileDownloader {
             .as_ref()
             .map(Cow::Borrowed)
             .unwrap_or_else(|| Cow::Owned(Ulid::new().to_string()));
-        let client = create_remote_client(&config, &session_id, false)?;
+        let client = create_remote_client(&config, &session_id, false).await?;
 
         Ok(Self { config, client })
     }

--- a/data/src/file_upload_session.rs
+++ b/data/src/file_upload_session.rs
@@ -150,7 +150,7 @@ impl FileUploadSession {
 
         let completion_tracker = Arc::new(CompletionTracker::new(progress_updater));
 
-        let client = create_remote_client(&config, &session_id, dry_run)?;
+        let client = create_remote_client(&config, &session_id, dry_run).await?;
 
         let shard_interface = SessionShardInterface::new(config.clone(), client.clone(), dry_run).await?;
 

--- a/data/src/migration_tool/hub_client.rs
+++ b/data/src/migration_tool/hub_client.rs
@@ -16,13 +16,13 @@ pub struct HubClient {
 }
 
 impl HubClient {
-    pub fn new(endpoint: &str, token: &str, repo_type: &str, repo_id: &str) -> Result<Self> {
+    pub async fn new(endpoint: &str, token: &str, repo_type: &str, repo_id: &str) -> Result<Self> {
         Ok(HubClient {
             endpoint: endpoint.to_owned(),
             token: token.to_owned(),
             repo_type: repo_type.to_owned(),
             repo_id: repo_id.to_owned(),
-            client: build_http_client(RetryConfig::default(), "")?,
+            client: build_http_client(RetryConfig::default(), "").await?,
         })
     }
 
@@ -104,7 +104,7 @@ mod tests {
             token: "[MASKED]".to_owned(),
             repo_type: "dataset".to_owned(),
             repo_id: "test/t2".to_owned(),
-            client: build_http_client(RetryConfig::default(), "")?,
+            client: build_http_client(RetryConfig::default(), "").await?,
         };
 
         let (cas_endpoint, jwt_token, jwt_token_expiry) = hub_client.get_jwt_token("read").await?;

--- a/data/src/migration_tool/migrate.rs
+++ b/data/src/migration_tool/migrate.rs
@@ -31,7 +31,7 @@ pub async fn migrate_with_external_runtime(
     repo_type: &str,
     repo_id: &str,
 ) -> Result<()> {
-    let hub_client = HubClient::new(hub_endpoint, hub_token, repo_type, repo_id)?;
+    let hub_client = HubClient::new(hub_endpoint, hub_token, repo_type, repo_id).await?;
 
     migrate_files_impl(file_paths, false, hub_client, cas_endpoint, None, false).await?;
 

--- a/data/src/remote_client_interface.rs
+++ b/data/src/remote_client_interface.rs
@@ -6,7 +6,7 @@ use cas_client::RemoteClient;
 use crate::configurations::*;
 use crate::errors::Result;
 
-pub(crate) fn create_remote_client(
+pub(crate) async fn create_remote_client(
     config: &TranslatorConfig,
     session_id: &str,
     dry_run: bool,
@@ -14,14 +14,17 @@ pub(crate) fn create_remote_client(
     let cas_storage_config = &config.data_config;
 
     match cas_storage_config.endpoint {
-        Endpoint::Server(ref endpoint) => Ok(Arc::new(RemoteClient::new(
-            endpoint,
-            &cas_storage_config.auth,
-            &Some(cas_storage_config.cache_config.clone()),
-            Some(config.shard_config.cache_directory.clone()),
-            session_id,
-            dry_run,
-        ))),
+        Endpoint::Server(ref endpoint) => Ok(Arc::new(
+            RemoteClient::new(
+                endpoint,
+                &cas_storage_config.auth,
+                &Some(cas_storage_config.cache_config.clone()),
+                Some(config.shard_config.cache_directory.clone()),
+                session_id,
+                dry_run,
+            )
+            .await,
+        )),
         Endpoint::FileSystem(ref path) => {
             #[cfg(not(target_family = "wasm"))]
             {

--- a/xet_threadpool/src/anycache.rs
+++ b/xet_threadpool/src/anycache.rs
@@ -59,3 +59,136 @@ impl AnyCache {
         Ok(built)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use tokio::task::JoinSet;
+    use tokio::time::{sleep, Duration, Instant};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn returns_same_value_without_recreating() {
+        let cache = AnyCache::new();
+        static CREATED: AtomicUsize = AtomicUsize::new(0);
+
+        let v1: String = cache
+            .get_cached_value("k", || async {
+                CREATED.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, ()>("hello".to_owned())
+            })
+            .await
+            .unwrap();
+
+        let v2: String = cache
+            .get_cached_value("k", || async {
+                // would fail if called again
+                Err::<String, _>(())
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(v1, "hello");
+        assert_eq!(v1, v2);
+        assert_eq!(CREATED.load(Ordering::SeqCst), 1, "creator should run only once");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn single_flight_serializes_concurrent_creators_for_same_key_and_type() {
+        let cache = Arc::new(AnyCache::new());
+        let creation_count = Arc::new(AtomicUsize::new(0));
+
+        // Fire a bunch of concurrent lookups for the *same* (key, type).
+        let mut joinset = JoinSet::new();
+
+        for _ in 0..32 {
+            let creation_count_ = creation_count.clone();
+
+            let slow_create = || async move {
+                creation_count_.fetch_add(1, Ordering::SeqCst);
+                sleep(Duration::from_millis(100)).await;
+                Ok::<_, ()>(42usize)
+            };
+
+            let c = cache.clone();
+            joinset.spawn(async move { c.get_cached_value("answer", slow_create).await.unwrap() });
+        }
+
+        for r in joinset.join_all().await {
+            assert_eq!(r, 42usize);
+        }
+        assert_eq!(creation_count.load(Ordering::SeqCst), 1, "only one creator should have run");
+    }
+
+    #[tokio::test]
+    async fn different_types_same_key_do_not_collide_or_block() {
+        let cache = AnyCache::new();
+
+        // Make creators that take noticeable time so we can measure overlap.
+        let t0 = Instant::now();
+        let f1 = cache.get_cached_value("shared-key", || async {
+            sleep(Duration::from_millis(120)).await;
+            Ok::<_, ()>("stringy".to_string())
+        });
+
+        let f2 = cache.get_cached_value("shared-key", || async {
+            sleep(Duration::from_millis(120)).await;
+            Ok::<_, ()>(999u32)
+        });
+
+        let (s, n) = tokio::join!(f1, f2);
+        let elapsed = t0.elapsed();
+
+        assert_eq!(s.unwrap(), "stringy");
+        assert_eq!(n.unwrap(), 999u32);
+
+        // If they were serialized by the same per-key mutex, we'd expect ~240ms.
+        // Parallel (separate (key,T) locks) should be close to ~120ms.
+        assert!(
+            elapsed < Duration::from_millis(200),
+            "operations should run in parallel for different types; elapsed={:?}",
+            elapsed
+        );
+    }
+
+    #[tokio::test]
+    async fn errors_are_propagated_and_not_cached() {
+        let cache = AnyCache::new();
+        let tries: AtomicUsize = AtomicUsize::new(0);
+
+        // First attempt errors
+        let err = cache
+            .get_cached_value::<u64, &'static str, _, _>("err-key", || async {
+                tries.fetch_add(1, Ordering::SeqCst);
+                Err("boom")
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(err, "boom");
+        assert_eq!(tries.load(Ordering::SeqCst), 1);
+
+        // Second attempt succeeds and should run creator again (not cached error)
+        let v = cache
+            .get_cached_value("err-key", || async {
+                tries.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, &'static str>(7u64)
+            })
+            .await
+            .unwrap();
+        assert_eq!(v, 7);
+        assert_eq!(tries.load(Ordering::SeqCst), 2);
+
+        // Third attempt should read from cache without calling creator
+        let v2 = cache
+            .get_cached_value("err-key", || async {
+                tries.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, &'static str>(999u64)
+            })
+            .await
+            .unwrap();
+        assert_eq!(v2, 7);
+        assert_eq!(tries.load(Ordering::SeqCst), 2, "no additional creator run after caching");
+    }
+}

--- a/xet_threadpool/src/anycache.rs
+++ b/xet_threadpool/src/anycache.rs
@@ -1,0 +1,61 @@
+use std::any::{Any, TypeId};
+use std::collections::HashMap;
+use std::future::Future;
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+
+type CachedValueContainer = Arc<Mutex<Option<Box<dyn Any + Send + Sync>>>>;
+
+/// A utility class to hold a cached value in a way that can be associated with the runtime.
+#[derive(Default, Debug)]
+pub struct AnyCache {
+    value_cache: Mutex<HashMap<String, CachedValueContainer>>,
+}
+
+impl AnyCache {
+    pub fn new() -> Self {
+        Self {
+            value_cache: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Returns a type- and key-specific string for use in the map.
+    fn make_typed_key<T: 'static>(base_key: &str) -> String {
+        format!("{}::{:?}", base_key, TypeId::of::<T>())
+    }
+
+    /// Get or create a cached value for `key` and type `T`.
+    ///
+    /// * Per-key+type single-flight: at most one `creation_function` runs concurrently for the same `(key, T)` pair.
+    /// * On type mismatch, the new value replaces the old.
+    pub async fn get_cached_value<T, E, F, Fut>(&self, key: &str, creation_function: F) -> Result<T, E>
+    where
+        T: Clone + Send + Sync + 'static,
+        F: FnOnce() -> Fut + Send,
+        Fut: Future<Output = Result<T, E>> + Send,
+    {
+        let typed_key = Self::make_typed_key::<T>(key);
+
+        // Grab or create the per-(key,type) mutex slot.
+        let cell = {
+            let mut map = self.value_cache.lock().await;
+            map.entry(typed_key).or_insert_with(|| Arc::new(Mutex::new(None))).clone()
+        };
+
+        // Lock this key+type cell; hold until value ready.
+        let mut slot = cell.lock().await;
+
+        // If we already have the right type stored, return clone.
+        if let Some(ref boxed) = *slot {
+            if let Some(v) = boxed.downcast_ref::<T>() {
+                return Ok(v.clone());
+            }
+        }
+
+        // Otherwise, create and store.
+        let built = creation_function().await?;
+        *slot = Some(Box::new(built.clone()) as Box<dyn Any + Send + Sync>);
+        Ok(built)
+    }
+}

--- a/xet_threadpool/src/lib.rs
+++ b/xet_threadpool/src/lib.rs
@@ -9,5 +9,6 @@ pub use sync_primatives::{spawn_os_thread, SyncJoinHandle};
 
 #[macro_use]
 mod global_semaphores;
+mod anycache;
 
 pub use global_semaphores::GlobalSemaphoreHandle;


### PR DESCRIPTION
This PR allows the different clients to be cached between calls to download_files, instead of each one creating a new client on the fly.  Because each client keeps connections open after use for the keep alive time, this can cause an explosion in the number of open file handles even though most of the connections aren't being used due to global constraints on the number of parallel downloads.  

To enable this, it also adds in a caching layer to the xet runtime that allows arbitrary values to be cached with the runtime; sorta a OnceLock type of mechanism but not using statics. 


