### PR TITLE
Add back retry for connection setup and sending request

### DIFF
--- a/cas_client/src/http_client.rs
+++ b/cas_client/src/http_client.rs
@@ -98,7 +98,7 @@ pub fn build_auth_http_client<R: RetryableStrategy + Send + Sync + 'static>(
     retry_config: RetryConfig<R>,
     session_id: &str,
 ) -> Result<ClientWithMiddleware, CasClientError> {
-    let auth_middleware = auth_config.as_ref().map(AuthMiddleware::from).info_none("CAS auth disabled");
+    let auth_middleware = auth_config.as_ref().map(AuthMiddleware::from);
     let logging_middleware = Some(LoggingMiddleware);
     let session_middleware = (!session_id.is_empty()).then(|| SessionMiddleware(session_id.to_owned()));
 

--- a/cas_client/src/remote_client.rs
+++ b/cas_client/src/remote_client.rs
@@ -72,7 +72,6 @@ pub struct RemoteClient {
     dry_run: bool,
     http_client_with_retry: Arc<ClientWithMiddleware>,
     authenticated_http_client_with_retry: Arc<ClientWithMiddleware>,
-    http_client: Arc<ClientWithMiddleware>,
     authenticated_http_client: Arc<ClientWithMiddleware>,
     chunk_cache: Option<Arc<dyn ChunkCache>>,
     #[cfg(not(target_family = "wasm"))]
@@ -225,7 +224,6 @@ impl RemoteClient {
             http_client_with_retry: Arc::new(
                 http_client::build_http_client(RetryConfig::default(), session_id).unwrap(),
             ),
-            http_client: Arc::new(http_client::build_http_client_no_retry(session_id).unwrap()),
             chunk_cache,
             #[cfg(not(target_family = "wasm"))]
             range_download_single_flight: Arc::new(Group::new()),
@@ -326,7 +324,7 @@ impl RemoteClient {
         // After the above, a task that defines fetching the remainder of the file reconstruction info is enqueued,
         // which will execute after the first of the above term download tasks finishes.
         let chunk_cache = self.chunk_cache.clone();
-        let term_download_client = self.http_client.clone();
+        let term_download_client = self.http_client_with_retry.clone();
         let range_download_single_flight = self.range_download_single_flight.clone();
         let download_scheduler = DownloadSegmentLengthTuner::from_configurable_constants();
         let download_scheduler_clone = download_scheduler.clone();
@@ -478,7 +476,7 @@ impl RemoteClient {
         // download tasks are enqueued and spawned with the degree of concurrency equal to `num_concurrent_range_gets`.
         // After the above, a task that defines fetching the remainder of the file reconstruction info is enqueued,
         // which will execute after the first of the above term download tasks finishes.
-        let term_download_client = self.http_client.clone();
+        let term_download_client = self.http_client_with_retry.clone();
         let download_scheduler = DownloadSegmentLengthTuner::from_configurable_constants();
 
         let download_concurrency_limiter = ThreadPool::current().global_semaphore(*DOWNLOAD_CONCURRENCY_LIMITER);


### PR DESCRIPTION
This PR fixes the regression that part of the retry logic for downloading was accidentally removed. The added back retry logic complements the retry for deserializing the data stream of responses.
Fix XET-696