### PR TITLE
Cache and reuse reqwest Client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4393,6 +4393,7 @@ version = "0.1.0"
 dependencies = [
  "error_printer",
  "oneshot",
+ "reqwest",
  "thiserror 2.0.12",
  "tokio",
  "tracing",

--- a/cas_client/src/http_client.rs
+++ b/cas_client/src/http_client.rs
@@ -91,7 +91,7 @@ fn reqwest_client() -> Result<reqwest::Client, CasClientError> {
     {
         use xet_threadpool::ThreadPool;
 
-        let client = ThreadPool::current().get_or_create_reqwest_client(|| {
+        let client = ThreadPool::get_or_create_reqwest_client(|| {
             reqwest::Client::builder()
                 .dns_resolver(Arc::from(dns_utils::GaiResolverWithAbsolute::default()))
                 .build()

--- a/cas_client/src/http_client.rs
+++ b/cas_client/src/http_client.rs
@@ -99,16 +99,6 @@ fn reqwest_client() -> Result<reqwest::Client, CasClientError> {
 
         Ok(client)
     }
-
-    // let mut reqwest_client_builder = reqwest::Client::builder();
-    // // custom dns resolver not supported in WASM. no access to getaddrinfo/any other dns interface.
-    // #[cfg(not(target_family = "wasm"))]
-    // {
-    //     reqwest_client_builder =
-    //         reqwest_client_builder.dns_resolver(Arc::from(dns_utils::GaiResolverWithAbsolute::default()));
-    // }
-    // let reqwest_client = reqwest_client_builder.build()?;
-    // Ok(reqwest_client)
 }
 
 /// Builds authenticated HTTP Client to talk to CAS.

--- a/hf_xet/Cargo.lock
+++ b/hf_xet/Cargo.lock
@@ -3920,6 +3920,7 @@ version = "0.1.0"
 dependencies = [
  "error_printer",
  "oneshot",
+ "reqwest",
  "thiserror 2.0.12",
  "tokio",
  "tracing",

--- a/hf_xet_wasm/Cargo.lock
+++ b/hf_xet_wasm/Cargo.lock
@@ -3137,6 +3137,7 @@ version = "0.1.0"
 dependencies = [
  "error_printer",
  "oneshot",
+ "reqwest",
  "thiserror 2.0.12",
  "tokio",
  "tracing",

--- a/xet_threadpool/Cargo.toml
+++ b/xet_threadpool/Cargo.toml
@@ -8,6 +8,7 @@ utils = { path = "../utils" }
 error_printer = { path = "../error_printer" }
 
 oneshot = { workspace = true }
+reqwest = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["time", "rt", "macros", "io-util"] }
 tracing = { workspace = true }


### PR DESCRIPTION
This PR caches the reqwest::Client in a runtime if it exists and re-uses it in all wrapped clients in the `RemoteClient` object. This effectively shares the connection pool and thus reduces opening sockets.

Fix XET-704