### PR TITLE
Limit number of idle connections

### DIFF
--- a/cas_client/src/constants.rs
+++ b/cas_client/src/constants.rs
@@ -11,4 +11,9 @@ utils::configurable_constants! {
     /// no more retries are attempted.
     ref CLIENT_RETRY_MAX_DURATION_MS: u64 = 6 * 60 * 1000; // 6m
 
+    /// Cleanup idle connections that are unused for this amount of time.
+    ref CLIENT_IDLE_CONNECTION_TIMEOUT_SECS: u64 = 60; // 6m
+
+    /// Only no more than this number of idle connections in the connection pool.
+    ref CLIENT_MAX_IDLE_CONNECTIONS: usize = 16;
 }

--- a/cas_client/src/http_client.rs
+++ b/cas_client/src/http_client.rs
@@ -93,6 +93,7 @@ fn reqwest_client() -> Result<reqwest::Client, CasClientError> {
 
         let client = ThreadPool::get_or_create_reqwest_client(|| {
             reqwest::Client::builder()
+                .pool_max_idle_per_host(32)
                 .dns_resolver(Arc::from(dns_utils::GaiResolverWithAbsolute::default()))
                 .build()
         })?;

--- a/cas_client/src/http_client.rs
+++ b/cas_client/src/http_client.rs
@@ -92,8 +92,11 @@ fn reqwest_client() -> Result<reqwest::Client, CasClientError> {
         use xet_threadpool::ThreadPool;
 
         let client = ThreadPool::get_or_create_reqwest_client(|| {
+            use crate::constants::{CLIENT_IDLE_CONNECTION_TIMEOUT_SECS, CLIENT_MAX_IDLE_CONNECTIONS};
+
             reqwest::Client::builder()
-                .pool_max_idle_per_host(32)
+                .pool_idle_timeout(Duration::from_secs(*CLIENT_IDLE_CONNECTION_TIMEOUT_SECS))
+                .pool_max_idle_per_host(*CLIENT_MAX_IDLE_CONNECTIONS)
                 .dns_resolver(Arc::from(dns_utils::GaiResolverWithAbsolute::default()))
                 .build()
         })?;


### PR DESCRIPTION
Limit the number of idle connections maintained in the reqwest connection pool.