### PR TITLE
enforce linting on hf_xet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Lint
         run: |
           cargo clippy -r --verbose -- -D warnings # elevates warnings to errors
+          cargo clippy -r --verbose --manifest-path hf_xet/Cargo.toml -- -D warnings # elevates warnings to errors
       - name: Build and Test
         run: |
           cargo test --verbose --no-fail-fast --features "strict"

--- a/hf_xet/src/lib.rs
+++ b/hf_xet/src/lib.rs
@@ -93,7 +93,7 @@ pub fn upload_files(
 
     let x: u64 = rand::rng().random();
 
-    let ret = async_run(py, async move {
+    async_run(py, async move {
         debug!(
             "Upload call {x:x}: (PID = {}) Uploading {} files {file_names}{}",
             std::process::id(),
@@ -115,9 +115,7 @@ pub fn upload_files(
         .collect();
         debug!("Upload call {x:x} finished.");
         PyResult::Ok(out)
-    });
-
-    ret
+    })
 }
 
 #[pyfunction]
@@ -138,7 +136,7 @@ pub fn download_files(
 
     let file_names = file_infos.iter().take(3).map(|(_, p)| p).join(", ");
 
-    let res = async_run(py, async move {
+    async_run(py, async move {
         debug!(
             "Download call {x:x}: (PID = {}) Downloading {} files {file_names}{}",
             std::process::id(),
@@ -154,9 +152,7 @@ pub fn download_files(
         debug!("Download call {x:x}: Completed.");
 
         PyResult::Ok(out)
-    });
-
-    res
+    })
 }
 
 #[pyfunction]


### PR DESCRIPTION
This PR adds an explicit lint command on the hf_xet directory. This is necessary because it is excluded from the workspace. Other excluded directories aren't touched very often and are less important for now.