### PR TITLE
Add ppc64le target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,10 @@ jobs:
             target: aarch64
             python-target: arm64
             manylinux: manylinux_2_28
+          - runner: ubuntu-22.04
+            target: ppc64le
+            python-target: ppc64le
+            manylinux: manylinux_2_28
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -78,6 +82,9 @@ jobs:
           then
             sudo apt-get install -y binutils-aarch64-linux-gnu
             alias objcopy=aarch64-linux-gnu-objcopy
+          elif [[ "${{ matrix.platform.target }}" == "ppc64le" ]]; then
+            sudo apt-get install -y binutils-powerpc64le-linux-gnu
+            alias objcopy=powerpc64le-linux-gnu-objcopy
           fi
 
           mkdir hf_xet/dbg


### PR DESCRIPTION
This PR adds `ppc64le` CI build

- Extend matrix with ppc64le (manylinux_2_28).

- Install binutils-powerpc64le-linux-gnu and alias objcopy accordingly.

- Keep existing aarch64 handling; create hf_xet/dbg across targets.

- Enables publishing manylinux wheels for ppc64le without impacting other targets.