### PR TITLE
Update PyPI package metadata for `hf-xet`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ xet-core enables huggingface_hub to utilize xet storage for uploading and downlo
 * [data](./data): main driver for client operations - FilePointerTranslator drives hydrating or shrinking files, chunking + deduplication here.
 * [error_printer](./error_printer): utility for printing errors conveniently.
 * [file_utils](./file_utils): SafeFileCreator utility, used by chunk_cache.
-* [hf_xet](./hf_xet): Python integration with Rust code, uses maturin to build hfxet Python package. Main integration with HF Hub Python package.
+* [hf_xet](./hf_xet): Python integration with Rust code, uses maturin to build `hf-xet` Python package. Main integration with HF Hub Python package.
 * [mdb_shard](./mdb_shard): Shard operations, including Shard format, dedupe probing, benchmarks, and utilities.
 * [merklehash](./merklehash): MerkleHash type, 256-bit hash, widely used across many crates.
 * [parutils](./parutils): Provides parallel execution utilities relying on Tokio (ex. parallel foreach).

--- a/README.md
+++ b/README.md
@@ -136,6 +136,18 @@ Here are the recommended steps:
 4. Copy the symbols to the site package path from step 2 above + `hf_xet`. Eg: `cp -r hf_xet-1.1.2-manylinux-x86_64.abi3.so.dbg /home/ubuntu/.venv/lib/python3.12/site-packages/hf_xet`
 5. Run your python binary with `RUST_BACKTRACE=full` and recreate your failure.
 
+### Debugging Environment Variables
+
+To enable logging and see more debugging / diagnostics information, set the following:
+
+```
+RUST_BACKTRACE=full
+RUST_LOG=info
+HF_XET_LOG_FILE=/tmp/xet.log
+```
+
+Note: HF_XET_LOG_FILE expects a full writable path. If one isn't found it will use stdout console for logging.
+
 ## References & History
 
 * [Technical Blog posts](https://xethub.com/)

--- a/hf_xet/pyproject.toml
+++ b/hf_xet/pyproject.toml
@@ -6,11 +6,32 @@ build-backend = "maturin"
 name = "hf-xet"
 requires-python = ">=3.8"
 description = "Fast transfer of large files with the Hugging Face Hub."
-license = { file = "LICENSE" }
+author = "Hugging Face, Inc."
+author_email = "julien@huggingface.co"
+maintainers = [
+    { name = "Rajat Arya", email = "rajat@rajatarya.com" },
+    { name = "Jared Sulzdorf", email = "jared@jsulz.com" },
+    { name = "Di Xiao", email = "di@hf.co" },
+    { name = "Assaf Vayner", email = "assaf@hf.co" },
+    { name = "Hoyt Koepke", email = "hoytak@gmail.com" },
+]
+license = "Apache-2.0"
+license-file = "LICENSE"
+readme = "../README.md"
 classifiers = [
+    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Fixes #465. Adapts #464.

Verified locally using `pip-licenses` and manual inspection of metadata.

Once merged will verify with PyPI through RC build.

@jsulz, @hoytak, @seanses, @assafvayner: Let me know if you want a different email address as a maintainer - these tie into your PyPI user profile.