### PR TITLE
Rename Threadpool class name to XetRuntime to reflect usage

### DIFF
--- a/cas_client/src/http_client.rs
+++ b/cas_client/src/http_client.rs
@@ -98,9 +98,9 @@ fn reqwest_client() -> Result<reqwest::Client, CasClientError> {
 
     #[cfg(not(target_family = "wasm"))]
     {
-        use xet_runtime::ThreadPool;
+        use xet_runtime::XetRuntime;
 
-        let client = ThreadPool::get_or_create_reqwest_client(|| {
+        let client = XetRuntime::get_or_create_reqwest_client(|| {
             reqwest::Client::builder()
                 .pool_idle_timeout(Duration::from_secs(*CLIENT_IDLE_CONNECTION_TIMEOUT_SECS))
                 .pool_max_idle_per_host(*CLIENT_MAX_IDLE_CONNECTIONS)

--- a/cas_client/src/remote_client.rs
+++ b/cas_client/src/remote_client.rs
@@ -27,7 +27,7 @@ use tracing::{debug, info, instrument};
 use utils::auth::AuthConfig;
 #[cfg(not(target_family = "wasm"))]
 use utils::singleflight::Group;
-use xet_runtime::{global_semaphore_handle, GlobalSemaphoreHandle, ThreadPool};
+use xet_runtime::{global_semaphore_handle, GlobalSemaphoreHandle, XetRuntime};
 
 #[cfg(not(target_family = "wasm"))]
 use crate::download_utils::*;
@@ -330,7 +330,7 @@ impl RemoteClient {
         let download_scheduler_clone = download_scheduler.clone();
 
         let download_concurrency_limiter =
-            ThreadPool::current().global_semaphore(*DOWNLOAD_CHUNK_RANGE_CONCURRENCY_LIMITER);
+            XetRuntime::current().global_semaphore(*DOWNLOAD_CHUNK_RANGE_CONCURRENCY_LIMITER);
 
         let queue_dispatcher: JoinHandle<Result<()>> = tokio::spawn(async move {
             let mut remaining_total_len = total_len;
@@ -481,7 +481,7 @@ impl RemoteClient {
         let download_scheduler = DownloadSegmentLengthTuner::from_configurable_constants();
 
         let download_concurrency_limiter =
-            ThreadPool::current().global_semaphore(*DOWNLOAD_CHUNK_RANGE_CONCURRENCY_LIMITER);
+            XetRuntime::current().global_semaphore(*DOWNLOAD_CHUNK_RANGE_CONCURRENCY_LIMITER);
 
         let process_result = move |result: TermDownloadResult<u64>,
                                    total_written: &mut u64,
@@ -826,7 +826,7 @@ mod tests {
     use httpmock::Method::GET;
     use httpmock::MockServer;
     use tracing_test::traced_test;
-    use xet_runtime::ThreadPool;
+    use xet_runtime::XetRuntime;
 
     use super::*;
     use crate::output_provider::BufferProvider;
@@ -839,7 +839,7 @@ mod tests {
         let prefix = PREFIX_DEFAULT;
         let raw_xorb = build_raw_xorb(3, ChunkSize::Random(512, 10248));
 
-        let threadpool = ThreadPool::new().unwrap();
+        let threadpool = XetRuntime::new().unwrap();
         let client = RemoteClient::new(CAS_ENDPOINT, &None, &None, None, "", false);
 
         let cas_object = build_and_verify_cas_object(raw_xorb, Some(CompressionScheme::LZ4));
@@ -1210,7 +1210,7 @@ mod tests {
     }
 
     fn test_reconstruct_file(test_case: TestCase, endpoint: &str) -> Result<()> {
-        let threadpool = ThreadPool::new()?;
+        let threadpool = XetRuntime::new()?;
 
         // test reconstruct and sequential write
         let test = test_case.clone();

--- a/data/src/bin/example.rs
+++ b/data/src/bin/example.rs
@@ -8,7 +8,7 @@ use cas_client::{FileProvider, OutputProvider};
 use clap::{Args, Parser, Subcommand};
 use data::configurations::*;
 use data::{FileDownloader, FileUploadSession, XetFileInfo};
-use xet_runtime::ThreadPool;
+use xet_runtime::XetRuntime;
 
 #[derive(Parser)]
 struct XCommand {
@@ -57,10 +57,10 @@ impl Command {
     }
 }
 
-fn get_threadpool() -> Arc<ThreadPool> {
-    static THREADPOOL: OnceLock<Arc<ThreadPool>> = OnceLock::new();
+fn get_threadpool() -> Arc<XetRuntime> {
+    static THREADPOOL: OnceLock<Arc<XetRuntime>> = OnceLock::new();
     THREADPOOL
-        .get_or_init(|| ThreadPool::new().expect("Error starting multithreaded runtime."))
+        .get_or_init(|| XetRuntime::new().expect("Error starting multithreaded runtime."))
         .clone()
 }
 

--- a/data/src/bin/xtool.rs
+++ b/data/src/bin/xtool.rs
@@ -15,7 +15,7 @@ use hub_client::{BearerCredentialHelper, HubClient, Operation};
 use merklehash::MerkleHash;
 use utils::auth::TokenRefresher;
 use walkdir::WalkDir;
-use xet_runtime::ThreadPool;
+use xet_runtime::XetRuntime;
 
 const DEFAULT_HF_ENDPOINT: &str = "https://huggingface.co";
 
@@ -224,7 +224,7 @@ async fn query_reconstruction(
 
 fn main() -> Result<()> {
     let cli = XCommand::parse();
-    let threadpool = ThreadPool::new()?;
+    let threadpool = XetRuntime::new()?;
     threadpool.external_run_async_task(async move { cli.run().await })??;
 
     Ok(())

--- a/data/src/data_client.rs
+++ b/data/src/data_client.rs
@@ -17,7 +17,7 @@ use ulid::Ulid;
 use utils::auth::{AuthConfig, TokenRefresher};
 use utils::normalized_path_from_user_string;
 use xet_runtime::utils::run_constrained_with_semaphore;
-use xet_runtime::{global_semaphore_handle, GlobalSemaphoreHandle, ThreadPool};
+use xet_runtime::{global_semaphore_handle, GlobalSemaphoreHandle, XetRuntime};
 
 use crate::configurations::*;
 use crate::constants::{INGESTION_BLOCK_SIZE, MAX_CONCURRENT_DOWNLOADS};
@@ -128,7 +128,7 @@ pub async fn upload_bytes_async(
     let config = default_config(endpoint.unwrap_or(DEFAULT_CAS_ENDPOINT.clone()), None, token_info, token_refresher)?;
     Span::current().record("session_id", &config.session_id);
 
-    let semaphore = ThreadPool::current().global_semaphore(*CONCURRENT_FILE_INGESTION_LIMITER);
+    let semaphore = XetRuntime::current().global_semaphore(*CONCURRENT_FILE_INGESTION_LIMITER);
     let upload_session = FileUploadSession::new(config.into(), progress_updater).await?;
     let clean_futures = file_contents.into_iter().map(|blob| {
         let upload_session = upload_session.clone();
@@ -222,7 +222,7 @@ pub async fn download_async(
         async move { smudge_file(&proc, &file_info, &file_path, updater).await }.instrument(info_span!("download_file"))
     });
 
-    let semaphore = ThreadPool::current().global_semaphore(*CONCURRENT_FILE_DOWNLOAD_LIMITER);
+    let semaphore = XetRuntime::current().global_semaphore(*CONCURRENT_FILE_DOWNLOAD_LIMITER);
 
     let paths = run_constrained_with_semaphore(smudge_file_futures, semaphore).await?;
 

--- a/data/src/migration_tool/migrate.rs
+++ b/data/src/migration_tool/migrate.rs
@@ -7,7 +7,7 @@ use mdb_shard::file_structs::MDBFileInfo;
 use tracing::{info_span, instrument, Instrument, Span};
 use utils::auth::TokenRefresher;
 use xet_runtime::utils::run_constrained;
-use xet_runtime::ThreadPool;
+use xet_runtime::XetRuntime;
 
 use super::hub_client_token_refresher::HubClientTokenRefresher;
 use crate::data_client::{clean_file, default_config};
@@ -66,7 +66,7 @@ pub async fn migrate_files_impl(
     let num_workers = if sequential {
         1
     } else {
-        ThreadPool::current().num_worker_threads()
+        XetRuntime::current().num_worker_threads()
     };
     let processor = if dry_run {
         FileUploadSession::dry_run(config.into(), None).await?

--- a/hf_xet/src/runtime.rs
+++ b/hf_xet/src/runtime.rs
@@ -8,12 +8,12 @@ use pyo3::prelude::*;
 use tracing::info;
 use xet_runtime::errors::MultithreadedRuntimeError;
 use xet_runtime::sync_primatives::spawn_os_thread;
-use xet_runtime::ThreadPool;
+use xet_runtime::XetRuntime;
 
 lazy_static! {
     static ref SIGINT_DETECTED: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
     static ref SIGINT_HANDLER_INSTALL_PID: (AtomicU32, Mutex<()>) = (AtomicU32::new(0), Mutex::new(()));
-    static ref MULTITHREADED_RUNTIME: RwLock<Option<(u32, Arc<ThreadPool>)>> = RwLock::new(None);
+    static ref MULTITHREADED_RUNTIME: RwLock<Option<(u32, Arc<XetRuntime>)>> = RwLock::new(None);
 }
 
 #[cfg(unix)]
@@ -118,7 +118,7 @@ fn signal_check_background_loop() {
 }
 
 // This should be called once on library load.
-pub fn init_threadpool() -> Result<Arc<ThreadPool>, MultithreadedRuntimeError> {
+pub fn init_threadpool() -> Result<Arc<XetRuntime>, MultithreadedRuntimeError> {
     // Need to initialize. Upgrade to write lock.
     let mut guard = MULTITHREADED_RUNTIME.write().unwrap();
 
@@ -141,7 +141,7 @@ pub fn init_threadpool() -> Result<Arc<ThreadPool>, MultithreadedRuntimeError> {
     }
 
     // Create a new Tokio runtime.
-    let runtime = ThreadPool::new()?;
+    let runtime = XetRuntime::new()?;
 
     // Check the signal handler.  This must be reinstalled on new or after a spawn
     check_sigint_handler()?;
@@ -169,7 +169,7 @@ pub fn init_threadpool() -> Result<Arc<ThreadPool>, MultithreadedRuntimeError> {
 }
 
 // This function initializes the runtime if not present, otherwise returns the existing one.
-fn get_threadpool() -> Result<Arc<ThreadPool>, MultithreadedRuntimeError> {
+fn get_threadpool() -> Result<Arc<XetRuntime>, MultithreadedRuntimeError> {
     // First try a read lock to see if it's already initialized.
     {
         let guard = MULTITHREADED_RUNTIME.read().unwrap();

--- a/utils/src/singleflight.rs
+++ b/utils/src/singleflight.rs
@@ -405,7 +405,7 @@ pub(crate) mod tests {
     use tokio::runtime::Handle;
     use tokio::task::JoinHandle;
     use tokio::time::timeout;
-    use xet_runtime::ThreadPool;
+    use xet_runtime::XetRuntime;
 
     use super::Group;
     use crate::errors::SingleflightError;
@@ -431,7 +431,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_simple_with_threadpool() {
-        let threadpool = Arc::new(ThreadPool::new().unwrap());
+        let threadpool = Arc::new(XetRuntime::new().unwrap());
         let g = Group::new();
         let res = threadpool
             .external_run_async_task(async move { g.work("key", return_res()).await })
@@ -452,7 +452,7 @@ pub(crate) mod tests {
     #[test]
     fn test_multiple_threads_with_threadpool() {
         let times_called = Arc::new(AtomicU32::new(0));
-        let threadpool = Arc::new(ThreadPool::new().unwrap());
+        let threadpool = Arc::new(XetRuntime::new().unwrap());
         let g: Arc<Group<usize, ()>> = Arc::new(Group::new());
         let mut handlers: Vec<JoinHandle<(usize, bool)>> = Vec::new();
         let threadpool_ = threadpool.clone();

--- a/xet_runtime/src/lib.rs
+++ b/xet_runtime/src/lib.rs
@@ -1,9 +1,9 @@
 pub mod errors;
 pub mod exports;
 
-pub mod threadpool;
+pub mod runtime;
 
-pub use threadpool::ThreadPool;
+pub use runtime::XetRuntime;
 pub mod sync_primatives;
 pub use sync_primatives::{spawn_os_thread, SyncJoinHandle};
 

--- a/xet_runtime/src/runtime.rs
+++ b/xet_runtime/src/runtime.rs
@@ -66,9 +66,9 @@ fn get_num_tokio_worker_threads() -> usize {
 /// # Example
 ///
 /// ```rust
-/// use xet_runtime::ThreadPool;
+/// use xet_runtime::XetRuntime;
 ///
-/// let pool = ThreadPool::new().expect("Error initializing runtime.");
+/// let pool = XetRuntime::new().expect("Error initializing runtime.");
 ///
 /// let result = pool
 ///     .external_run_async_task(async {
@@ -99,7 +99,7 @@ fn get_num_tokio_worker_threads() -> usize {
 ///
 /// - `ThreadPool`: The main struct that encapsulates the Tokio runtime.
 #[derive(Debug)]
-pub struct ThreadPool {
+pub struct XetRuntime {
     // The runtime used when it's created by this struct,
     // None if this struct uses an external runtime.
     runtime: std::sync::RwLock<Option<TokioRuntime>>,
@@ -126,10 +126,10 @@ pub struct ThreadPool {
 // the worker threads in the runtime.  This way, XetRuntime::current() will always refer to
 // the runtime active with that worker thread.
 thread_local! {
-    static THREAD_RUNTIME_REF: RefCell<Option<(u32, Arc<ThreadPool>)>> = const { RefCell::new(None) };
+    static THREAD_RUNTIME_REF: RefCell<Option<(u32, Arc<XetRuntime>)>> = const { RefCell::new(None) };
 }
 
-impl ThreadPool {
+impl XetRuntime {
     /// Return the current threadpool that the current worker thread uses.  Will fail if  
     /// called from a thread that is not spawned from the current runtime.  
     #[inline]
@@ -362,7 +362,7 @@ impl ThreadPool {
     }
 }
 
-impl Display for ThreadPool {
+impl Display for XetRuntime {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // Need to be careful that this doesn't acquire locks eagerly, as this function can be called
         // from some weird places like displaying the backtrace of a panic or exception.


### PR DESCRIPTION
The Threadpool class does quite a bit more than just manage a threadpool; this PR simply changes the name to reflect this usage. 