### PR TITLE
Improved user-configurable constant handling

### DIFF
--- a/cas_client/src/remote_client.rs
+++ b/cas_client/src/remote_client.rs
@@ -42,29 +42,28 @@ pub const CAS_ENDPOINT: &str = "http://localhost:8080";
 pub const PREFIX_DEFAULT: &str = "default";
 
 utils::configurable_constants! {
-// Env (HF_XET_NUM_CONCURRENT_RANGE_GETS) to set the number of concurrent range gets.
-// setting this value to 0 disables the limit, sets it to the max, this is not recommended as it may lead to errors
+    /// Env (HF_XET_NUM_CONCURRENT_RANGE_GETS) to set the number of concurrent range gets.
+    /// setting this value to 0 disables the limit, sets it to the max, this is not recommended as it may lead to errors
     ref NUM_CONCURRENT_RANGE_GETS: usize = GlobalConfigMode::HighPerformanceOption {
         standard: 48,
         high_performance: 256,
     };
 
-    // Send a report of successful partial upload every 512kb.
+    /// Send a report of successful partial upload every 512kb.
     ref UPLOAD_REPORTING_BLOCK_SIZE : usize = 512 * 1024;
+
+    /// Env (HF_XET_RECONSTRUCT_WRITE_SEQUENTIALLY) to switch to writing terms sequentially to disk.
+    /// Benchmarks have shown that on SSD machines, writing in parallel seems to far outperform
+    /// sequential term writes.
+    /// However, this is not likely the case for writing to HDD and may in fact be worse,
+    /// so for those machines, setting this env may help download perf.
+    ref RECONSTRUCT_WRITE_SEQUENTIALLY : bool = false;
+
 }
 
 lazy_static! {
     static ref DOWNLOAD_CHUNK_RANGE_CONCURRENCY_LIMITER: GlobalSemaphoreHandle =
         global_semaphore_handle!(*NUM_CONCURRENT_RANGE_GETS);
-}
-
-utils::configurable_bool_constants! {
-// Env (HF_XET_RECONSTRUCT_WRITE_SEQUENTIALLY) to switch to writing terms sequentially to disk.
-// Benchmarks have shown that on SSD machines, writing in parallel seems to far outperform
-// sequential term writes.
-// However, this is not likely the case for writing to HDD and may in fact be worse,
-// so for those machines, setting this env may help download perf.
-    ref RECONSTRUCT_WRITE_SEQUENTIALLY = false;
 }
 
 pub struct RemoteClient {

--- a/utils/src/constant_declarations.rs
+++ b/utils/src/constant_declarations.rs
@@ -1,3 +1,91 @@
+use std::fmt::Debug;
+use std::str::FromStr;
+
+use tracing::{info, warn};
+
+/// A trait to control how a value is parsed from an environment string or other config source
+/// if it's present.
+///
+/// The main reason to do things like this is to
+pub trait ParsableConfigValue: Debug + Sized {
+    fn parse_user_value(value: &str) -> Option<Self>;
+
+    /// Parse the value, returning the default if it can't be parsed or the string is empty.  
+    /// Issue a warning if it can't be parsed.
+    fn parse(variable_name: &str, value: Option<String>, default: Self) -> Self {
+        match value {
+            Some(v) => match Self::parse_user_value(&v) {
+                Some(v) => {
+                    info!("Config: {variable_name} = {v:?} (user set)");
+                    v
+                },
+                None => {
+                    warn!("Configuration value {v} for {variable_name} cannot be parsed into correct type; reverting to default.");
+                    info!("Config: {variable_name} = {default:?} (default due to parse error)");
+                    default
+                },
+            },
+            None => {
+                info!("Config: {variable_name} = {default:?} (default)");
+                default
+            },
+        }
+    }
+}
+
+/// Most values work with the FromStr implementation, but we want to override the behavior for some types
+/// (e.g. Option<T> and bool) to have custom parsing behavior.
+pub trait FromStrParseable: FromStr + Debug {}
+
+impl<T: FromStrParseable> ParsableConfigValue for T {
+    fn parse_user_value(value: &str) -> Option<Self> {
+        // Just wrap the base FromStr parser.
+        value.parse::<T>().ok()
+    }
+}
+
+// Implement FromStrParseable for all the base types where the FromStr parsing method just works.
+impl FromStrParseable for usize {}
+impl FromStrParseable for u8 {}
+impl FromStrParseable for u16 {}
+impl FromStrParseable for u32 {}
+impl FromStrParseable for u64 {}
+impl FromStrParseable for isize {}
+impl FromStrParseable for i8 {}
+impl FromStrParseable for i16 {}
+impl FromStrParseable for i32 {}
+impl FromStrParseable for i64 {}
+impl FromStrParseable for f32 {}
+impl FromStrParseable for f64 {}
+impl FromStrParseable for String {}
+
+/// Special handling for bool:
+/// - true: "1","true","yes","y","on"  -> true
+/// - false: "0","false","no","n","off","" -> false
+fn parse_bool_value(value: &str) -> Option<bool> {
+    let t = value.trim().to_ascii_lowercase();
+
+    match t.as_str() {
+        "0" | "false" | "no" | "n" | "off" => Some(false),
+        "1" | "true" | "yes" | "y" | "on" => Some(true),
+        _ => None,
+    }
+}
+
+impl ParsableConfigValue for bool {
+    fn parse_user_value(value: &str) -> Option<Self> {
+        parse_bool_value(value)
+    }
+}
+
+/// Enable Option<T> to allow the default value to be None if nothing is set and appear as
+/// Some(Value) if the user specifies the value.
+impl<T: ParsableConfigValue> ParsableConfigValue for Option<T> {
+    fn parse_user_value(value: &str) -> Option<Self> {
+        T::parse_user_value(value).map(Some)
+    }
+}
+
 /// A small marker struct so you can write `release_fixed(1234)`.
 /// In debug builds, we allow env override; in release, we ignore env.
 pub enum GlobalConfigMode<T> {
@@ -21,10 +109,6 @@ impl<T> From<T> for GlobalConfigMode<T> {
 // Reexport this so that dependencies don't have weird other dependencies
 pub use lazy_static::lazy_static;
 
-pub fn convert_value_to_bool(s: String) -> bool {
-    matches!(s.to_uppercase().as_str(), "1" | "ON" | "YES" | "TRUE")
-}
-
 #[macro_export]
 macro_rules! configurable_constants {
     ($(
@@ -39,45 +123,8 @@ macro_rules! configurable_constants {
                 pub static ref $name: $type = {
                     let v : GlobalConfigMode<$type> = ($value).into();
                     let try_load_from_env = |v_| {
-                        std::env::var(concat!("HF_XET_",stringify!($name)))
-                            .ok()
-                            .and_then(|s| s.parse::<$type>().ok())
-                            .unwrap_or(v_)
-                    };
-
-                    match (v, cfg!(debug_assertions)) {
-                        (GlobalConfigMode::ReleaseFixed(v), false) => v,
-                        (GlobalConfigMode::ReleaseFixed(v), true) => try_load_from_env(v),
-                        (GlobalConfigMode::EnvConfigurable(v), _) => try_load_from_env(v),
-                        (GlobalConfigMode::HighPerformanceOption { standard, high_performance }, _) => try_load_from_env(if is_high_performance() { high_performance } else { standard }),
-                    }
-                };
-            }
-        )+
-    };
-}
-
-/// using configurable_bool_constants will set the variable to true if the environment variable is found
-/// and is set to a "truthy" value defined as one of `{"1", "ON", "YES", "TRUE"}` (case-insensitive).
-/// Any other value (or undefined) will be considered as `False`.
-#[macro_export]
-macro_rules! configurable_bool_constants {
-    ($(
-        $(#[$meta:meta])*
-        ref $name:ident = $value:expr;
-    )+) => {
-        $(
-            #[allow(unused_imports)]
-            use utils::constant_declarations::*;
-            lazy_static! {
-                $(#[$meta])*
-                pub static ref $name: bool = {
-                    let v : GlobalConfigMode<bool> = ($value).into();
-                    let try_load_from_env = |v_| {
-                        std::env::var(concat!("HF_XET_",stringify!($name)))
-                            .ok()
-                            .map(convert_value_to_bool)
-                            .unwrap_or(v_)
+                        let maybe_env_value = std::env::var(concat!("HF_XET_",stringify!($name))).ok();
+                        <$type>::parse(stringify!($name), maybe_env_value, v_)
                     };
 
                     match (v, cfg!(debug_assertions)) {
@@ -157,10 +204,10 @@ macro_rules! test_set_globals {
 }
 
 fn get_high_performance_flag() -> bool {
-    if let Ok(val) = std::env::var(concat!("HF_XET_", "HIGH_PERFORMANCE")) {
-        convert_value_to_bool(val)
-    } else if let Ok(val) = std::env::var(concat!("HF_XET_", "HP")) {
-        convert_value_to_bool(val)
+    if let Ok(val) = std::env::var("HF_XET_HIGH_PERFORMANCE") {
+        parse_bool_value(&val).unwrap_or(false)
+    } else if let Ok(val) = std::env::var("HF_XET_HP") {
+        parse_bool_value(&val).unwrap_or(false)
     } else {
         false
     }


### PR DESCRIPTION
This PR adds in two upgrades to the current configurable_constants! macro that allows for users to specify the values of configuration constants using environment variables and the like.  It adds two things: 
- Allows bool values to be parsed by 0, 1, true, false, on, off, etc.   configurable_bool_constants! is no longer needed. 
- Allows Option<T> to be a specified type with a default value of None, which parses the environment value as type T but puts it in Some(Value) if it's present and None if it's not specified.  This allows us to determine if a value has been specified, e.g. in the case where the default depends on other things but can be overridden.