### PR TITLE
Build and release git-xet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,10 @@ jobs:
         uses: dtolnay/rust-toolchain@1.89.0
         with:
           components: clippy
+      - name: Install or upgrade OpenSSL
+        run: |
+          which -a openssl
+          /usr/bin/openssl version -a
       - name: Set up Git LFS
         run: |
           brew install git-lfs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,10 +71,6 @@ jobs:
         uses: dtolnay/rust-toolchain@1.89.0
         with:
           components: clippy
-      - name: Install or upgrade OpenSSL
-        run: |
-          which -a openssl
-          /usr/bin/openssl version -a
       - name: Set up Git LFS
         run: |
           brew install git-lfs

--- a/.github/workflows/git-xet-release.yml
+++ b/.github/workflows/git-xet-release.yml
@@ -108,4 +108,4 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create ${{ github.event.inputs.tag}} git-xet* --generate-notes --prerelease --target ${{github.sha}}
+          gh release create ${{ github.event.inputs.tag}} git-xet*/* --generate-notes --prerelease --target ${{github.sha}}

--- a/.github/workflows/git-xet-release.yml
+++ b/.github/workflows/git-xet-release.yml
@@ -1,0 +1,87 @@
+name: git-xet Release
+run-name: git-xet release, tag ${{ inputs.tag || 'main' }}
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Semantic version for release (tag will shard the same name)"
+        required: true
+        default: "v0.1.0"
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  linux:
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      matrix:
+        platform:
+          - runner: ubuntu-22.04
+            target: x86_64
+            manylinux: auto
+          - runner: ubuntu-22.04
+            target: aarch64
+            manylinux: manylinux_2_28
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust 1.89
+        uses: dtolnay/rust-toolchain@1.89.0
+      - name: Build
+        run: |
+          cargo build --release
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: git-xet-${{ matrix.platform.target }}
+          path: target/release/git-xet
+
+  macos:
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      matrix:
+        platform:
+          - runner: macos-13
+            target: x86_64
+            rust_target: x86_64-apple-darwin
+          - runner: macos-14
+            target: aarch64
+            rust_target: aarch64-apple-darwin
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust 1.89
+        uses: dtolnay/rust-toolchain@1.89.0
+      - name: Build
+        run: |
+          cargo build --release
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: git-xet-${{ matrix.platform.target }}
+          path: target/release/git-xet
+
+  windows:
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      matrix:
+        platform:
+          - runner: windows-latest
+            target: x64
+            rust_target: x86_64-pc-windows-msvc
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust 1.89
+        uses: dtolnay/rust-toolchain@1.89.0
+      - name: Build
+        run: |
+          cargo build --release
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: git-xet-${{ matrix.platform.target }}
+          path: target/release/git-xet.exe

--- a/.github/workflows/git-xet-release.yml
+++ b/.github/workflows/git-xet-release.yml
@@ -11,7 +11,6 @@ on:
         description: "Semantic version for release (tag will shard the same name)"
         required: true
         default: "v0.1.0"
-  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/git-xet-release.yml
+++ b/.github/workflows/git-xet-release.yml
@@ -24,10 +24,8 @@ jobs:
         platform:
           - runner: ubuntu-22.04
             target: x86_64
-            manylinux: auto
-          - runner: ubuntu-22.04
+          - runner: ubuntu-22.04-arm
             target: aarch64
-            manylinux: manylinux_2_28
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust 1.89
@@ -48,10 +46,8 @@ jobs:
         platform:
           - runner: macos-13
             target: x86_64
-            rust_target: x86_64-apple-darwin
-          - runner: macos-14
+          - runner: macos-15
             target: aarch64
-            rust_target: aarch64-apple-darwin
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust 1.89
@@ -71,7 +67,7 @@ jobs:
           certificate-password: ${{ secrets.CLI_MACOS_CERTIFICATE_PWD }}
           apple-notary-user: ${{ secrets.CLI_MACOS_NOTARY_USER }}
           apple-notary-password: ${{ secrets.CLI_MACOS_NOTARY_PWD }}
-          apple-product-id: co.huggingface.git-xet
+          apple-product-id: co.huggingface.gitxet
           options: --options runtime --entitlements dist/entitlements.xml
       - name: Upload binary
         uses: actions/upload-artifact@v4
@@ -86,7 +82,6 @@ jobs:
         platform:
           - runner: windows-latest
             target: x86_64
-            rust_target: x86_64-pc-windows-msvc
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust 1.89

--- a/.github/workflows/git-xet-release.yml
+++ b/.github/workflows/git-xet-release.yml
@@ -35,10 +35,10 @@ jobs:
       - name: Build
         run: |
           cargo build --release
-      - name: Upload wheels
+      - name: Upload binary
         uses: actions/upload-artifact@v4
         with:
-          name: git-xet-${{ matrix.platform.target }}
+          name: git-xet-linux-${{ matrix.platform.target }}
           path: target/release/git-xet
 
   macos:
@@ -59,11 +59,25 @@ jobs:
       - name: Build
         run: |
           cargo build --release
-      - name: Upload wheels
+          mkdir dist
+          cp target/release/git-xet dist/
+          cp git_xet/entitlements.xml dist/
+      - name: Codesign and Notarization
+        uses: lando/code-sign-action@v3
+        with:
+          file: dist/git-xet
+          certificate-data: ${{ secrets.CLI_MACOS_CERTIFICATE }}
+          certificate-id: ${{ secrets.CLI_MACOS_TEAM_ID }}
+          certificate-password: ${{ secrets.CLI_MACOS_CERTIFICATE_PWD }}
+          apple-notary-user: ${{ secrets.CLI_MACOS_NOTARY_USER }}
+          apple-notary-password: ${{ secrets.CLI_MACOS_NOTARY_PWD }}
+          apple-product-id: co.huggingface.git-xet
+          options: --options runtime --entitlements dist/entitlements.xml
+      - name: Upload binary
         uses: actions/upload-artifact@v4
         with:
-          name: git-xet-${{ matrix.platform.target }}
-          path: target/release/git-xet
+          name: git-xet-macos-${{ matrix.platform.target }}
+          path: dist/git-xet
 
   windows:
     runs-on: ${{ matrix.platform.runner }}
@@ -71,7 +85,7 @@ jobs:
       matrix:
         platform:
           - runner: windows-latest
-            target: x64
+            target: x86_64
             rust_target: x86_64-pc-windows-msvc
     steps:
       - uses: actions/checkout@v4
@@ -80,8 +94,8 @@ jobs:
       - name: Build
         run: |
           cargo build --release
-      - name: Upload wheels
+      - name: Upload binary
         uses: actions/upload-artifact@v4
         with:
-          name: git-xet-${{ matrix.platform.target }}
+          name: git-xet-windows-${{ matrix.platform.target }}
           path: target/release/git-xet.exe

--- a/.github/workflows/git-xet-release.yml
+++ b/.github/workflows/git-xet-release.yml
@@ -108,4 +108,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create ${{ github.event.inputs.tag}} git-xet*/* --generate-notes --prerelease --target ${{github.sha}}
+          ls -l
+          ls -l git-xet*/*
+          gh release create git-xet-v0.0.1 git-xet*/* --generate-notes --prerelease --target ${{github.sha}}

--- a/.github/workflows/git-xet-release.yml
+++ b/.github/workflows/git-xet-release.yml
@@ -94,3 +94,18 @@ jobs:
         with:
           name: git-xet-windows-${{ matrix.platform.target }}
           path: target/release/git-xet.exe
+
+  github-release:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    needs: [linux, windows, macos]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create ${{ github.event.inputs.tag}} git-xet* --generate-notes --prerelease --target ${{github.sha}}

--- a/.github/workflows/git-xet-release.yml
+++ b/.github/workflows/git-xet-release.yml
@@ -100,9 +100,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     needs: [linux, windows, macos]
     steps:
-      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
       - name: Create GitHub Release
         env:
@@ -110,4 +110,4 @@ jobs:
         run: |
           ls -l
           ls -l git-xet*/*
-          gh release create git-xet-v0.0.1 git-xet*/* --generate-notes --prerelease --target ${{github.sha}}
+          gh release create git-xet-${{ github.event.inputs.tag}} git-xet*/* --generate-notes --prerelease --target ${{github.sha}}

--- a/git_xet/entitlements.xml
+++ b/git_xet/entitlements.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+        <true/>
+    </dict>
+</plist>

--- a/git_xet/entitlements.xml
+++ b/git_xet/entitlements.xml
@@ -4,5 +4,7 @@
     <dict>
         <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
         <true/>
+        <key>com.apple.security.cs.disable-library-validation</key>
+        <true/>
     </dict>
 </plist>


### PR DESCRIPTION
The defines the workflow to build git-xet on Linux (amd64 & arm64), macOS (amd64 & arm64) and Windows (amd64). For the macOS build the compiled binary is signed and notarized in place.