### PR TITLE
Fix git-xet release bug

### DIFF
--- a/.github/workflows/git-xet-release.yml
+++ b/.github/workflows/git-xet-release.yml
@@ -11,7 +11,6 @@ on:
         description: "Semantic version for release (tag will shard the same name)"
         required: true
         default: "v0.1.0"
-  pull_request:
 
 permissions:
   contents: read
@@ -100,6 +99,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     needs: [linux, windows, macos]
     steps:
       - uses: actions/checkout@v4
@@ -112,4 +112,4 @@ jobs:
         run: |
           ls -l dist
           for dir in dist/*; do (cd "$dir" && zip -r "../$(basename "$dir").zip" .); done
-          gh release create git-xet-v0.1.0 dist/*.zip --generate-notes --prerelease --target ${{github.sha}}
+          gh release create git-xet-${{ github.event.inputs.tag}} dist/*.zip --generate-notes --prerelease --target ${{github.sha}}


### PR DESCRIPTION
The binaries have the same name "git-xet", uploading them directly leads to a release failure. We thus zip the binaries with each zip file name being the name argument in the upload-artifact actions, i.e. "git-xet-[linux|macos|windows]-${{ matrix.platform.target }}".

The test commit [34fcdf2](https://github.com/huggingface/xet-core/pull/505/commits/34fcdf25d7ac3d54795458f545f8c6c94a87e5d0) creates a release at https://github.com/huggingface/xet-core/releases/tag/git-xet-v0.1.0