### PR TITLE
Convert status code to error for get_cas_jwt

### DIFF
--- a/cas_client/src/lib.rs
+++ b/cas_client/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
 pub use chunk_cache::{CHUNK_CACHE_SIZE_BYTES, CacheConfig};
-pub use http_client::{Api, RetryConfig, build_auth_http_client, build_http_client};
+pub use http_client::{Api, ResponseErrorLogger, RetryConfig, build_auth_http_client, build_http_client};
 pub use interface::Client;
 #[cfg(not(target_family = "wasm"))]
 pub use local_client::LocalClient;

--- a/hub_client/src/client.rs
+++ b/hub_client/src/client.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use cas_client::exports::ClientWithMiddleware;
-use cas_client::{Api, RetryConfig, build_http_client};
+use cas_client::{Api, ResponseErrorLogger, RetryConfig, build_http_client};
 use http::header;
 use urlencoding::encode;
 
@@ -96,7 +96,7 @@ impl HubClient {
             .fill_credential(req)
             .await
             .map_err(HubClientError::CredentialHelper)?;
-        let response = req.send().await?;
+        let response = req.send().await.process_error("xet-write-token")?;
 
         let info: CasJWTInfo = response.json().await?;
 


### PR DESCRIPTION
Let the error status code be caught early instead of later during json deserialization.