### PR TITLE
Added lazy evaluation functionality to error printer.

### DIFF
--- a/error_printer/src/lib.rs
+++ b/error_printer/src/lib.rs
@@ -11,7 +11,6 @@ pub trait ErrorPrinter {
     fn log_error_fn<M: Display, F: FnOnce() -> M>(self, message_fn: F) -> Self;
 
     fn warn_error<M: Display>(self, message: M) -> Self;
-
     fn warn_error_fn<M: Display, F: FnOnce() -> M>(self, message_fn: F) -> Self;
 
     fn debug_error<M: Display>(self, message: M) -> Self;


### PR DESCRIPTION
Currently, the full message given to a function in error_printer must be always created. This causes extra work when there are no errors if the message should contain additional data. 

This PR introduces `_fn` versions of the existing functions that call a given function on demand to obtain the message.  Thus `.warn_error_fn(|| format!("Error processing {context}"))` would only allocate and create the error string when an error needs to be logged. 