### PR TITLE
Cache rust build in actions

### DIFF
--- a/.github/actions/cache-rust-build/action.yml
+++ b/.github/actions/cache-rust-build/action.yml
@@ -1,0 +1,16 @@
+name: 'Cache Rust Build'
+description: 'Cache Rust dependency and build artifact'
+runs:
+  using: "composite"
+  steps:
+    - name: Cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+          hf_xet/target
+          hf_xet_wasm/target
+          hf_xet_thin_wasm/target
+        key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
         uses: dtolnay/rust-toolchain@1.89.0
         with:
           components: clippy
+      - uses: ./.github/actions/cache-rust-build
       - name: Lint
         run: |
           cargo clippy -r --verbose -- -D warnings # elevates warnings to errors
@@ -59,6 +60,7 @@ jobs:
         uses: dtolnay/rust-toolchain@1.89.0
         with:
           components: clippy
+      - uses: ./.github/actions/cache-rust-build
       - name: Build and Test
         run: |
           cargo test --verbose --no-fail-fast --features "strict"
@@ -75,6 +77,7 @@ jobs:
         run: |
           brew install git-lfs
           git lfs install
+      - uses: ./.github/actions/cache-rust-build
       - name: Build and Test
         run: |
           cargo test --verbose --no-fail-fast --features "strict"
@@ -89,6 +92,7 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
           components: rust-src
+      - uses: ./.github/actions/cache-rust-build
       - name: Install wasm-bindgen-cli and wasm-pack
         run: |
           cargo install --version 0.2.100 wasm-bindgen-cli

--- a/.github/workflows/git-xet-release.yml
+++ b/.github/workflows/git-xet-release.yml
@@ -10,8 +10,7 @@ on:
       tag:
         description: "Semantic version for release (tag will shard the same name)"
         required: true
-        default: "v0.1"
-  pull_request:
+        default: "v0.1.0"
 
 permissions:
   contents: read

--- a/.github/workflows/git-xet-release.yml
+++ b/.github/workflows/git-xet-release.yml
@@ -10,7 +10,7 @@ on:
       tag:
         description: "Semantic version for release (tag will shard the same name)"
         required: true
-        default: "v0.1.0"
+        default: "v0.1"
   pull_request:
 
 permissions:

--- a/.github/workflows/git-xet-release.yml
+++ b/.github/workflows/git-xet-release.yml
@@ -11,6 +11,7 @@ on:
         description: "Semantic version for release (tag will shard the same name)"
         required: true
         default: "v0.1.0"
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/git-xet-release.yml
+++ b/.github/workflows/git-xet-release.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Rust 1.89
         uses: dtolnay/rust-toolchain@1.89.0
+      - uses: ./.github/actions/cache-rust-build
       - name: Build
         run: |
           cargo build --release
@@ -51,6 +52,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Rust 1.89
         uses: dtolnay/rust-toolchain@1.89.0
+      - uses: ./.github/actions/cache-rust-build
       - name: Build
         run: |
           cargo build --release
@@ -85,6 +87,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Rust 1.89
         uses: dtolnay/rust-toolchain@1.89.0
+      - uses: ./.github/actions/cache-rust-build
       - name: Build
         run: |
           cargo build --release


### PR DESCRIPTION
In response to [A Joint Statement on Sustainable Stewardship](https://openssf.org/blog/2025/09/23/open-infrastructure-is-not-free-a-joint-statement-on-sustainable-stewardship/) and [Rust Foundation Signs Joint Statement on Open Source Infrastructure Stewardship](https://rustfoundation.org/media/rust-foundation-signs-joint-statement-on-open-source-infrastructure-stewardship/), implements caching of dependency and build artifact, and reduces some CI runtime. Cache entry keys are formed by `os_type`-`arch_type`-`hash of Cargo.lock`, cache configuration adapts from https://docs.github.com/en/actions/tutorials/build-and-test-code/rust#caching-dependencies.