### PR TITLE
Upgrade macos-13 to macos-15-intel due to closing down

### DIFF
--- a/.github/workflows/git-xet-release.yml
+++ b/.github/workflows/git-xet-release.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-13
+          - runner: macos-15-intel
             target: x86_64
           - runner: macos-15
             target: aarch64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,7 +242,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-13
+          - runner: macos-15-intel
             target: x86_64
             rust_target: x86_64-apple-darwin
           - runner: macos-14


### PR DESCRIPTION
Upgrade the Intel macos runner due to [GitHub Actions: macOS 13 runner image is closing down](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/).