### PR TITLE
fix: explicitly specify main branch for hub client in migration utility

### DIFF
--- a/data/src/migration_tool/migrate.rs
+++ b/data/src/migration_tool/migrate.rs
@@ -34,7 +34,7 @@ pub async fn migrate_with_external_runtime(
 ) -> Result<()> {
     let cred_helper = BearerCredentialHelper::new(hub_token.to_owned(), "");
     let hub_client =
-        HubClient::new(hub_endpoint, RepoInfo::try_from(repo_type, repo_id)?, None, "xtool", "", cred_helper)?;
+        HubClient::new(hub_endpoint, RepoInfo::try_from(repo_type, repo_id)?, Some("main".to_owned()), "xtool", "", cred_helper)?;
 
     migrate_files_impl(file_paths, false, hub_client, cas_endpoint, None, false).await?;
 


### PR DESCRIPTION
The current hub client does not pass revision into the argument, which causes the moon-landing call to append `create_pr=1` query param to the token API and returns 403 error.