### PR TITLE
Drop `auto-initialize` from `pyo3` dep

### DIFF
--- a/hf_xet/Cargo.toml
+++ b/hf_xet/Cargo.toml
@@ -30,7 +30,6 @@ pprof = { version = "0.14", features = [
 pyo3 = { version = "0.26", features = [
     "extension-module",
     "abi3-py37",
-    "auto-initialize",
 ] }
 rand = "0.9.2"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
As stated in `pyo3`'s docs, embedding the Python interpreter statically does not yet have first-class support in PyO3

Should resolve #512