### PR TITLE
Add fallback if unable to get git commit

### DIFF
--- a/xet_logging/src/logging.rs
+++ b/xet_logging/src/logging.rs
@@ -48,7 +48,7 @@ pub fn init(cfg: LoggingConfig) {
     }
 
     // Log the version information.
-    info!("{}, xet-core revision {}", &cfg.version, git_version::git_version!());
+    info!("{}, xet-core revision {}", &cfg.version, git_version::git_version!(fallback = "unknown"));
 
     if let Some(dir_cleanup_task_fn) = dir_cleanup_task {
         dir_cleanup_task_fn();


### PR DESCRIPTION
- necessary to allow uv to build hf-xet (see errors below)

This PR specifies the fallback option on the `git_version!` macro, as written in the docs for git-version-macro crate.

See this build/install error when trying to install hf-xet on python 3.14t:

```
(venv-py314t)  ✘ rajat@cantrust  ~  uv pip install hf-xet==1.1.11b1
Using Python 3.14.0rc2 environment at: venv-py314t
Resolved 1 package in 108ms
  × Failed to build `hf-xet==1.1.11b1`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `maturin.build_wheel` failed (exit status: 1)

      [stdout]
      Running `maturin pep517 build-wheel -i /Users/rajat/.cache/uv/builds-v0/.tmpH8zWNh/bin/python --compatibility off`

      [stderr]
          Updating crates.io index
       Downloading crates ...
        Downloaded git-version v0.3.9
        Downloaded windows-threading v0.1.0
        Downloaded git-version-macro v0.3.9
        Downloaded windows-future v0.2.1
        Downloaded windows-numerics v0.2.0
        Downloaded windows-collections v0.2.0
        Downloaded ntapi v0.4.1
        Downloaded objc2-io-kit v0.3.1
        Downloaded objc2-core-foundation v0.3.1
        Downloaded sysinfo v0.37.0
        Downloaded windows v0.61.3
      ⚠️ Warning: You specified the python source as /Users/rajat/.cache/uv/sdists-v9/pypi/hf-xet/1.1.11b1/uozi8-wYrrSik9zuoLSCa/src/hf_xet/python, but
      the python module at /Users/rajat/.cache/uv/sdists-v9/pypi/hf-xet/1.1.11b1/uozi8-wYrrSik9zuoLSCa/src/hf_xet/python/hf_xet is missing. No python
      module will be included.
      🔗 Found pyo3 bindings with abi3 support
      🐍 Not using a specific python interpreter
      📡 Using build options features from pyproject.toml
      ⚠️ Warning: CPython 3.14t at /Users/rajat/.cache/uv/builds-v0/.tmpH8zWNh/bin/python does not yet support abi3 so the build artifacts will be
      version-specific.
      💻 Using `MACOSX_DEPLOYMENT_TARGET=11.0` for aarch64-apple-darwin by default
         Compiling proc-macro2 v1.0.101
         Compiling unicode-ident v1.0.18
         Compiling libc v0.2.175
         Compiling cfg-if v1.0.1
         Compiling shlex v1.3.0
         Compiling memchr v2.7.5
         Compiling itoa v1.0.15
         Compiling once_cell v1.21.3
         Compiling pin-project-lite v0.2.16
         Compiling autocfg v1.5.0
         Compiling serde v1.0.219
         Compiling core-foundation-sys v0.8.7
         Compiling bytes v1.10.1
         Compiling futures-core v0.3.31
         Compiling cc v1.2.33
         Compiling zerocopy v0.8.26
         Compiling futures-sink v0.3.31
         Compiling ryu v1.0.20
         Compiling tracing-core v0.1.34
         Compiling serde_json v1.0.142
         Compiling futures-channel v0.3.31
         Compiling pin-utils v0.1.0
         Compiling bitflags v2.9.2
         Compiling getrandom v0.3.3
         Compiling futures-io v0.3.31
         Compiling slab v0.4.11
         Compiling futures-task v0.3.31
         Compiling num-traits v0.2.19
         Compiling base64 v0.22.1
         Compiling crossbeam-utils v0.8.21
         Compiling smallvec v1.15.1
         Compiling stable_deref_trait v1.2.0
         Compiling thiserror v2.0.15
         Compiling num-conv v0.1.0
         Compiling time-core v0.1.4
         Compiling lazy_static v1.5.0
         Compiling powerfmt v0.2.0
         Compiling pkg-config v0.3.32
         Compiling lmdb-rkv-sys v0.11.2
         Compiling deranged v0.4.0
         Compiling time-macros v0.2.22
         Compiling arrayvec v0.7.6
         Compiling option-ext v0.2.0
         Compiling blake3 v1.8.2
         Compiling ring v0.17.14
         Compiling fnv v1.0.7
         Compiling byteorder v1.5.0
         Compiling bytemuck v1.23.2
         Compiling heed-traits v0.8.0
         Compiling target-lexicon v0.13.3
         Compiling quote v1.0.40
         Compiling syn v2.0.106
         Compiling time v0.3.41
         Compiling crossbeam-queue v0.3.12
         Compiling litemap v0.8.0
         Compiling synchronoise v1.0.1
         Compiling socket2 v0.6.0
         Compiling mio v1.0.4
         Compiling getrandom v0.2.16
         Compiling rand_core v0.9.3
         Compiling page_size v0.4.2
         Compiling rust_decimal v1.38.0
         Compiling ppv-lite86 v0.2.21
         Compiling zeroize v1.8.1
         Compiling arrayref v0.3.9
         Compiling constant_time_eq v0.3.1
         Compiling syn v1.0.109
         Compiling writeable v0.6.1
         Compiling rustls-pki-types v1.12.0
         Compiling rand_chacha v0.9.0
         Compiling rand v0.9.2
         Compiling dirs-sys v0.5.0
         Compiling http v1.3.1
         Compiling iana-time-zone v0.1.63
         Compiling safe-transmute v0.11.3
         Compiling icu_normalizer_data v2.0.0
         Compiling dtor-proc-macro v0.0.5
         Compiling untrusted v0.9.0
         Compiling icu_properties_data v2.0.1
         Compiling dtor v0.0.6
         Compiling http-body v1.0.1
         Compiling chrono v0.4.41
         Compiling pyo3-build-config v0.26.0
         Compiling synstructure v0.13.2
         Compiling dirs v6.0.0
         Compiling system-configuration-sys v0.6.0
         Compiling anstyle v1.0.11
         Compiling winnow v0.7.13
         Compiling percent-encoding v2.3.1
         Compiling ctor-proc-macro v0.0.6
         Compiling thiserror v1.0.69
         Compiling httparse v1.10.1
         Compiling ctor v0.4.3
         Compiling serde_derive v1.0.219
         Compiling tokio-macros v2.5.0
         Compiling futures-macro v0.3.31
         Compiling zerofrom-derive v0.1.6
         Compiling tracing-attributes v0.1.30
         Compiling tokio v1.47.1
         Compiling yoke-derive v0.8.0
         Compiling futures-util v0.3.31
         Compiling zerovec-derive v0.11.1
         Compiling zerofrom v0.1.6
         Compiling thiserror-impl v2.0.15
         Compiling tracing v0.1.41
         Compiling yoke v0.8.0
         Compiling displaydoc v0.2.5
         Compiling async-trait v0.1.89
         Compiling zerovec v0.11.4
         Compiling zerotrie v0.2.2
         Compiling pin-project-internal v1.1.10
         Compiling futures-executor v0.3.31
         Compiling error_printer v0.14.5 (/Users/rajat/.cache/uv/sdists-v9/pypi/hf-xet/1.1.11b1/uozi8-wYrrSik9zuoLSCa/src/error_printer)
         Compiling futures v0.3.31
         Compiling derivative v2.2.0
         Compiling thiserror-impl v1.0.69
         Compiling tinystr v0.8.1
         Compiling potential_utf v0.1.2
         Compiling icu_collections v2.0.0
         Compiling icu_locale_core v2.0.0
         Compiling pin-project v1.1.10
         Compiling icu_provider v2.0.0
         Compiling shellexpand v3.1.1
         Compiling aho-corasick v1.1.3
         Compiling regex-syntax v0.8.5
         Compiling log v0.4.27
         Compiling tower-service v0.3.3
         Compiling heck v0.5.0
         Compiling rustls v0.23.31
         Compiling try-lock v0.2.5
         Compiling want v0.3.1
         Compiling icu_properties v2.0.1
         Compiling icu_normalizer v2.0.0
         Compiling bincode v1.3.3
         Compiling duration-str v0.17.0
         Compiling regex-automata v0.4.9
         Compiling heed-types v0.8.0
         Compiling core-foundation v0.9.4
         Compiling core-foundation v0.10.1
         Compiling security-framework-sys v2.14.0
         Compiling anyhow v1.0.99
         Compiling atomic-waker v1.1.2
         Compiling subtle v2.6.1
         Compiling utf8parse v0.2.2
         Compiling hyper v1.7.0
         Compiling anstyle-parse v0.2.7
         Compiling security-framework v3.3.0
         Compiling system-configuration v0.6.1
         Compiling idna_adapter v1.2.1
         Compiling form_urlencoded v1.2.1
         Compiling sync_wrapper v1.0.2
         Compiling ipnet v2.11.0
         Compiling anstyle-query v1.1.4
         Compiling utf8_iter v1.0.4
         Compiling colorchoice v1.0.4
         Compiling tower-layer v0.3.3
         Compiling is_terminal_polyfill v1.70.1
         Compiling rustix v1.0.8
         Compiling tower v0.5.2
         Compiling regex v1.11.2
         Compiling rustls-native-certs v0.8.1
         Compiling anstream v0.6.20
         Compiling hyper-util v0.1.16
         Compiling idna v1.0.3
         Compiling tokio-util v0.7.16
         Compiling webpki-roots v1.0.2
         Compiling rand_core v0.6.4
         Compiling errno v0.3.13
         Compiling version_check v0.9.5
         Compiling iri-string v0.7.8
         Compiling strsim v0.11.1
         Compiling typenum v1.18.0
         Compiling clap_lex v0.7.5
         Compiling clap_builder v4.5.44
         Compiling generic-array v0.14.7
         Compiling rand_chacha v0.3.1
         Compiling url v2.5.4
         Compiling tower-http v0.6.6
         Compiling serde_urlencoded v0.7.1
         Compiling clap_derive v4.5.45
         Compiling http-body-util v0.1.3
         Compiling fastrand v2.3.0
         Compiling predicates-core v1.0.9
         Compiling mockall_derive v0.13.1
         Compiling heed v0.11.0
         Compiling either v1.15.0
         Compiling rand v0.8.5
         Compiling tempfile v3.20.0
         Compiling itertools v0.14.0
         Compiling merklehash v0.14.5 (/Users/rajat/.cache/uv/sdists-v9/pypi/hf-xet/1.1.11b1/uozi8-wYrrSik9zuoLSCa/src/merklehash)
         Compiling utils v0.14.5 (/Users/rajat/.cache/uv/sdists-v9/pypi/hf-xet/1.1.11b1/uozi8-wYrrSik9zuoLSCa/src/utils)
         Compiling uuid v1.18.0
         Compiling termtree v0.5.1
         Compiling more-asserts v0.3.1
         Compiling static_assertions v1.1.0
         Compiling cfg-if v0.1.10
         Compiling crc32fast v1.5.0
         Compiling heapify v0.2.0
         Compiling gearhash v0.1.3
         Compiling predicates-tree v1.0.12
         Compiling predicates v3.1.3
         Compiling rustls-webpki v0.103.4
         Compiling clap v4.5.45
         Compiling progress_tracking v0.1.0 (/Users/rajat/.cache/uv/sdists-v9/pypi/hf-xet/1.1.11b1/uozi8-wYrrSik9zuoLSCa/src/progress_tracking)
         Compiling serde_repr v0.1.20
         Compiling dirs-sys v0.4.1
         Compiling colored v2.2.0
         Compiling lock_api v0.4.13
         Compiling csv-core v0.1.12
         Compiling mdb_shard v0.14.5 (/Users/rajat/.cache/uv/sdists-v9/pypi/hf-xet/1.1.11b1/uozi8-wYrrSik9zuoLSCa/src/mdb_shard)
         Compiling whoami v1.6.1
         Compiling regex-syntax v0.6.29
         Compiling twox-hash v2.1.1
         Compiling downcast v0.11.0
         Compiling fragile v2.0.1
         Compiling parking_lot_core v0.9.11
         Compiling file_utils v0.14.2 (/Users/rajat/.cache/uv/sdists-v9/pypi/hf-xet/1.1.11b1/uozi8-wYrrSik9zuoLSCa/src/file_utils)
         Compiling lz4_flex v0.11.5
         Compiling cas_types v0.1.0 (/Users/rajat/.cache/uv/sdists-v9/pypi/hf-xet/1.1.11b1/uozi8-wYrrSik9zuoLSCa/src/cas_types)
         Compiling csv v1.3.1
         Compiling dirs v5.0.1
         Compiling deduplication v0.14.5 (/Users/rajat/.cache/uv/sdists-v9/pypi/hf-xet/1.1.11b1/uozi8-wYrrSik9zuoLSCa/src/deduplication)
         Compiling retry-policies v0.4.0
         Compiling pyo3-ffi v0.26.0
         Compiling pyo3-macros-backend v0.26.0
         Compiling regex-automata v0.1.10
         Compiling num-integer v0.1.46
         Compiling sha2-asm v0.6.4
         Compiling countio v0.2.19
         Compiling half v2.6.0
         Compiling scopeguard v1.2.0
         Compiling protobuf v3.7.2
         Compiling oneshot v0.1.11
         Compiling overload v0.1.1
         Compiling nu-ansi-term v0.46.0
         Compiling cas_object v0.1.0 (/Users/rajat/.cache/uv/sdists-v9/pypi/hf-xet/1.1.11b1/uozi8-wYrrSik9zuoLSCa/src/cas_object)
         Compiling num-bigint v0.4.6
         Compiling mockall v0.13.1
         Compiling matchers v0.1.0
         Compiling tokio-rustls v0.26.2
         Compiling chunk_cache v0.1.0 (/Users/rajat/.cache/uv/sdists-v9/pypi/hf-xet/1.1.11b1/uozi8-wYrrSik9zuoLSCa/src/chunk_cache)
         Compiling crypto-common v0.1.6
         Compiling hyper-rustls v0.27.7
         Compiling block-buffer v0.10.4
         Compiling tokio-retry v0.3.0
         Compiling protobuf-support v3.7.2
         Compiling reqwest v0.12.23
         Compiling tracing-serde v0.2.0
         Compiling tracing-log v0.2.0
         Compiling sharded-slab v0.1.7
         Compiling objc2-core-foundation v0.3.1
         Compiling memoffset v0.9.1
         Compiling thread_local v1.1.9
         Compiling prometheus v0.14.0
         Compiling digest v0.10.7
         Compiling tracing-subscriber v0.3.19
         Compiling simple_asn1 v0.6.3
         Compiling parking_lot v0.12.4
         Compiling objc2-io-kit v0.3.1
         Compiling pyo3 v0.26.0
         Compiling git-version-macro v0.3.9
         Compiling cpufeatures v0.2.17
         Compiling reqwest-middleware v0.4.2
         Compiling xet_runtime v0.1.0 (/Users/rajat/.cache/uv/sdists-v9/pypi/hf-xet/1.1.11b1/uozi8-wYrrSik9zuoLSCa/src/xet_runtime)
         Compiling crossbeam-channel v0.5.15
         Compiling pem v3.0.5
         Compiling reqwest-retry v0.7.0
         Compiling same-file v1.0.6
         Compiling urlencoding v2.1.3
         Compiling signal-hook v0.3.18
         Compiling walkdir v2.5.0
         Compiling git-version v0.3.9
         Compiling jsonwebtoken v9.3.1
         Compiling cas_client v0.14.5 (/Users/rajat/.cache/uv/sdists-v9/pypi/hf-xet/1.1.11b1/uozi8-wYrrSik9zuoLSCa/src/cas_client)
         Compiling tracing-appender v0.2.3
         Compiling sha2 v0.10.9
         Compiling sysinfo v0.37.0
         Compiling ulid v1.2.1
         Compiling signal-hook-registry v1.4.6
         Compiling unindent v0.2.4
         Compiling indoc v2.0.6
         Compiling xet_logging v0.14.5 (/Users/rajat/.cache/uv/sdists-v9/pypi/hf-xet/1.1.11b1/uozi8-wYrrSik9zuoLSCa/src/xet_logging)
      error: git describe exited with status 128: fatal: invalid gitfile format: /Users/rajat/.cache/uv/sdists-v9/.git
        --> /Users/rajat/.cache/uv/sdists-v9/pypi/hf-xet/1.1.11b1/uozi8-wYrrSik9zuoLSCa/src/xet_logging/src/logging.rs:51:53
         |
      51 |     info!("{}, xet-core revision {}", &cfg.version, git_version::git_version!());
         |                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
         |
         = note: this error originates in the macro `git_version::git_version` (in Nightly builds, run with -Z macro-backtrace for more info)

      error: could not compile `xet_logging` (lib) due to 1 previous error
      warning: build failed, waiting for other jobs to finish...
      💥 maturin failed
        Caused by: Failed to build a native library through cargo
        Caused by: Cargo build finished with "exit status: 101": `env -u CARGO MACOSX_DEPLOYMENT_TARGET="11.0" PYO3_BUILD_EXTENSION_MODULE="1"
      PYO3_ENVIRONMENT_SIGNATURE="cpython-3.14-64bit" PYO3_PYTHON="/Users/rajat/.cache/uv/builds-v0/.tmpH8zWNh/bin/python"
      PYTHON_SYS_EXECUTABLE="/Users/rajat/.cache/uv/builds-v0/.tmpH8zWNh/bin/python" "cargo" "rustc"
      "--features" "pyo3/extension-module" "--message-format" "json-render-diagnostics" "--manifest-path"
      "/Users/rajat/.cache/uv/sdists-v9/pypi/hf-xet/1.1.11b1/uozi8-wYrrSik9zuoLSCa/src/hf_xet/Cargo.toml" "--release" "--lib" "--" "-C"
      "link-arg=-undefined" "-C" "link-arg=dynamic_lookup" "-C" "link-args=-Wl,-install_name,@rpath/hf_xet.abi3.so"`
      Error: command ['maturin', 'pep517', 'build-wheel', '-i', '/Users/rajat/.cache/uv/builds-v0/.tmpH8zWNh/bin/python', '--compatibility', 'off']
      returned non-zero exit status 1
```