### PR TITLE
Update git-xet brew installation instruction

### DIFF
--- a/git_xet/README.md
+++ b/git_xet/README.md
@@ -8,6 +8,7 @@ Make sure you have [git](https://git-scm.com/downloads) and [git-lfs](https://gi
    ```
    brew tap huggingface/tap
    brew install git-xet
+   git-xet install
    ```
  Or, using an installation script, run the following in your terminal (requires `curl` and `unzip`):
    ```


### PR DESCRIPTION
Users need to run `git-xet install` after `brew install git-xet`. This instruction is printed out at the end of the `brew install git-xet` step but people may not pay attention to that.