### PR TITLE
Force cas_client to only use http1 when uploading/downloading

### DIFF
--- a/cas_client/src/http_client.rs
+++ b/cas_client/src/http_client.rs
@@ -104,6 +104,7 @@ fn reqwest_client() -> Result<reqwest::Client, CasClientError> {
             reqwest::Client::builder()
                 .pool_idle_timeout(*CLIENT_IDLE_CONNECTION_TIMEOUT)
                 .pool_max_idle_per_host(*CLIENT_MAX_IDLE_CONNECTIONS)
+                .http1_only() // high throughput parallel I/O has been shown to bottleneck with http2
                 .build()
         })?;
 


### PR DESCRIPTION
While investigating perf issues server-side, our usage of http2 with internal systems led to a throughput bottleneck as all requests would get multiplexed on a single connection. CAS (and the backing S3 storage) are designed to be able to accept/produce large volumes of data that should be spread across multiple connections (see [S3 perf considerations](https://docs.aws.amazon.com/AmazonS3/latest/userguide/optimizing-performance-guidelines.html#optimizing-performance-guidelines-scale)). Although there are changes going into the backend services to ensure http1.1 communication (i.e. to spread requests across separate connections), it would be good to also have cas_client only use http1.1 when uploading and downloading to maximize network throughput.