### PR TITLE
add a way to enable chunk cache in hf-xet

### DIFF
--- a/cas_client/src/lib.rs
+++ b/cas_client/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-pub use chunk_cache::{CHUNK_CACHE_SIZE_BYTES, CacheConfig};
+pub use chunk_cache::{CHUNK_CACHE_SIZE_BYTES, CacheConfig, ENABLE_CHUNK_CACHE_OVERRIDE};
 pub use http_client::{Api, ResponseErrorLogger, RetryConfig, build_auth_http_client, build_http_client};
 pub use interface::Client;
 #[cfg(not(target_family = "wasm"))]

--- a/chunk_cache/src/lib.rs
+++ b/chunk_cache/src/lib.rs
@@ -16,6 +16,8 @@ pub use crate::disk::DEFAULT_CHUNK_CACHE_CAPACITY;
 
 utils::configurable_constants! {
     ref CHUNK_CACHE_SIZE_BYTES: u64 = DEFAULT_CHUNK_CACHE_CAPACITY;
+
+    ref ENABLE_CHUNK_CACHE_OVERRIDE: bool = false;
 }
 
 /// Return dto for cache gets


### PR DESCRIPTION
With the change to disable the chunk cache in hf-xet there was no way that was setup to allow users to optionally enable the chunk cache if they want to (I want to do this 😁).

In this PR I add a config env var to override the default behavior in hf-xet and enable the cache.