### PR TITLE
Remove incorrect clippy allow

### DIFF
--- a/git_xet/src/auth/ssh.rs
+++ b/git_xet/src/auth/ssh.rs
@@ -36,7 +36,6 @@ pub struct SSHCredentialHelper {
 }
 
 impl SSHCredentialHelper {
-    #[allow(clippy::new_ret_no_self)]
     pub fn new(remote_url: &GitUrl, operation: Operation) -> Arc<Self> {
         Arc::new(Self {
             remote_url: remote_url.clone(),

--- a/hub_client/src/auth/basics.rs
+++ b/hub_client/src/auth/basics.rs
@@ -9,7 +9,6 @@ use super::CredentialHelper;
 pub struct NoopCredentialHelper {}
 
 impl NoopCredentialHelper {
-    #[allow(clippy::new_ret_no_self)]
     pub fn new() -> Arc<Self> {
         Arc::new(Self {})
     }
@@ -33,7 +32,6 @@ pub struct BearerCredentialHelper {
 }
 
 impl BearerCredentialHelper {
-    #[allow(clippy::new_ret_no_self)]
     pub fn new(hf_token: String, whoami: &'static str) -> Arc<Self> {
         Arc::new(Self {
             hf_token,


### PR DESCRIPTION
The attribute `#[allow(clippy::new_ret_no_self)]` is not appropriate for functions that return `Arc<Self>`.