### PR TITLE
refactor to rewrite shard header with footer_len set to 0

### DIFF
--- a/data/src/shard_interface.rs
+++ b/data/src/shard_interface.rs
@@ -349,6 +349,7 @@ mod tests {
 
     use super::*;
 
+    #[test]
     fn test_read_shard_to_bytes_remove_footer() -> Result<()> {
         let tmp_dir = TempDir::with_prefix("test_read_shard_to_bytes_remove_footer")?;
         let tmp_dir_path = tmp_dir.path();


### PR DESCRIPTION
related to https://github.com/huggingface/xet-core/issues/547

When xet-core uploads the shard the header field where the footer length is specified is set to 200 where it should be 0 according to the specification.

Note: this value is ignored by the server today, but ideally we would set this right since it can be useful to know if there is a footer on the shard when reading the shard as a whole in a non-streaming fashion.