### PR TITLE
Fix hf-xet release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ on:
         description: 'Semantic version for PyPI release (tag will share the same name)'
         required: true
         default: 'v0.1.0'
-  pull_request:
 
 permissions:
   contents: read


### PR DESCRIPTION
hf-xet release workflow has been failing (see the last two commits into `main`) due to outdated package list. This updates the package list before installing a package.

The test trigger commit [e91d821](https://github.com/huggingface/xet-core/pull/586/commits/e91d8215ba54adb4918facb657a73bfe6e55617a) verifies this fix.