### PR TITLE
Add Unix domain socket support for CAS HTTP connections

### DIFF
--- a/hub_client/src/auth/basics.rs
+++ b/hub_client/src/auth/basics.rs
@@ -46,6 +46,12 @@ impl CredentialHelper for BearerCredentialHelper {
         Ok(req.bearer_auth(&self.hf_token))
     }
 
+    fn fill_headers(&self, headers: &mut reqwest::header::HeaderMap) {
+        if let Ok(value) = format!("Bearer {}", self.hf_token).parse() {
+            headers.insert(reqwest::header::AUTHORIZATION, value);
+        }
+    }
+
     fn whoami(&self) -> &str {
         self._whoami
     }

--- a/hub_client/src/auth/interface.rs
+++ b/hub_client/src/auth/interface.rs
@@ -5,6 +5,12 @@ use reqwest_middleware::RequestBuilder;
 #[async_trait]
 pub trait CredentialHelper: Send + Sync {
     async fn fill_credential(&self, req: RequestBuilder) -> Result<RequestBuilder>;
+
+    /// Fill credentials into a HeaderMap (for Unix socket requests).
+    fn fill_headers(&self, headers: &mut reqwest::header::HeaderMap) {
+        let _ = headers; // Default implementation does nothing
+    }
+
     // Used in tests to identify the source of the credential.
     fn whoami(&self) -> &str;
 }

--- a/xet_config/src/groups/client.rs
+++ b/xet_config/src/groups/client.rs
@@ -299,4 +299,13 @@ crate::config_group!({
     /// Use the environment variable `HF_XET_CLIENT_AC_INITIAL_DOWNLOAD_CONCURRENCY` to set this value.
     ref ac_initial_download_concurrency: usize = 1;
 
+    /// Path to Unix domain socket for CAS HTTP connections.
+    /// When set, all CAS HTTP traffic uses this socket instead of TCP.
+    /// Only supported on Linux/macOS (not WASM).
+    ///
+    /// The default value is None (use TCP).
+    ///
+    /// Use the environment variable `HF_XET_CLIENT_UNIX_SOCKET_PATH` to set this value.
+    ref unix_socket_path: Option<String> = None;
+
 });


### PR DESCRIPTION
Support `HF_XET_UNIX_SOCKET=/path/to/socket` to route traffic through a Unix socket instead of TCP.

This is useful when running a XET client in a sandbox that doesn't have direct access to the network.