### PR TITLE
Wait for heed db closing

### DIFF
--- a/cas_client/src/simulation/local_client.rs
+++ b/cas_client/src/simulation/local_client.rs
@@ -160,7 +160,8 @@ impl Drop for LocalClient {
         // allowing the file handles to be released. Without this, the cached
         // environment reference prevents the file descriptors from being closed.
         if let Some(env) = self.global_dedup_db_env.take() {
-            let _closing_event = env.prepare_for_closing();
+            let closing_event = env.prepare_for_closing();
+            closing_event.wait();
         }
     }
 }


### PR DESCRIPTION
Unit test `test_multiple_resume()` contains a loop where each iteration internally opens and closes a heed DB that is used for simulating a global dedup table. If the DB is not fully closed before any call to open it again, an error is returned leading this unit test to fail:

```
thread 'tests::test_multiple_resume' panicked at data/tests/test_session_resume.rs:140:18:
called `Result::unwrap()` on an `Err` value: CasClientError(Other("Error opening db at \"/var/folders/kg/7q73ww8s3llgyl61c9z_j5g40000gn/T/.tmp09NYmC/xet/xorbs/global_dedup_lookup.db\": database is in a closing phase, you can't open it at the same time"))
```
e.g. https://github.com/huggingface/xet-core/actions/runs/21423725203/job/61779697529?pr=617#step:6:1928

This PR actually waits for the DB to close in the simulation client's Drop function.