### PR TITLE
Full fix for session resume test failure.

### DIFF
--- a/data/src/configurations.rs
+++ b/data/src/configurations.rs
@@ -142,6 +142,38 @@ impl TranslatorConfig {
         Ok(translator_config)
     }
 
+    /// Creates a TranslatorConfig that connects to a CAS server at the given endpoint.
+    /// Shard cache and session directories are created under the provided base directory.
+    /// Useful for tests that use LocalTestServer.
+    pub fn test_server_config(endpoint: impl AsRef<str>, base_dir: impl AsRef<Path>) -> Result<Self> {
+        let path = base_dir.as_ref().join("xet");
+        std::fs::create_dir_all(&path)?;
+
+        let translator_config = Self {
+            data_config: DataConfig {
+                endpoint: Endpoint::Server(endpoint.as_ref().to_string()),
+                compression: Default::default(),
+                auth: None,
+                prefix: PREFIX_DEFAULT.into(),
+                staging_directory: None,
+                user_agent: String::new(),
+            },
+            shard_config: ShardConfig {
+                prefix: PREFIX_DEFAULT.into(),
+                cache_directory: path.join("shard-cache"),
+                session_directory: path.join("shard-session"),
+                global_dedup_policy: Default::default(),
+            },
+            repo_info: Some(RepoInfo {
+                repo_paths: vec!["".into()],
+            }),
+            session_id: None,
+            progress_config: ProgressConfig { aggregate: true },
+        };
+
+        Ok(translator_config)
+    }
+
     pub fn disable_progress_aggregation(self) -> Self {
         Self {
             progress_config: ProgressConfig { aggregate: false },

--- a/data/tests/test_session_resume.rs
+++ b/data/tests/test_session_resume.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use cas_client::LocalTestServer;
 // Run tests that determine deduplication, especially across different test subjects.
 use data::FileUploadSession;
 use data::configurations::TranslatorConfig;
@@ -54,10 +55,9 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(0);
         rng.fill(&mut data[..]);
 
-        // Set a temporary directory for the endpoint.
-        let cas_dir = TempDir::new().unwrap();
-
-        let config = Arc::new(TranslatorConfig::local_config(cas_dir).unwrap());
+        let server = LocalTestServer::start(true).await;
+        let shard_base = TempDir::new().unwrap();
+        let config = Arc::new(TranslatorConfig::test_server_config(server.endpoint(), shard_base.path()).unwrap());
 
         {
             let progress_tracker = AggregatingProgressUpdater::new_aggregation_only();
@@ -126,10 +126,9 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(0);
         rng.fill(&mut data[..]);
 
-        // Set a temporary directory for the endpoint.
-        let cas_dir = TempDir::new().unwrap();
-
-        let config = Arc::new(TranslatorConfig::local_config(cas_dir).unwrap());
+        let server = LocalTestServer::start(true).await;
+        let shard_base = TempDir::new().unwrap();
+        let config = Arc::new(TranslatorConfig::test_server_config(server.endpoint(), shard_base.path()).unwrap());
 
         let mut prev_rn = 0;
 


### PR DESCRIPTION
There is an issue in main where test_multiple_resume fails due to a LocalClient trying to open a database tied to a directory at the same time another client is dropping that database on the same thread.  This fixes it by switching to LocalTestServer that is persistent through the whole test. 