### PR TITLE
Bake in openssl for git-xet macOS built in Github Action

### DIFF
--- a/.github/workflows/git-xet-release.yml
+++ b/.github/workflows/git-xet-release.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: ./.github/actions/cache-rust-build
       - name: Build
         run: |
-          cargo build --release
+          cargo build --release --features "git2-vendored-openssl"
           mkdir dist
           cp target/release/git-xet dist/
           cp git_xet/entitlements.xml dist/

--- a/git_xet/Cargo.toml
+++ b/git_xet/Cargo.toml
@@ -36,6 +36,7 @@ serial_test = { workspace = true }
 
 [features]
 git-xet-for-integration-test = []
+git2-vendored-openssl = ["git2/vendored-openssl"]
 
 # tell cargo-machete a renamed crate
 [package.metadata.cargo-machete.renamed]


### PR DESCRIPTION
Fix issue https://github.com/huggingface/xet-core/issues/621. Fix XET-819.

The script https://github.com/huggingface/xet-core/blob/main/git_xet/install.sh installs the git-xet built in Github Actions, and when git-xet is built for macOS it is linked to `homebrew/openssl@3` because the `git2` crate depends on openssl. For users who don't have homebrew and `homebrew/openssl` installed (so why would prefer the installation script) running this git-xet on their system immediately crashes.

This PR 
- adds a feature "git2-vendored-openssl" that enables "git2/vendored-openssl" which bakes openssl statically into git-xet,
- updates Github Actions CI to build git-xet with this feature for macOS version.

This would increase the git-xet binary size from ~9MB to ~13MB and drops the `homebrew/openssl` linkage (comparing output of `otool -L git-xet`, left is from `git-xet` before this change):
<img width="1456" height="390" alt="Screenshot 2026-01-28 at 3 33 39 PM" src="https://github.com/user-attachments/assets/5c779d78-a042-45d8-99e5-95394db6e774" />

The homebrew official bottles for git-xet will not be affected and still uses `hombrew/openssl` because they build from source code (the above feature not enabled).