### PR TITLE
Fix wheel pack renaming issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ on:
         description: 'Semantic version for PyPI release (tag will share the same name)'
         required: true
         default: 'v0.1.0'
-  pull_request:
 
 permissions:
   contents: read


### PR DESCRIPTION
When we `wheel unpack` a wheel to strip debug symbols and then `wheel pack` to re-pack the wheel, the result wheel name can be different from that of the one generated by `maturin build`, leading to two wheel files published to PyPI for one Python-platform combination.

For example, in our `hf-xet-1.2.1` [release](https://pypi.org/project/hf-xet/1.2.1/#files) there are two files both correspond to Python tag `cp37`, ABI tag `abi3`, and platform tags `manylinux_2_17_x86_64` & `manylinux2014_x86_64`, only that the order of the platform tags are switched by `wheel pack`:
<img width="720" height="146" alt="Screenshot 2026-01-29 at 12 23 33 PM" src="https://github.com/user-attachments/assets/f7cd670a-0b63-4687-867a-8963f3e5bbcd" />
Depends on their package manager version, people may accidentally install the larger wheel.

We only want to publish one wheel for a specific Python-platform combination, so removing all wheels before re-packing.