### PR TITLE
Change default download buffer size

### DIFF
--- a/xet_config/src/groups/reconstruction.rs
+++ b/xet_config/src/groups/reconstruction.rs
@@ -23,10 +23,10 @@ crate::config_group!({
     /// The maximum amount of data that can be buffered in flight during file reconstruction.
     /// This controls memory usage by limiting how much data can be downloaded but not yet written.
     ///
-    /// The default value is 8GB.
+    /// The default value is 2GB.
     ///
     /// Use the environment variable `HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_SIZE` to set this value.
-    ref download_buffer_size: ByteSize = ByteSize::from("8gb");
+    ref download_buffer_size: ByteSize = ByteSize::from("2gb");
 
     /// The basic unit of data acquired in a permit for the download buffer.  Because the underlying unit in the
     /// Mutex supporting this is a u32, this requires us to measure size in larger values than bytes.


### PR DESCRIPTION
Reduces the default download buffer size to a more friendly number.

### Benchmark ###
Download benchmark with different default memory configs on three scenarios:
• Comparable disk write speed and network ingress speed (i4i.xlarge, up to 10 Gbps ingress, stable 550 MB/s write SSD)
• Faster disk write (i4i.xlarge, ingress limited to 1 Gbps using "tc" command, stable 550 MB/s write SSD)
• Faster network ingress (m5d.xlarge, up to 10 Gbps ingress, stable 150 MB/s write SSD)

Benchmark results are at https://docs.google.com/spreadsheets/d/1ozpk0kU7uM8SGODXxXtXQauc3l5CEoWG/edit?usp=sharing&ouid=108235600614994105911&rtpof=true&sd=true, implying no substantial improvement with buffer size over 2 GB, with the default download parallelism of 8 set by huggingface-hub. Setting total download buffer size to 8GB gives each parallel download task in average `2 GB / 8 = 256 MB` pending bytes to write, or `256 MB / 64 MB = 4` or even more pending terms if the network speed is comparable to that of the disk, and keeps the disk writer always busy.

