### PR TITLE
Fix writev exceeding limits

### DIFF
--- a/file_reconstruction/src/data_writer/sequential_writer.rs
+++ b/file_reconstruction/src/data_writer/sequential_writer.rs
@@ -20,10 +20,9 @@ use crate::{ErrorState, FileReconstructionError, Result};
 //  system call failed because this limit was exceeded. The wrapper function would allocate a temporary buffer large
 //  enough for all of the items specified by iov, copies data from iov to this buffer, and passes the buffer in a
 //  call to write().
-// To avoid these potential syscall failures or performance degradation, we put a limit on the sum of the iov_len values
-// in the iov array and on iovcnt.
-const WRITEV_MAX_BYTES: usize = 1024 * 1024 * 1024; // 1 GB
-const WRITEV_MAX_SLICE: usize = 128;
+// To avoid these potential syscall failures or performance degradation, we limit iovcnt to 24. Given our max Xorb size
+// 64 MiB, this effectively limits total number of bytes in iov to 64 MiB * 24 = 1.5 GiB.
+const WRITEV_MAX_SLICE: usize = 24;
 
 /// Items sent to the background writer thread.
 enum QueueItem {
@@ -130,7 +129,7 @@ impl<W: Write + Send + 'static> WriterThread<W> {
     }
 
     /// Run the vectorized writer loop.
-    fn run_vectorized(mut self, writev_max_bytes: usize, writev_max_slice: usize) -> Result<()> {
+    fn run_vectorized(mut self) -> Result<()> {
         let mut pending_writes: VecDeque<PendingWrite> = VecDeque::new();
 
         while !self.finished || !pending_writes.is_empty() {
@@ -151,14 +150,9 @@ impl<W: Write + Send + 'static> WriterThread<W> {
             }
 
             // Build IoSlice vector from all pending writes.
-            let mut total_to_writev = 0;
             let io_slices: Vec<IoSlice<'_>> = pending_writes
                 .iter()
-                .take(writev_max_slice)
-                .take_while(|(data, _)| {
-                    total_to_writev += data.len();
-                    total_to_writev <= writev_max_bytes
-                })
+                .take(WRITEV_MAX_SLICE)
                 .map(|(data, _)| IoSlice::new(data))
                 .collect();
 
@@ -350,7 +344,7 @@ impl SequentialWriter {
     /// The writer type `W` can be any type implementing `Write + Send + 'static`.
     /// The writer is moved to a background thread for blocking I/O operations.
     pub fn new<W: Write + Send + 'static>(writer: W) -> Self {
-        Self::new_internal(writer, false, 0, 0)
+        Self::new_internal(writer, false)
     }
 
     /// Creates a new sequential writer that uses vectorized writes (write_vectored).
@@ -367,24 +361,10 @@ impl SequentialWriter {
     /// The writer is moved to a background thread for blocking I/O operations.
     pub fn new_vectorized<W: Write + Send + 'static>(writer: W) -> Self {
         // with default limits for Linux and macOS
-        Self::new_internal(writer, true, WRITEV_MAX_BYTES, WRITEV_MAX_SLICE)
+        Self::new_internal(writer, true)
     }
 
-    #[cfg(test)]
-    fn new_vectorized_with_config<W: Write + Send + 'static>(
-        writer: W,
-        writev_max_bytes: usize,
-        writev_max_slice: usize,
-    ) -> Self {
-        Self::new_internal(writer, true, writev_max_bytes, writev_max_slice)
-    }
-
-    fn new_internal<W: Write + Send + 'static>(
-        writer: W,
-        use_vectorized: bool,
-        writev_max_bytes: usize,
-        writev_max_slice: usize,
-    ) -> Self {
+    fn new_internal<W: Write + Send + 'static>(writer: W, use_vectorized: bool) -> Self {
         let (tx, rx) = unbounded_channel::<QueueItem>();
         let error_state = Arc::new(ErrorState::new());
         let bytes_written = Arc::new(AtomicU64::new(0));
@@ -395,7 +375,7 @@ impl SequentialWriter {
         let handle = XetRuntime::current().spawn_blocking(move || {
             let writer_thread = WriterThread::new(rx, writer, bytes_written_clone);
             let result = if use_vectorized {
-                writer_thread.run_vectorized(writev_max_bytes, writev_max_slice)
+                writer_thread.run_vectorized()
             } else {
                 writer_thread.run()
             };
@@ -448,9 +428,6 @@ mod tests {
         max_write_size: Option<usize>,
         /// Maximum bytes to write per write_vectored call, a call exceeding this limit triggers partial writes.
         max_vectored_write_size: Option<usize>,
-        /// Hard limit maximum bytes to write per write_vectored call, a call exceeding this limit returns InvalidInput
-        /// error.
-        hard_limit_vectored_write_bytes: Option<usize>,
         /// Hard limit maximum number of slices per write_vectored call, a call exceeding this limit returns
         /// InvalidInput error.
         hard_limit_vectored_write_slice: Option<usize>,
@@ -472,9 +449,8 @@ mod tests {
             }
         }
 
-        fn vectorized_hard_limit(max_bytes: usize, max_slice: usize) -> Self {
+        fn vectorized_hard_limit(max_slice: usize) -> Self {
             Self {
-                hard_limit_vectored_write_bytes: Some(max_bytes),
                 hard_limit_vectored_write_slice: Some(max_slice),
                 ..Default::default()
             }
@@ -555,12 +531,6 @@ mod tests {
                 && bufs.len() > max_slice
             {
                 return Err(io::Error::new(io::ErrorKind::InvalidInput, "simulated iovcnt EINVAL"));
-            }
-
-            if let Some(max_bytes) = self.config.hard_limit_vectored_write_bytes
-                && bufs.iter().fold(0usize, |sum, data| sum + data.len()) > max_bytes
-            {
-                return Err(io::Error::new(io::ErrorKind::InvalidInput, "simulated iov EINVAL"));
             }
 
             self.vectored_write_count.fetch_add(1, Ordering::Relaxed);
@@ -1227,9 +1197,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_vectorized_exceeded_max_slice() {
-        let test_writer = TestWriter::new(TestWriterConfig::vectorized_hard_limit(20000, 2)); // hard limit set to 2 slices at a time
+        let test_writer = TestWriter::new(TestWriterConfig::vectorized_hard_limit(2)); // hard limit set to 2 slices at a time
 
-        let writer = Arc::new(SequentialWriter::new_vectorized_with_config(Box::new(test_writer), 20000, 20)); // controlled writev at max 20 slices at a time
+        let writer = Arc::new(SequentialWriter::new_vectorized(Box::new(test_writer))); // controlled writev at max 24 slices at a time
 
         // Write in slices of 10 bytes, creating in total 1000 slices
         for i in 0..1000 {
@@ -1259,75 +1229,15 @@ mod tests {
     #[tokio::test]
     async fn test_vectorized_controlled_max_slice() {
         let expected: Vec<u8> = (0..10000).map(|i| (i % 256) as u8).collect();
-        let test_writer = TestWriter::new(TestWriterConfig::vectorized_hard_limit(20000, 2)); // hard limit set to 2 slices at a time
+        let test_writer = TestWriter::new(TestWriterConfig::vectorized_hard_limit(40)); // hard limit set to 40 slices at a time
         let buffer = test_writer.buffer.clone();
 
-        let writer = Arc::new(SequentialWriter::new_vectorized_with_config(Box::new(test_writer), 20000, 2)); // controlled writev at max 2 slices at a time
+        let writer = Arc::new(SequentialWriter::new_vectorized(Box::new(test_writer))); // controlled writev at max 24 slices at a time
 
         // Write in slices of 10 bytes, creating in total 1000 slices
         for i in 0..1000 {
             let start = i * 10;
             let end = start + 10;
-            let chunk: Vec<u8> = (start..end).map(|j| (j % 256) as u8).collect();
-            writer
-                .set_next_term_data_source(
-                    FileRange::new(start as u64, end as u64),
-                    None,
-                    immediate_future(Bytes::from(chunk)),
-                )
-                .await
-                .unwrap();
-        }
-
-        writer.finish().await.unwrap();
-
-        let result = buffer.lock().unwrap();
-        assert_eq!(&*result, &expected);
-    }
-
-    #[tokio::test]
-    async fn test_vectorized_exceeded_max_bytes() {
-        let test_writer = TestWriter::new(TestWriterConfig::vectorized_hard_limit(2000, 100)); // hard limit set to 2000 bytes at a time
-
-        let writer = Arc::new(SequentialWriter::new_vectorized_with_config(Box::new(test_writer), 20000, 100)); // controlled writev at max 20000 bytes at a time
-
-        // Write in slices of 1000 bytes, creating in total 10 slices
-        for i in 0..10 {
-            let start = i * 1000;
-            let end = start + 1000;
-            let chunk: Vec<u8> = (start..end).map(|j| (j % 256) as u8).collect();
-            if writer
-                .set_next_term_data_source(
-                    FileRange::new(start as u64, end as u64),
-                    None,
-                    immediate_future(Bytes::from(chunk)),
-                )
-                .await
-                .is_err()
-            {
-                break;
-            }
-        }
-
-        let ret = writer.finish().await;
-        assert!(ret.is_err());
-        if let Err(FileReconstructionError::IoError(inner_err)) = ret {
-            assert_eq!(inner_err.kind(), std::io::ErrorKind::InvalidInput);
-        };
-    }
-
-    #[tokio::test]
-    async fn test_vectorized_controlled_max_bytes() {
-        let expected: Vec<u8> = (0..10000).map(|i| (i % 256) as u8).collect();
-        let test_writer = TestWriter::new(TestWriterConfig::vectorized_hard_limit(2000, 100)); // hard limit set to 2000 bytes at a time
-        let buffer = test_writer.buffer.clone();
-
-        let writer = Arc::new(SequentialWriter::new_vectorized_with_config(Box::new(test_writer), 2000, 100)); // controlled writev at max 2000 bytes at a time
-
-        // Write in slices of 1000 bytes, creating in total 10 slices
-        for i in 0..10 {
-            let start = i * 1000;
-            let end = start + 1000;
             let chunk: Vec<u8> = (start..end).map(|j| (j % 256) as u8).collect();
             writer
                 .set_next_term_data_source(


### PR DESCRIPTION
On macOS and Linux, `writev(int fildes, const struct iovec *iov, int iovcnt)` may return EINVAL if
- the sum of the iov_len values in the iov array overflows a 32-bit integer (macOS) or an ssize_t value (Linux);
- iovcnt is less than or equal to 0, or greater than UIO_MAXIOV (POSIX standard IOV_MAX, value 1024); and specially on Linux, the glibc wrapper functions do some extra work if they detect that the underlying kernel system call failed because this limit was exceeded. The wrapper function would allocate a temporary buffer large enough for all of the items specified by iov, copies data from iov to this buffer, and passes the buffer in a call to write().

To avoid these potential syscall failures or performance degradation, we put a limit on the total number of bytes and number of slices to call `writev()`. Also adding unit tests for these two limits.

Fix https://github.com/huggingface/xet-core/issues/604, fix XET-813. Special thanks to @volodymyrjf for the investigation.