### PR TITLE
Add Windows ARM64 build support

### DIFF
--- a/.github/workflows/git-xet-release.yml
+++ b/.github/workflows/git-xet-release.yml
@@ -84,7 +84,7 @@ jobs:
           - runner: windows-latest
             target: x86_64
             wix_arch: x64
-          - runner: win11-arm
+          - runner: windows-11-arm
             target: aarch64
             wix_arch: arm64
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,7 +213,7 @@ jobs:
           - runner: windows-latest
             target: x64
             rust_target: x86_64-pc-windows-msvc
-          - runner: win11-arm
+          - runner: windows-11-arm
             target: aarch64
             rust_target: aarch64-pc-windows-msvc
         python-version:


### PR DESCRIPTION
## Summary

Closes #588

- Add `win11-arm` runner with `aarch64-pc-windows-msvc` target to the hf-xet Python wheel release pipeline
- Add `win11-arm` runner with `aarch64` target to the git-xet CLI release pipeline, parameterizing the WiX installer `-arch` flag

## Test plan

- [x] Trigger a workflow_dispatch run of the Release workflow and verify `windows` matrix includes both `x64` and `aarch64` entries
- [x] Verify ARM64 wheels and .pdb debug symbols are built and uploaded
- [ ] Trigger a workflow_dispatch run of the git-xet Release workflow and verify ARM64 binary and MSI installer are produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)