### PR TITLE
Don't build shellexpand in wasm

### DIFF
--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -25,7 +25,6 @@ futures = { workspace = true }
 lazy_static = { workspace = true }
 pin-project = { workspace = true }
 serde = { workspace = true }
-shellexpand = { workspace = true, features = ["path"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = [
     "time",
@@ -39,6 +38,7 @@ tracing = { workspace = true }
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 bincode = { workspace = true }
 rand = { workspace = true }
+shellexpand = { workspace = true, features = ["path"] }
 tokio-util = { workspace = true, features = ["io"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]


### PR DESCRIPTION
Crate `shellexpand` seems to be not compatible with the nightly toolchain: https://github.com/huggingface/xet-core/actions/runs/22319509143/job/64573656769
This should fix the WASM build error on the main branch and in https://github.com/huggingface/xet-core/pull/661 and https://github.com/huggingface/xet-core/pull/662

Will revisit whether to drop the nightly toolchain requirement from WASM build in the future.