### PR TITLE
Allow deduplication to be turned off completely for a given file.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,7 +1077,9 @@ dependencies = [
  "more-asserts",
  "progress_tracking",
  "rand 0.9.1",
+ "tokio",
  "utils",
+ "xet_config",
  "xet_runtime",
 ]
 

--- a/data/src/file_cleaner.rs
+++ b/data/src/file_cleaner.rs
@@ -50,7 +50,11 @@ impl SingleFileCleaner {
         sha256: Option<Sha256>,
         session: Arc<FileUploadSession>,
     ) -> Self {
-        let deduper = FileDeduper::new(UploadSessionDataManager::new(session.clone()), file_id);
+        let deduper = FileDeduper::new(
+            UploadSessionDataManager::new(session.clone()),
+            file_id,
+            xet_config().deduplication.clone(),
+        );
 
         Self {
             file_name,

--- a/deduplication/Cargo.toml
+++ b/deduplication/Cargo.toml
@@ -9,6 +9,7 @@ mdb_shard = { path = "../mdb_shard" }
 merklehash = { path = "../merklehash" }
 progress_tracking = { path = "../progress_tracking" }
 utils = { path = "../utils" }
+xet_config = { path = "../xet_config" }
 
 async-trait = { workspace = true }
 bytes = { workspace = true }
@@ -18,3 +19,4 @@ lazy_static = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true }
+tokio = { workspace = true, features = ["rt", "macros"] }

--- a/hf_xet/Cargo.lock
+++ b/hf_xet/Cargo.lock
@@ -806,6 +806,7 @@ dependencies = [
  "more-asserts",
  "progress_tracking",
  "utils",
+ "xet_config",
  "xet_runtime",
 ]
 

--- a/hf_xet_thin_wasm/Cargo.lock
+++ b/hf_xet_thin_wasm/Cargo.lock
@@ -344,6 +344,7 @@ dependencies = [
  "more-asserts",
  "progress_tracking",
  "utils",
+ "xet_config",
  "xet_runtime",
 ]
 

--- a/hf_xet_wasm/Cargo.lock
+++ b/hf_xet_wasm/Cargo.lock
@@ -648,6 +648,7 @@ dependencies = [
  "more-asserts",
  "progress_tracking",
  "utils",
+ "xet_config",
  "xet_runtime",
 ]
 
@@ -1163,6 +1164,7 @@ dependencies = [
  "wasm-bindgen-test",
  "wasm_thread",
  "web-sys",
+ "xet_runtime",
 ]
 
 [[package]]

--- a/hf_xet_wasm/Cargo.toml
+++ b/hf_xet_wasm/Cargo.toml
@@ -14,6 +14,7 @@ mdb_shard = { path = "../mdb_shard" }
 merklehash = { path = "../merklehash" }
 progress_tracking = { path = "../progress_tracking" }
 utils = { path = "../utils" }
+xet_runtime = { path = "../xet_runtime" }
 
 async-trait = "0.1"
 bytes = "1.11"

--- a/hf_xet_wasm/src/wasm_file_cleaner.rs
+++ b/hf_xet_wasm/src/wasm_file_cleaner.rs
@@ -5,6 +5,7 @@ use mdb_shard::file_structs::FileMetadataExt;
 use merklehash::MerkleHash;
 use tokio::sync::mpsc;
 use tokio_with_wasm::alias as wasmtokio;
+use xet_runtime::xet_config;
 
 use super::errors::*;
 use super::wasm_deduplication_interface::UploadSessionDataManager;
@@ -71,7 +72,7 @@ impl SingleFileCleaner {
             _file_id: file_id,
             session: session.clone(),
             cpu_task: CPUTask::CurrentThread((Chunker::default(), ShaGeneration::new(sha256))),
-            dedup_manager: FileDeduper::new(UploadSessionDataManager::new(session), file_id),
+            dedup_manager: FileDeduper::new(UploadSessionDataManager::new(session), file_id, xet_config().deduplication.clone()),
         }
     }
 
@@ -109,7 +110,7 @@ impl SingleFileCleaner {
             _file_id: file_id,
             session: session.clone(),
             cpu_task,
-            dedup_manager: FileDeduper::new(UploadSessionDataManager::new(session), file_id),
+            dedup_manager: FileDeduper::new(UploadSessionDataManager::new(session), file_id, xet_config().deduplication.clone()),
         }
     }
 

--- a/xet_config/src/groups/deduplication.rs
+++ b/xet_config/src/groups/deduplication.rs
@@ -1,4 +1,9 @@
 crate::config_group!({
+    /// Enable deduplication; if false, then deduplication is disabled.  Note that
+    /// this may result in significantly higher data and memory usage.
+    ref enable_deduplication: bool = true;
+
+
     /// Number of ranges to use when estimating fragmentation
     ///
     /// The default value is 128.
@@ -17,6 +22,7 @@ crate::config_group!({
     ///
     /// Use the environment variable `HF_XET_DEDUPLICATION_MIN_N_CHUNKS_PER_RANGE_HYSTERESIS_FACTOR` to set this value.
     ref min_n_chunks_per_range_hysteresis_factor: f32 = 0.5;
+
     /// Minimum number of chunks per range.
     ///
     /// The default value is 8.0.


### PR DESCRIPTION
This PR adds in the ability to turn of deduplication entirely using a config setting.  Default behavior hasn't changed. 