### PR TITLE
Pass file size to FileReconstructor to avoid spurious 416 errors

### DIFF
--- a/data/src/file_download_session.rs
+++ b/data/src/file_download_session.rs
@@ -225,7 +225,7 @@ impl FileDownloadSession {
             task
         });
 
-        let mut reconstructor = FileReconstructor::new(&self.client, file_id);
+        let mut reconstructor = FileReconstructor::new(&self.client, file_id).with_file_size(file_info.file_size());
 
         if let Some(range) = range {
             reconstructor = reconstructor.with_byte_range(range);

--- a/file_reconstruction/src/file_reconstructor.rs
+++ b/file_reconstruction/src/file_reconstructor.rs
@@ -41,6 +41,10 @@ pub struct FileReconstructor {
 
     /// Optional on-disk chunk cache for xorb data deduplication across files.
     chunk_cache: Option<Arc<dyn ChunkCache>>,
+
+    /// Known file size used to bound the reconstruction range for full-file downloads.
+    /// Prevents speculative prefetch blocks from requesting ranges beyond EOF.
+    file_size: Option<u64>,
 }
 
 impl FileReconstructor {
@@ -54,6 +58,7 @@ impl FileReconstructor {
             custom_buffer_semaphore: None,
             cancellation_token: CancellationToken::new(),
             chunk_cache: None,
+            file_size: None,
         }
     }
 
@@ -94,6 +99,13 @@ impl FileReconstructor {
     pub fn with_cancellation_token(self, token: CancellationToken) -> Self {
         Self {
             cancellation_token: token,
+            ..self
+        }
+    }
+
+    pub fn with_file_size(self, file_size: u64) -> Self {
+        Self {
+            file_size: Some(file_size),
             ..self
         }
     }
@@ -202,6 +214,7 @@ impl FileReconstructor {
         let Self {
             client,
             byte_range,
+            file_size,
             config,
             custom_buffer_semaphore,
             chunk_cache,
@@ -211,7 +224,10 @@ impl FileReconstructor {
         run_state.check_run_state()?;
 
         let file_hash = *run_state.file_hash();
-        let requested_range = byte_range.unwrap_or_else(FileRange::full);
+        let requested_range = byte_range.unwrap_or_else(|| match file_size {
+            Some(s) => FileRange::new(0, s),
+            None => FileRange::full(),
+        });
 
         let mut term_manager = ReconstructionTermManager::new(
             config.clone(),


### PR DESCRIPTION
## Summary

- Add `file_size: Option<u64>` field + `with_file_size()` builder to `FileReconstructor`
- Use it to bound `requested_range` for full-file downloads instead of `FileRange::full()` (0..u64::MAX)
- Chain `.with_file_size(file_info.file_size())` in `FileDownloadSession::setup_reconstructor`

This prevents `ReconstructionTermManager` from speculatively prefetching blocks beyond EOF, which caused the CAS server to return 416 Range Not Satisfiable for small files. The retry_wrapper logged this as `ERROR "Fatal Error"` before `remote_client` silently converted it to `Ok(None)`.