### PR TITLE
feat: accept pre-computed SHA-256 in upload_files()

### DIFF
--- a/hf_xet/src/lib.rs
+++ b/hf_xet/src/lib.rs
@@ -141,14 +141,14 @@ pub fn upload_files(
     request_headers: Option<HashMap<String, String>>,
     sha256s: Option<Vec<String>>,
 ) -> PyResult<Vec<PyXetUploadInfo>> {
-    if let Some(ref s) = sha256s {
-        if s.len() != file_paths.len() {
-            return Err(PyRuntimeError::new_err(format!(
-                "sha256s length ({}) must match file_paths length ({})",
-                s.len(),
-                file_paths.len()
-            )));
-        }
+    if let Some(ref s) = sha256s
+        && s.len() != file_paths.len()
+    {
+        return Err(PyRuntimeError::new_err(format!(
+            "sha256s length ({}) must match file_paths length ({})",
+            s.len(),
+            file_paths.len()
+        )));
     }
 
     let refresher = token_refresher.map(WrappedTokenRefresher::from_func).transpose()?.map(Arc::new);


### PR DESCRIPTION
## Summary

- Add optional `sha256s` keyword parameter to the Python-exposed `upload_files()` function
- Forward it to `data_client::upload_async()` which already supports it

## Context

### Double computation today

`huggingface_hub` computes SHA-256 on every file during `CommitOperationAdd.__post_init__()` for LFS batch negotiation, then `hf_xet` recomputes it internally because `upload_files()` doesn't accept pre-computed hashes.

### Performance impact

This change eliminates the redundant computation entirely.

### Backward compatibility

- `sha256s` is a keyword-only parameter with default `None` — no change for existing callers
- `data_client::upload_async()` already accepts `sha256s: Option<Vec<String>>` since day one
- When provided, `SingleFileCleaner` uses `ShaGenerator::ProvidedValue` and skips internal recomputation

Companion PR: huggingface/huggingface_hub#3876