### PR TITLE
fix: prevent panic in FileTerm::extract_bytes on runtime shutdown

### DIFF
--- a/file_reconstruction/src/reconstruction_terms/file_term.rs
+++ b/file_reconstruction/src/reconstruction_terms/file_term.rs
@@ -27,14 +27,27 @@ pub struct FileTerm {
 }
 
 impl FileTerm {
-    pub fn extract_bytes(&self, xorb_block_data: &XorbBlockData) -> Bytes {
+    pub fn extract_bytes(&self, xorb_block_data: &XorbBlockData) -> Result<Bytes> {
         let local_start_chunk = (self.xorb_chunk_range.start - self.xorb_block.chunk_range.start) as usize;
         let start_byte_offset = xorb_block_data.chunk_offsets[local_start_chunk];
         let start_byte_offset = start_byte_offset + self.offset_into_first_range as usize;
         let expected_size = (self.byte_range.end - self.byte_range.start) as usize;
         let end_byte_offset = start_byte_offset + expected_size;
 
-        xorb_block_data.data.slice(start_byte_offset..end_byte_offset)
+        if end_byte_offset > xorb_block_data.data.len() {
+            return Err(FileReconstructionError::CorruptedReconstruction(format!(
+                "extract_bytes: range {}..{} out of bounds for xorb data of size {} \
+                 (xorb={:?}, chunks={:?}, file_range={:?})",
+                start_byte_offset,
+                end_byte_offset,
+                xorb_block_data.data.len(),
+                self.xorb_block.xorb_hash,
+                self.xorb_chunk_range,
+                self.byte_range,
+            )));
+        }
+
+        Ok(xorb_block_data.data.slice(start_byte_offset..end_byte_offset))
     }
 
     /// Get a future that will retrieve and extract the data bytes for this file term.
@@ -52,7 +65,7 @@ impl FileTerm {
         if let Ok(guard) = self.xorb_block.data.try_read()
             && let Some(ref xorb_block_data) = *guard
         {
-            let bytes = self.extract_bytes(xorb_block_data);
+            let bytes = self.extract_bytes(xorb_block_data)?;
             return Ok(Box::pin(async move { Ok(bytes) }));
         }
 
@@ -65,7 +78,7 @@ impl FileTerm {
 
         let task = tokio::task::spawn(async move {
             let xorb_block_data = xorb_block.retrieve_data(client, permit, url_info, progress_updater).await?;
-            Ok(file_term.extract_bytes(&xorb_block_data))
+            file_term.extract_bytes(&xorb_block_data)
         });
 
         Ok(Box::pin(async move { task.await? }))


### PR DESCRIPTION
## Summary

When the tokio runtime is dropped while background prefetch/reconstruction tasks are still in flight (e.g. after FUSE unmount), `FileTerm::extract_bytes` panics in `Bytes::slice()`:

```
thread 'tokio-runtime-worker' panicked at bytes-1.11.1/src/bytes.rs:392:
range end out of bounds: 67032765 <= 11538145

stack backtrace:
   2: file_reconstruction::reconstruction_terms::file_term::FileTerm::extract_bytes
   3: file_reconstruction::reconstruction_terms::file_term::FileTerm::get_data_task::{{closure}}::{{closure}}
```

This is 100% reproducible: read from a large xet-backed file, drop the runtime → background prefetch tasks are killed mid-execution and `extract_bytes` tries to `slice()` a `Bytes` buffer that's shorter than expected.

The fix converts the panic into a graceful `Err(CorruptedReconstruction)` by bounds-checking before `slice()`, and changes `extract_bytes` to return `Result<Bytes>`.

## Reproduction

Steps:
1. Create a `FileDownloadSession`
2. Start `download_stream` + concurrent `download_to_writer` on a large xet file (e.g. `model.safetensors` from `openai-community/gpt2`, ~548MB)
3. Read a few chunks to trigger the prefetch pipeline
4. Drop the tokio runtime (simulates process exit after FUSE unmount)

Output before fix:
```
model.safetensors: xet_hash=63bed80836ee..., size=548105171
  chunk 0: 8388608 bytes
  chunk 1: 16777216 bytes
  chunk 2: 41932220 bytes
Downloads kicked off — prefetch running in background
Dropping tokio runtime...
CAUGHT PANIC: panicked at bytes-1.11.1/src/bytes.rs:392:
range end out of bounds: 67029993 <= 18637893
CAUGHT PANIC: panicked at bytes-1.11.1/src/bytes.rs:392:
range end out of bounds: 66987011 <= 37594994
CAUGHT PANIC: panicked at bytes-1.11.1/src/bytes.rs:392:
range end out of bounds: 67032765 <= 58649036
```

<details>
<summary>Reproduction script (standalone test, requires HF_TOKEN + network)</summary>

```rust
use std::sync::Arc;
use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};

#[test]
fn test_prefetch_panic_on_runtime_drop() {
    // Tune xet-core for aggressive prefetch
    for (k, v) in [
        ("HF_XET_CLIENT_AC_INITIAL_DOWNLOAD_CONCURRENCY", "16"),
        ("HF_XET_CLIENT_AC_MIN_BYTES_REQUIRED_FOR_ADJUSTMENT", "4194304"),
        ("HF_XET_RECONSTRUCTION_MIN_RECONSTRUCTION_FETCH_SIZE", "8388608"),
        ("HF_XET_RECONSTRUCTION_MIN_PREFETCH_BUFFER", "8388608"),
        ("HF_XET_RECONSTRUCTION_TARGET_BLOCK_COMPLETION_TIME", "30"),
        ("HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_SIZE", "134217728"),
        ("HF_XET_RECONSTRUCTION_DOWNLOAD_BUFFER_LIMIT", "268435456"),
    ] {
        if std::env::var(k).is_err() {
            unsafe { std::env::set_var(k, v) };
        }
    }

    let token = std::env::var("HF_TOKEN").expect("HF_TOKEN required");

    // Install panic hook
    let panicked = Arc::new(AtomicBool::new(false));
    let panic_count = Arc::new(AtomicUsize::new(0));
    {
        let p = panicked.clone();
        let c = panic_count.clone();
        std::panic::set_hook(Box::new(move |info| {
            eprintln!("CAUGHT PANIC: {info}");
            p.store(true, Ordering::SeqCst);
            c.fetch_add(1, Ordering::SeqCst);
        }));
    }

    let runtime = tokio::runtime::Builder::new_multi_thread()
        .enable_all()
        .build()
        .unwrap();

    let done = Arc::new(AtomicBool::new(false));
    let done2 = done.clone();

    runtime.spawn(async move {
        // Setup: get CAS config for openai-community/gpt2 model.safetensors
        // (use your Hub API client to get xet_hash, file_size, and CAS token)

        let session = data::FileDownloadSession::new(config, None, None)
            .await.unwrap();
        let file_info = data::XetFileInfo::new(xet_hash, file_size);

        // Start download_stream + concurrent range reads
        let mut stream = session.download_stream(&file_info, None).unwrap();
        for _ in 0..3 {
            let _ = stream.next().await;
        }
        for j in 0..4 {
            let s = session.clone();
            let fi = file_info.clone();
            tokio::spawn(async move {
                let start = (j as u64) * 100_000_000;
                let buf = std::io::Cursor::new(Vec::with_capacity(50_000_000));
                let _ = s.download_to_writer(&fi, start..start + 50_000_000, buf, None).await;
            });
        }

        done2.store(true, Ordering::SeqCst);
        let _keep = (stream, session);
        loop { tokio::time::sleep(tokio::time::Duration::from_secs(60)).await; }
    });

    while !done.load(Ordering::SeqCst) {
        std::thread::sleep(std::time::Duration::from_millis(10));
    }
    std::thread::sleep(std::time::Duration::from_millis(50));

    // Drop runtime -> kills prefetch tasks -> panic in extract_bytes
    drop(runtime);
    std::thread::sleep(std::time::Duration::from_secs(2));

    assert!(panicked.load(Ordering::SeqCst),
        "Expected prefetch panic but none occurred");
}
```

</details>