### PR TITLE
feat: add chunk_byte_sizes to XorbReconstructionTerm

### DIFF
--- a/cas_client/src/simulation/local_client.rs
+++ b/cas_client/src/simulation/local_client.rs
@@ -906,6 +906,7 @@ impl Client for LocalClient {
                 hash: segment.xorb_hash.into(),
                 unpacked_length: segment.unpacked_segment_bytes,
                 range: chunk_range,
+                chunk_byte_sizes: Vec::new(),
             };
 
             terms.push(xorb_reconstruction_term);

--- a/cas_client/src/simulation/memory_client.rs
+++ b/cas_client/src/simulation/memory_client.rs
@@ -772,6 +772,7 @@ impl Client for MemoryClient {
                 hash: segment.xorb_hash.into(),
                 unpacked_length: segment.unpacked_segment_bytes,
                 range: chunk_range,
+                chunk_byte_sizes: Vec::new(),
             };
 
             terms.push(xorb_reconstruction_term);

--- a/cas_types/src/lib.rs
+++ b/cas_types/src/lib.rs
@@ -185,6 +185,12 @@ pub struct XorbReconstructionTerm {
     pub unpacked_length: u32,
     // chunk index start and end in a xorb
     pub range: ChunkRange,
+    // Per-chunk uncompressed byte sizes, in chunk order within `range`.
+    // Enables client-side chunk-level trimming for range queries derived
+    // from a cached full-file plan, avoiding over-fetch of entire xorb terms.
+    // Empty when the server does not populate this field (backward-compatible).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub chunk_byte_sizes: Vec<u32>,
 }
 
 /// To use a XorbReconstructionFetchInfo fetch info all that's needed


### PR DESCRIPTION
## Summary

- Add `chunk_byte_sizes: Vec<u32>` field to `XorbReconstructionTerm` in `cas_types`
- When populated by the CAS server, provides per-chunk uncompressed byte sizes in chunk order within the term's range
- Enables clients (e.g. hf-mount) to do chunk-level trimming when deriving range queries from a cached full-file plan, avoiding over-fetch of entire xorb terms for small random reads
- Backward-compatible: uses `serde(default, skip_serializing_if = "Vec::is_empty")`