### PR TITLE
feat: adaptive V2 reconstruction with split/grouped range strategy

### DIFF
--- a/cas_client/src/remote_client.rs
+++ b/cas_client/src/remote_client.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::time::Instant;
 
 use bytes::Bytes;
 use cas_object::SerializedCasObject;
@@ -232,6 +233,7 @@ impl RemoteClient {
         let api_tag = "cas::get_reconstruction_v1";
         let client = self.authenticated_http_client.clone();
 
+        let t0 = Instant::now();
         let result: Result<QueryReconstructionResponse> = RetryWrapper::new(api_tag)
             .run_and_extract_json(move || {
                 let mut request = client.get(url.clone()).with_extension(Api(api_tag));
@@ -245,6 +247,18 @@ impl RemoteClient {
 
         match result {
             Ok(query_reconstruction_response) => {
+                let elapsed = t0.elapsed();
+                let n_terms = query_reconstruction_response.terms.len();
+                let n_xorbs = query_reconstruction_response.fetch_info.len();
+                let n_urls: usize = query_reconstruction_response.fetch_info.values().map(|v| v.len()).sum();
+                eprintln!(
+                    "[BENCH] recon_v1 file={} elapsed={:.1?} terms={} xorbs={} urls={}",
+                    file_id.hex(),
+                    elapsed,
+                    n_terms,
+                    n_xorbs,
+                    n_urls
+                );
                 event!(
                     INFORMATION_LOG_LEVEL,
                     call_id,
@@ -280,6 +294,7 @@ impl RemoteClient {
         let api_tag = "cas::get_reconstruction_v2";
         let client = self.authenticated_http_client.clone();
 
+        let t0 = Instant::now();
         let result: Result<QueryReconstructionResponseV2> = RetryWrapper::new(api_tag)
             .run_and_extract_json(move || {
                 let mut request = client.get(url.clone()).with_extension(Api(api_tag));
@@ -292,6 +307,20 @@ impl RemoteClient {
 
         match result {
             Ok(response) => {
+                let elapsed = t0.elapsed();
+                let n_terms = response.terms.len();
+                let n_xorbs = response.xorbs.len();
+                let n_urls: usize = response.xorbs.values().map(|v| v.len()).sum();
+                let n_ranges: usize = response.xorbs.values().flat_map(|v| v.iter().map(|f| f.ranges.len())).sum();
+                eprintln!(
+                    "[BENCH] recon_v2 file={} elapsed={:.1?} terms={} xorbs={} urls={} ranges={}",
+                    file_id.hex(),
+                    elapsed,
+                    n_terms,
+                    n_xorbs,
+                    n_urls,
+                    n_ranges
+                );
                 event!(
                     INFORMATION_LOG_LEVEL,
                     call_id,
@@ -402,8 +431,11 @@ impl Client for RemoteClient {
         let http_client = self.http_client.clone();
         let url_info = Arc::new(url_info);
 
-        let (_, url_ranges) = url_info.retrieve_url().await?;
+        let (bench_url_str, url_ranges) = url_info.retrieve_url().await?;
         let total_download_bytes: u64 = url_ranges.iter().map(|r| r.length()).sum();
+        let bench_n_ranges = url_ranges.len();
+        let bench_host = bench_url_str.split('/').nth(2).unwrap_or("?").to_string();
+        let bench_t0 = Instant::now();
 
         let mut transfer_reporter = StreamProgressReporter::new(total_download_bytes)
             .with_adaptive_concurrency_reporter(download_permit.get_partial_completion_reporting_function());
@@ -434,11 +466,29 @@ impl Client for RemoteClient {
                             .join(",");
 
                         let response = http_client
-                            .get(url)
+                            .get(url.clone())
                             .header(RANGE, format!("bytes={range_header}"))
                             .with_extension(Api(api_tag))
                             .send()
                             .await?;
+
+                        let xcache = response
+                            .headers()
+                            .get("x-cache")
+                            .and_then(|v| v.to_str().ok())
+                            .unwrap_or("?")
+                            .to_string();
+                        let status = response.status();
+                        eprintln!(
+                            "[BENCH] s3_resp url_host={} status={} x-cache={} ranges={}",
+                            url.host_str().unwrap_or("?"),
+                            status,
+                            xcache,
+                            range_header.matches(',').count() + 1
+                        );
+                        if status.as_u16() >= 400 {
+                            eprintln!("[BENCH] s3_err status={} range=bytes={}", status, range_header);
+                        }
 
                         if response.status() == reqwest::StatusCode::FORBIDDEN {
                             url_info
@@ -467,19 +517,24 @@ impl Client for RemoteClient {
                             // parts, and deserialize each CAS object independently. We bypass
                             // the streaming progress wrapper since the multipart MIME overhead
                             // would inflate the byte count beyond what the progress tracker expects.
+                            let t_body = Instant::now();
                             let body = resp
                                 .bytes()
                                 .await
                                 .map_err(|e| RetryableReqwestError::RetryableError(CasClientError::from(e)))?;
+                            let body_elapsed = t_body.elapsed();
 
+                            let t_parse = Instant::now();
                             let multipart_parts = crate::multipart::parse_multipart_byteranges(&content_type, body)
                                 .map_err(RetryableReqwestError::FatalError)?;
+                            let parse_elapsed = t_parse.elapsed();
 
                             let mut all_decompressed = Vec::with_capacity(uncompressed_size_if_known.unwrap_or(0));
                             let mut all_chunk_indices = Vec::<u32>::new();
                             let mut total_compressed_bytes = 0u64;
 
-                            for part in multipart_parts {
+                            let t_decomp = Instant::now();
+                            for part in &multipart_parts {
                                 total_compressed_bytes += part.data.len() as u64;
 
                                 let (data, chunk_indices) =
@@ -497,6 +552,10 @@ impl Client for RemoteClient {
 
                                 transfer_reporter.report_progress(total_compressed_bytes as usize);
                             }
+                            let decomp_elapsed = t_decomp.elapsed();
+
+                            eprintln!("[BENCH] multipart parts={} body_bytes={} body_recv={:.1?} parse={:.1?} decompress={:.1?} decompressed_bytes={}",
+                                multipart_parts.len(), total_compressed_bytes, body_elapsed, parse_elapsed, decomp_elapsed, all_decompressed.len());
 
                             if let Some(expected) = uncompressed_size_if_known {
                                 debug_assert_eq!(
@@ -559,6 +618,16 @@ impl Client for RemoteClient {
                 },
             )
             .await?;
+
+        let bench_elapsed = bench_t0.elapsed();
+        eprintln!(
+            "[BENCH] s3_fetch host={} ranges={} download_bytes={} decompressed_bytes={} elapsed={:.1?}",
+            bench_host,
+            bench_n_ranges,
+            total_download_bytes,
+            result.0.len(),
+            bench_elapsed
+        );
 
         Ok(result)
     }

--- a/file_reconstruction/src/reconstruction_terms/file_term.rs
+++ b/file_reconstruction/src/reconstruction_terms/file_term.rs
@@ -151,51 +151,105 @@ pub async fn retrieve_file_term_block(
         };
 
         // Find the XorbMultiRangeFetch entry that contains this term's chunk range.
-        // A V2 xorb descriptor may have multiple fetch entries (e.g. when ranges were
-        // split due to URL length limits), so we search for the one that covers this term.
+        //
+        // For each fetch entry, we decide whether to split individual ranges into
+        // separate XorbBlocks (one HTTP request per range) or keep them grouped
+        // (one multi-range HTTP request).
+        //
+        // Splitting is better for large ranges: each single-range request benefits
+        // from CDN cache and runs in parallel. Multi-range requests bypass the CDN
+        // cache (unique Range header = cache miss) and are slower.
+        //
+        // Grouping is better for many small ranges: avoids per-request overhead
+        // (~15ms per connection) when ranges are tiny.
+        //
+        // Threshold: split when average range size >= 256KB and there aren't
+        // too many ranges (to avoid overwhelming the CDN with parallel requests).
+        const SPLIT_RANGE_THRESHOLD: u64 = 256 * 1024;
+        const MAX_SPLIT_RANGES: usize = 200;
+
         let xorb_block_index = 'find_xorb_block: {
             for fetch_entry in xorb_descriptor.iter() {
-                // Check if the term's chunk range is fully contained within
-                // one of this fetch entry's ranges.
-                let term_contained = fetch_entry
-                    .ranges
-                    .iter()
-                    .any(|r| r.chunks.start <= term.range.start && term.range.end <= r.chunks.end);
+                let total_bytes: u64 = fetch_entry.ranges.iter().map(|r| r.bytes.length()).sum();
+                let avg_range_size = total_bytes / fetch_entry.ranges.len().max(1) as u64;
+                let should_split = fetch_entry.ranges.len() > 1
+                    && fetch_entry.ranges.len() <= MAX_SPLIT_RANGES
+                    && avg_range_size >= SPLIT_RANGE_THRESHOLD;
 
-                if !term_contained {
-                    continue;
+                if should_split {
+                    // Split mode: find the specific range containing this term and
+                    // create a separate single-range XorbBlock for it.
+                    let matching_range = fetch_entry
+                        .ranges
+                        .iter()
+                        .find(|r| r.chunks.start <= term.range.start && term.range.end <= r.chunks.end);
+
+                    let Some(range_desc) = matching_range else {
+                        continue;
+                    };
+
+                    let index = match xorb_index_lookup.entry((xorb_hash, range_desc.chunks.start)) {
+                        Entry::Occupied(entry) => *entry.get(),
+                        Entry::Vacant(entry) => {
+                            let new_index = xorb_blocks.len();
+
+                            xorb_blocks.push(XorbBlock {
+                                xorb_hash,
+                                chunk_ranges: vec![range_desc.chunks],
+                                xorb_block_index: new_index,
+                                references: vec![],
+                                uncompressed_size_if_known: None,
+                                data: RwLock::new(None),
+                            });
+
+                            xorb_block_retrieval_urls.push((fetch_entry.url.clone(), vec![range_desc.bytes]));
+
+                            entry.insert(new_index);
+                            new_index
+                        },
+                    };
+
+                    break 'find_xorb_block index;
+                } else {
+                    // Grouped mode: keep all ranges in a single XorbBlock (original V2 behavior).
+                    // Used for small/fragmented ranges where per-request overhead dominates.
+                    let term_contained = fetch_entry
+                        .ranges
+                        .iter()
+                        .any(|r| r.chunks.start <= term.range.start && term.range.end <= r.chunks.end);
+
+                    if !term_contained {
+                        continue;
+                    }
+
+                    let first_chunk_start = fetch_entry.ranges[0].chunks.start;
+
+                    let index = match xorb_index_lookup.entry((xorb_hash, first_chunk_start)) {
+                        Entry::Occupied(entry) => *entry.get(),
+                        Entry::Vacant(entry) => {
+                            let new_index = xorb_blocks.len();
+
+                            let chunk_ranges: Vec<ChunkRange> = fetch_entry.ranges.iter().map(|r| r.chunks).collect();
+                            let http_ranges: Vec<HttpRange> = fetch_entry.ranges.iter().map(|r| r.bytes).collect();
+
+                            xorb_blocks.push(XorbBlock {
+                                xorb_hash,
+                                chunk_ranges,
+                                xorb_block_index: new_index,
+                                references: vec![],
+                                uncompressed_size_if_known: None,
+                                data: RwLock::new(None),
+                            });
+
+                            xorb_block_retrieval_urls.push((fetch_entry.url.clone(), http_ranges));
+
+                            entry.insert(new_index);
+                            new_index
+                        },
+                    };
+
+                    break 'find_xorb_block index;
                 }
-
-                // Use (xorb_hash, first_chunk_start) as a dedup key so that multiple
-                // terms referencing the same fetch entry share a single XorbBlock.
-                let first_chunk_start = fetch_entry.ranges[0].chunks.start;
-
-                let index = match xorb_index_lookup.entry((xorb_hash, first_chunk_start)) {
-                    Entry::Occupied(entry) => *entry.get(),
-                    Entry::Vacant(entry) => {
-                        // First time seeing this fetch entry — create a new XorbBlock.
-                        let new_index = xorb_blocks.len();
-
-                        let chunk_ranges: Vec<ChunkRange> = fetch_entry.ranges.iter().map(|r| r.chunks).collect();
-                        let http_ranges: Vec<HttpRange> = fetch_entry.ranges.iter().map(|r| r.bytes).collect();
-
-                        xorb_blocks.push(XorbBlock {
-                            xorb_hash,
-                            chunk_ranges,
-                            xorb_block_index: new_index,
-                            references: vec![],
-                            uncompressed_size_if_known: None,
-                            data: RwLock::new(None),
-                        });
-
-                        xorb_block_retrieval_urls.push((fetch_entry.url.clone(), http_ranges));
-
-                        entry.insert(new_index);
-                        new_index
-                    },
-                };
-
-                break 'find_xorb_block index;
             }
             return Err(FileReconstructionError::CorruptedReconstruction(format!(
                 "No xorb fetch entry found for file term {local_term_index:?} in xorb info for xorb hash {xorb_hash:?}"


### PR DESCRIPTION
## Summary

- Split large ranges (avg >= 256KB, <= 200 ranges) into individual single-range HTTP requests for better CDN cache hit rates and parallelism
- Keep small/fragmented ranges grouped in multi-range requests to avoid per-request overhead (~15ms per connection)
- Includes `[BENCH]` instrumentation (eprintln) for V1 vs V2 comparison: reconstruction timing, S3 response details, multipart parsing

This is the "V2-adaptive" approach from the benchmark results:

```
  label                  r/xorb |      V1 V2-orig V2-adpt |
 ----------------------------------------------------------
  gpt2_548MB                1.0 |    1.8s    2.0s    1.9s |
  smollm17b_3.4GB           1.0 |    6.0s    5.7s    4.2s |
  qwen35b_gguf_69GB        40.9 |  101.7s  301.2s   72.1s |
```

V2-adaptive is on par with V1 for non-fragmented files and 29% faster on highly fragmented ones.