### PR TITLE
ci: add riscv64 target to Linux wheel builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,24 +59,6 @@ jobs:
         run: |
           # the build and test steps would update Cargo.lock if it is out of date
           test -z "$(git status --porcelain Cargo.lock)" || (echo "Cargo.lock has uncommitted changes!" && exit 1)
-  build_and_test-linux-riscv64:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Install Rust 1.89
-        uses: dtolnay/rust-toolchain@1.89.0
-        with:
-          targets: riscv64gc-unknown-linux-gnu
-      - name: Install cross
-        run: |
-          curl -sL https://github.com/cross-rs/cross/releases/latest/download/cross-x86_64-unknown-linux-gnu.tar.gz | tar xz -C /usr/local/bin
-      - name: Build and Test
-        run: |
-          cross test --target riscv64gc-unknown-linux-gnu --verbose --no-fail-fast
-      - name: Build and Test hf_xet
-        run: |
-          cd hf_xet && cross test --target riscv64gc-unknown-linux-gnu --verbose --no-fail-fast
   build_and_test-win:
     runs-on: windows-latest
     steps:

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,6 +1,0 @@
-[target.riscv64gc-unknown-linux-gnu]
-pre-build = [
-    "dpkg --add-architecture $CROSS_DEB_ARCH",
-    "apt-get update && apt-get --assume-yes install libssl-dev:$CROSS_DEB_ARCH pkg-config",
-]
-image = "ghcr.io/cross-rs/riscv64gc-unknown-linux-gnu:edge"


### PR DESCRIPTION
## Summary

Add `linux_riscv64` wheels to the release workflow for hf-xet.

### Changes

- Add `riscv64` platform entry to the `linux` job matrix (manylinux_2_28)
- Maturin cross-compiles via cargo target `riscv64gc-unknown-linux-gnu`
- Add `binutils-riscv64-linux-gnu` for debug symbol stripping on riscv64

### Evidence

A tested riscv64 wheel (hf_xet v1.3.2) is available in our community index:
https://gounthar.github.io/riscv64-python-wheels/simple/hf-xet/

Built natively on BananaPi F3 (SpacemiT K1, rv64imafdcv, 8 cores @ 1.6 GHz, 16 GB RAM).

### Context

- `manylinux_2_28_riscv64` is available in pypa/manylinux
- maturin-action cross-compiles via cargo (no QEMU needed for Rust projects)
- Several Rust-based packages already ship riscv64 wheels (watchfiles, rignore, pydantic-core)
- RISC-V hardware is shipping (SiFive, SpacemiT K1/K3, Sophgo SG2044)

Closes #700