### PR TITLE
Implement scaled connection concurrency

### DIFF
--- a/wasm/hf_xet_wasm/src/wasm_file_upload_session.rs
+++ b/wasm/hf_xet_wasm/src/wasm_file_upload_session.rs
@@ -173,7 +173,7 @@ impl FileUploadSession {
         log::info!("shard hash: {shard_hash}, {} bytes", shard_data.len());
 
         let _timer = ConsoleTimer::new("upload shard");
-        let permit = self.client.acquire_upload_permit().await?;
+        let permit = self.client.acquire_upload_permit(Some(shard_data.len() as u64)).await?;
         self.client.upload_shard(shard_data.into(), permit).await?;
 
         Ok(())

--- a/wasm/hf_xet_wasm/src/xorb_uploader.rs
+++ b/wasm/hf_xet_wasm/src/xorb_uploader.rs
@@ -36,7 +36,10 @@ impl XorbUploaderLocalSequential {
 #[cfg_attr(target_family = "wasm", async_trait(?Send))]
 impl XorbUploader for XorbUploaderLocalSequential {
     async fn upload_xorb(&mut self, input: SerializedXorbObject) -> Result<()> {
-        let permit = self.client.acquire_upload_permit().await?;
+        let permit = self
+            .client
+            .acquire_upload_permit(Some(input.serialized_data.len() as u64))
+            .await?;
         let _ = self.client.upload_xorb(&self.cas_prefix, input, None, permit).await?;
         Ok(())
     }
@@ -72,7 +75,9 @@ impl XorbUploader for XorbUploaderSpawnParallel {
 
         let client = self.client.clone();
         let cas_prefix = self.cas_prefix.clone();
-        let upload_permit = client.acquire_upload_permit().await?;
+        let upload_permit = client
+            .acquire_upload_permit(Some(input.serialized_data.len() as u64))
+            .await?;
 
         self.tasks.spawn(async move {
             let _timer = ConsoleTimer::new(format!("upload xorb {}", input.hash));

--- a/xet_client/src/cas_client/adaptive_concurrency/controller.rs
+++ b/xet_client/src/cas_client/adaptive_concurrency/controller.rs
@@ -262,8 +262,16 @@ pub struct AdaptiveConcurrencyController {
     // Also holds related constants
     state: Mutex<ConcurrencyControllerState>,
 
-    // The semaphore from which new permits are issued.
+    // The semaphore from which new permits are issued. With scaled permits,
+    // the semaphore holds `concurrency * permit_base_unit` raw permits where
+    // permit_base_unit = ac_max_reference_transmission_size (in bytes).
     concurrency_semaphore: Arc<AdjustableSemaphore>,
+
+    // The max reference transmission size in bytes. Each byte of transfer costs
+    // one raw semaphore permit, so a full-size transfer costs permit_base_unit
+    // permits. Smaller transfers cost proportionally fewer permits (floored
+    // at base_unit / ac_max_small_transfer_concurrency_factor).
+    permit_base_unit: u64,
 
     // constants used to calculate how long things should be expected to take.
     min_concurrency_increase_delay: Duration,
@@ -300,12 +308,14 @@ impl AdaptiveConcurrencyController {
         );
 
         let config = xet_config();
+        let base_unit = *config.client.ac_max_reference_transmission_size;
         Arc::new(Self {
             state: Mutex::new(ConcurrencyControllerState::new()),
             concurrency_semaphore: AdjustableSemaphore::new(
-                current_concurrency as u64,
-                (min_concurrency as u64, max_concurrency as u64),
+                current_concurrency as u64 * base_unit,
+                (min_concurrency as u64 * base_unit, max_concurrency as u64 * base_unit),
             ),
+            permit_base_unit: base_unit,
 
             min_concurrency_increase_delay: Duration::from_millis(config.client.ac_min_adjustment_window_ms),
             min_concurrency_decrease_delay: Duration::from_millis(config.client.ac_min_adjustment_window_ms),
@@ -320,12 +330,14 @@ impl AdaptiveConcurrencyController {
     pub fn new_fixed(logging_tag: &'static str, concurrency: usize) -> Arc<Self> {
         info!("Fixing maximum concurrency for {logging_tag} at {concurrency}; adaptive concurrency disabled.");
 
+        let base_unit = *xet_config().client.ac_max_reference_transmission_size;
         Arc::new(Self {
             state: Mutex::new(ConcurrencyControllerState::new()),
             concurrency_semaphore: AdjustableSemaphore::new(
-                concurrency as u64,
-                (concurrency as u64, concurrency as u64),
+                concurrency as u64 * base_unit,
+                (concurrency as u64 * base_unit, concurrency as u64 * base_unit),
             ),
+            permit_base_unit: base_unit,
             adjustment_disabled: true,
             min_concurrency_increase_delay: Default::default(),
             min_concurrency_decrease_delay: Default::default(),
@@ -361,13 +373,55 @@ impl AdaptiveConcurrencyController {
         )
     }
 
-    pub async fn acquire_connection_permit(self: &Arc<Self>) -> Result<ConnectionPermit, CasClientError> {
-        let _permit = self.concurrency_semaphore.acquire().await?;
+    /// Computes the number of raw semaphore permits a transfer of the given size should consume.
+    ///
+    /// Each byte of transfer size costs one permit, so permit_base_unit
+    /// (= ac_max_reference_transmission_size) permits represent one full-size transfer.
+    /// The result is clamped to `[base_unit / F, base_unit]` where
+    /// F = ac_max_small_transfer_concurrency_factor.
+    fn compute_permit_cost(&self, size: Option<u64>) -> u64 {
+        let base_unit = self.permit_base_unit;
+        let configured_factor = xet_config().client.ac_max_small_transfer_concurrency_factor;
+        // Guard against invalid/misconfigured values so clamp bounds remain well-ordered.
+        let factor = if configured_factor.is_finite() && configured_factor >= 1.0 {
+            configured_factor
+        } else {
+            1.0
+        };
+        let min_permits = (base_unit as f64 / factor).ceil() as u64;
+
+        let size = match size {
+            Some(s) if s > 0 => s,
+            _ => return base_unit,
+        };
+
+        size.clamp(min_permits, base_unit)
+    }
+
+    /// Returns the effective concurrency as a float: total active raw permits / base_unit.
+    /// This represents bandwidth-weighted concurrent connections.
+    fn effective_active_concurrency(&self) -> f64 {
+        self.concurrency_semaphore.active_permits() as f64 / self.permit_base_unit as f64
+    }
+
+    /// Acquire a connection permit, optionally providing the expected transfer size in bytes.
+    ///
+    /// When `size` is provided, the permit cost is scaled proportionally to the transfer's
+    /// expected bandwidth consumption relative to a full-size (64MB) transfer. Smaller transfers
+    /// consume fewer permits, allowing higher concurrency for small-transfer workloads.
+    ///
+    /// When `size` is `None`, the permit defaults to a full-size transfer cost.
+    pub async fn acquire_connection_permit_with_size(
+        self: &Arc<Self>,
+        size: Option<u64>,
+    ) -> Result<ConnectionPermit, CasClientError> {
+        let num_permits = self.compute_permit_cost(size);
+        let _permit = self.concurrency_semaphore.acquire_many(num_permits).await?;
 
         let info = Arc::new(ConnectionPermitInfo {
             controller: Arc::clone(self),
             transfer_start_time: Mutex::new(Instant::now()),
-            starting_concurrency: self.concurrency_semaphore.active_permits() as usize,
+            starting_concurrency: self.effective_active_concurrency(),
             rtt_model_at_start: Some(self.state.lock().await.rtt_predictor.clone()),
             report_portion: AtomicU32::new(0),
             last_partial_report_ms: AtomicU64::new(0),
@@ -376,20 +430,26 @@ impl AdaptiveConcurrencyController {
         Ok(ConnectionPermit { _permit, info })
     }
 
-    /// The current concurrency; there may be more permits out there due to the lazy resolution of decrements, but those
-    /// are resolved before any new permits are issued.
+    pub async fn acquire_connection_permit(self: &Arc<Self>) -> Result<ConnectionPermit, CasClientError> {
+        self.acquire_connection_permit_with_size(None).await
+    }
+
+    /// The current effective concurrency (total raw permits / base_unit).
+    /// There may be more permits out there due to the lazy resolution of decrements,
+    /// but those are resolved before any new permits are issued.
     pub fn total_permits(&self) -> usize {
-        self.concurrency_semaphore.total_permits() as usize
+        (self.concurrency_semaphore.total_permits() / self.permit_base_unit) as usize
     }
 
-    /// The number of permits available currently.  Used mainly for testing.
+    /// The number of available permits in effective concurrency units (raw / base_unit).
+    /// Used mainly for testing.
     pub fn available_permits(&self) -> usize {
-        self.concurrency_semaphore.available_permits() as usize
+        (self.concurrency_semaphore.available_permits() / self.permit_base_unit) as usize
     }
 
-    /// The number of currently active permits (concurrent connections).
+    /// The number of currently active permits in effective concurrency units (raw / base_unit).
     pub fn active_permits(&self) -> usize {
-        self.concurrency_semaphore.active_permits() as usize
+        (self.concurrency_semaphore.active_permits() / self.permit_base_unit) as usize
     }
 
     /// Get the current network model state from the concurrency controller.
@@ -400,10 +460,7 @@ impl AdaptiveConcurrencyController {
 
     /// The current state of the model used for predicting the network latency.
     pub async fn latency_model_state(&self) -> CCLatencyModelState {
-        self.state
-            .lock()
-            .await
-            .latency_model_state(self.concurrency_semaphore.active_permits() as f64)
+        self.state.lock().await.latency_model_state(self.effective_active_concurrency())
     }
 
     /// Update the controller with the results of a transfer.
@@ -458,9 +515,9 @@ impl AdaptiveConcurrencyController {
             state_lg.completed_transmissions_count += 1;
         }
 
-        // Get the effective concurrency for this transfer.
-        let cur_concurrency = self.concurrency_semaphore.active_permits() as f64;
-        let avg_concurrency = (cur_concurrency + permit_info.starting_concurrency as f64) / 2.;
+        // Get the effective (bandwidth-weighted) concurrency for this transfer.
+        let cur_concurrency = self.effective_active_concurrency();
+        let avg_concurrency = (cur_concurrency + permit_info.starting_concurrency) / 2.;
 
         let track_as_success = transmission_successful && completed_in_time && {
             // Now test to see if the transfer is within a reasonable margin of error from the predicted rtt.
@@ -516,25 +573,25 @@ impl AdaptiveConcurrencyController {
             && state_lg.completed_transmissions_count >= self.min_completed_transmissions_required_for_adjustment
             && state_lg.last_adjustment_time.elapsed() > self.min_concurrency_increase_delay
         {
-            let old_concurrency = self.concurrency_semaphore.total_permits();
-            let new_concurrency = 1. + old_concurrency as f64;
+            let old_effective = self.total_permits();
+            let new_effective = 1.0 + old_effective as f64;
 
             // Calculate predicted RTT once for both decision and logging
             let predicted_rtt = state_lg
                 .rtt_predictor
-                .predicted_rtt(reference_size, new_concurrency)
+                .predicted_rtt(reference_size, new_effective)
                 .unwrap_or(f64::INFINITY);
 
             if predicted_rtt < target_rtt_secs {
-                self.concurrency_semaphore.increment_total_permits(1);
-                let new_concurrency_actual = self.concurrency_semaphore.total_permits();
+                self.concurrency_semaphore.increment_total_permits(self.permit_base_unit);
+                let new_effective_actual = self.total_permits();
                 state_lg.last_adjustment_time = Instant::now();
 
                 info!(
                     "Concurrency control for {}: Increased concurrency from {} to {}; reason: success ratio {:.3} is above threshold {:.3} and predicted RTT for {}MB at new concurrency is {:.2}s < target {:.1}s",
                     self.logging_tag,
-                    old_concurrency,
-                    new_concurrency_actual,
+                    old_effective,
+                    new_effective_actual,
                     model_state.success_ratio,
                     model_state.success_ratio_thresholds.0,
                     reference_size / (1024 * 1024),
@@ -553,13 +610,12 @@ impl AdaptiveConcurrencyController {
             // Now, only adjust it down if it's a fully completed transfer.  Otherwise we may run things out of
             // permits too quickly.
             if state_lg.last_adjustment_time.elapsed() > self.min_concurrency_decrease_delay {
-                let old_concurrency = self.concurrency_semaphore.total_permits();
+                let old_effective = self.total_permits();
 
-                // Attempt decrement; we're delegating the bounds checking entirely to the semaphore, so
-                // we don't care about whether it succeeded or not.
-                let _ = self.concurrency_semaphore.decrement_total_permits(1);
+                // Attempt decrement by one base_unit (one full-size transfer slot).
+                let _ = self.concurrency_semaphore.decrement_total_permits(self.permit_base_unit);
 
-                let new_concurrency = self.concurrency_semaphore.total_permits();
+                let new_effective = self.total_permits();
                 state_lg.last_adjustment_time = Instant::now();
 
                 let reason = if !transmission_successful {
@@ -571,8 +627,8 @@ impl AdaptiveConcurrencyController {
                 info!(
                     "Concurrency control for {}: Decreased concurrency from {} to {}; reason: {} (success_ratio = {:.3}, threshold = {:.3})",
                     self.logging_tag,
-                    old_concurrency,
-                    new_concurrency,
+                    old_effective,
+                    new_effective,
                     reason,
                     model_state.success_ratio,
                     model_state.success_ratio_thresholds.1
@@ -582,12 +638,12 @@ impl AdaptiveConcurrencyController {
 
         if state_lg.last_logging_time.elapsed() > Duration::from_millis(config.client.ac_logging_interval_ms) {
             state_lg.last_logging_time = Instant::now();
-            let latency_state = state_lg.latency_model_state(self.concurrency_semaphore.active_permits() as f64);
+            let latency_state = state_lg.latency_model_state(self.effective_active_concurrency());
             let ref_size_mb = reference_size as f64 / (1024.0 * 1024.0);
             info!(
                 "Concurrency control for {}: Current concurrency = {}; predicted bandwidth = {:.0}; success_ratio = {:.3}; reference_size = {:.1}MB; observed bytes sent so far = {}; completed transmissions = {}",
                 self.logging_tag,
-                self.concurrency_semaphore.total_permits(),
+                self.total_permits(),
                 latency_state.predicted_bandwidth,
                 model_state.success_ratio,
                 ref_size_mb,
@@ -602,7 +658,8 @@ impl AdaptiveConcurrencyController {
 pub struct ConnectionPermitInfo {
     controller: Arc<AdaptiveConcurrencyController>,
     transfer_start_time: Mutex<Instant>,
-    starting_concurrency: usize,
+    /// Effective concurrency (bandwidth-weighted) at the time the permit was acquired.
+    starting_concurrency: f64,
     rtt_model_at_start: Option<RTTPredictor>,
     /// Maximum portion completed so far, scaled to u32::MAX (0-u32::MAX represents 0.0-1.0)
     report_portion: AtomicU32,
@@ -758,12 +815,14 @@ impl ConcurrencyControllerState {
 #[cfg(test)]
 impl AdaptiveConcurrencyController {
     pub fn new_testing(concurrency: usize, concurrency_bounds: (usize, usize)) -> Arc<Self> {
+        let base_unit = *xet_config().client.ac_max_reference_transmission_size;
         Arc::new(Self {
             state: Mutex::new(ConcurrencyControllerState::new_testing()),
             concurrency_semaphore: AdjustableSemaphore::new(
-                concurrency as u64,
-                (concurrency_bounds.0 as u64, concurrency_bounds.1 as u64),
+                concurrency as u64 * base_unit,
+                (concurrency_bounds.0 as u64 * base_unit, concurrency_bounds.1 as u64 * base_unit),
             ),
+            permit_base_unit: base_unit,
             min_concurrency_increase_delay: Duration::from_millis(test_constants::INCR_SPACING_MS),
             min_concurrency_decrease_delay: Duration::from_millis(test_constants::DECR_SPACING_MS),
             adjustment_disabled: false,
@@ -1130,5 +1189,82 @@ mod tests {
             small_concurrency >= large_concurrency,
             "Small-transfer concurrency ({small_concurrency}) should be >= large-transfer concurrency ({large_concurrency})"
         );
+    }
+
+    #[tokio::test]
+    async fn test_permit_cost_scales_with_size() {
+        time::pause();
+        let controller = AdaptiveConcurrencyController::new_testing(10, (1, 20));
+
+        let config = xet_config();
+        let ref_size = *config.client.ac_max_reference_transmission_size;
+        let factor = config.client.ac_max_small_transfer_concurrency_factor;
+        let base_unit = controller.permit_base_unit;
+        let min_permits = (base_unit as f64 / factor).ceil() as u64;
+
+        // Full-size transfer costs base_unit (= ref_size / 1024)
+        assert_eq!(controller.compute_permit_cost(Some(ref_size)), base_unit);
+
+        // Half-size transfer costs half
+        assert_eq!(controller.compute_permit_cost(Some(ref_size / 2)), base_unit / 2);
+
+        // Tiny transfer hits the floor (min_permits = base_unit / factor)
+        assert_eq!(controller.compute_permit_cost(Some(1024)), min_permits);
+
+        // Unknown size defaults to base_unit
+        assert_eq!(controller.compute_permit_cost(None), base_unit);
+
+        // Zero size defaults to base_unit
+        assert_eq!(controller.compute_permit_cost(Some(0)), base_unit);
+    }
+
+    #[tokio::test]
+    async fn test_scaled_permits_allow_more_small_concurrent_transfers() {
+        time::pause();
+        let controller = AdaptiveConcurrencyController::new_testing(4, (1, 4));
+
+        let config = xet_config();
+        let factor = config.client.ac_max_small_transfer_concurrency_factor;
+        let base_unit = controller.permit_base_unit;
+        let min_permits = (base_unit as f64 / factor).ceil() as u64;
+
+        assert_eq!(controller.total_permits(), 4);
+
+        // With full-size transfers (base_unit each), we can acquire exactly 4
+        let mut full_permits = Vec::new();
+        for _ in 0..4 {
+            let p = controller.acquire_connection_permit().await.unwrap();
+            full_permits.push(p);
+        }
+        assert_eq!(controller.available_permits(), 0);
+        drop(full_permits);
+
+        // With minimum-cost transfers (min_permits each), we can fit more.
+        let expected_tiny_count = (4 * base_unit / min_permits) as usize;
+        let mut tiny_permits = Vec::new();
+        for _ in 0..expected_tiny_count {
+            let p = controller.acquire_connection_permit_with_size(Some(1024)).await.unwrap();
+            tiny_permits.push(p);
+        }
+
+        // Should have acquired factor times more permits than full-size
+        assert_eq!(tiny_permits.len(), (4.0 * factor) as usize);
+    }
+
+    #[tokio::test]
+    async fn test_effective_concurrency_reflects_permit_weights() {
+        time::pause();
+        let controller = AdaptiveConcurrencyController::new_testing(10, (1, 10));
+
+        // Acquire one full-size permit: effective active = 1.0 base_unit
+        let _p1 = controller.acquire_connection_permit().await.unwrap();
+        let eff_1 = controller.effective_active_concurrency();
+        assert!((eff_1 - 1.0).abs() < 0.01);
+
+        // Acquire one tiny permit: effective active ~ 1.0 + 0.5 = 1.5
+        let _p2 = controller.acquire_connection_permit_with_size(Some(1024)).await.unwrap();
+        let eff_2 = controller.effective_active_concurrency();
+        assert!(eff_2 > 1.0);
+        assert!(eff_2 < 2.0);
     }
 }

--- a/xet_client/src/cas_client/interface.rs
+++ b/xet_client/src/cas_client/interface.rs
@@ -38,7 +38,10 @@ pub trait Client: Send + Sync {
 
     async fn batch_get_reconstruction(&self, file_ids: &[MerkleHash]) -> Result<BatchQueryReconstructionResponse>;
 
-    async fn acquire_download_permit(&self) -> Result<ConnectionPermit>;
+    /// Acquire a download permit. When `size` is provided, the permit cost is
+    /// scaled proportionally to the transfer size, allowing higher concurrency
+    /// for small downloads.
+    async fn acquire_download_permit(&self, size: Option<u64>) -> Result<ConnectionPermit>;
 
     /// Optional progress callback receives (delta, completed, total) in transfer bytes.
     /// When [uncompressed_size_if_known] is [Some], the returned Bytes must have len() equal to that value.
@@ -52,8 +55,10 @@ pub trait Client: Send + Sync {
 
     async fn query_for_global_dedup_shard(&self, prefix: &str, chunk_hash: &MerkleHash) -> Result<Option<Bytes>>;
 
-    /// Acquire an upload permit.
-    async fn acquire_upload_permit(&self) -> Result<ConnectionPermit>;
+    /// Acquire an upload permit. When `size` is provided, the permit cost is
+    /// scaled proportionally to the transfer size, allowing higher concurrency
+    /// for small uploads.
+    async fn acquire_upload_permit(&self, size: Option<u64>) -> Result<ConnectionPermit>;
 
     /// Upload a new shard.
     async fn upload_shard(&self, shard_data: bytes::Bytes, upload_permit: ConnectionPermit) -> Result<bool>;

--- a/xet_client/src/cas_client/remote_client.rs
+++ b/xet_client/src/cas_client/remote_client.rs
@@ -255,8 +255,10 @@ impl Client for RemoteClient {
         Ok(response)
     }
 
-    async fn acquire_download_permit(&self) -> Result<ConnectionPermit> {
-        self.download_concurrency_controller.acquire_connection_permit().await
+    async fn acquire_download_permit(&self, size: Option<u64>) -> Result<ConnectionPermit> {
+        self.download_concurrency_controller
+            .acquire_connection_permit_with_size(size)
+            .await
     }
 
     async fn get_file_term_data(
@@ -399,8 +401,10 @@ impl Client for RemoteClient {
         Ok(Some(response.bytes().await?))
     }
 
-    async fn acquire_upload_permit(&self) -> Result<ConnectionPermit> {
-        self.upload_concurrency_controller.acquire_connection_permit().await
+    async fn acquire_upload_permit(&self, size: Option<u64>) -> Result<ConnectionPermit> {
+        self.upload_concurrency_controller
+            .acquire_connection_permit_with_size(size)
+            .await
     }
 
     #[instrument(skip_all, name = "RemoteClient::upload_shard", fields(shard.len = shard_data.len()))]
@@ -614,7 +618,10 @@ mod tests {
         // Act
         let result = threadpool
             .external_run_async_task(async move {
-                let permit = client.acquire_upload_permit().await.unwrap();
+                let permit = client
+                    .acquire_upload_permit(Some(xorb_obj.serialized_data.len() as u64))
+                    .await
+                    .unwrap();
                 client.upload_xorb(prefix, xorb_obj, None, permit).await
             })
             .unwrap();

--- a/xet_client/src/cas_client/simulation/client_testing_utils.rs
+++ b/xet_client/src/cas_client/simulation/client_testing_utils.rs
@@ -135,7 +135,9 @@ pub trait ClientTestingUtils: Client + Send + Sync {
 
             let serialized_xorb = SerializedXorbObject::from_xorb(raw_xorb.clone(), None, true)?;
 
-            let upload_permit = self.acquire_upload_permit().await?;
+            let upload_permit = self
+                .acquire_upload_permit(Some(serialized_xorb.serialized_data.len() as u64))
+                .await?;
             self.upload_xorb("default", serialized_xorb, None, upload_permit).await?;
 
             xorb_data.insert(xorb_seed, raw_xorb);
@@ -193,8 +195,9 @@ pub trait ClientTestingUtils: Client + Send + Sync {
             metadata_ext: None,
         })?;
 
-        let upload_permit = self.acquire_upload_permit().await?;
-        self.upload_shard(shard.to_bytes()?.into(), upload_permit).await?;
+        let shard_bytes = shard.to_bytes()?;
+        let upload_permit = self.acquire_upload_permit(Some(shard_bytes.len() as u64)).await?;
+        self.upload_shard(shard_bytes.into(), upload_permit).await?;
 
         // Convert xorb_data from seed-keyed to hash-keyed
         let xorbs = xorb_data.into_values().map(|x| (x.hash(), x)).collect();

--- a/xet_client/src/cas_client/simulation/client_unit_testing.rs
+++ b/xet_client/src/cas_client/simulation/client_unit_testing.rs
@@ -653,11 +653,9 @@ pub async fn test_global_dedup(client: Arc<dyn DirectAccessClient>) {
 
     let shard_hash = parse_shard_filename(&new_shard_path).unwrap();
 
-    let permit = client.acquire_upload_permit().await.unwrap();
-    client
-        .upload_shard(std::fs::read(&new_shard_path).unwrap().into(), permit)
-        .await
-        .unwrap();
+    let shard_data = std::fs::read(&new_shard_path).unwrap();
+    let permit = client.acquire_upload_permit(Some(shard_data.len() as u64)).await.unwrap();
+    client.upload_shard(shard_data.into(), permit).await.unwrap();
 
     let dedup_hashes =
         MDBShardInfo::filter_cas_chunks_for_global_dedup(&mut std::fs::File::open(&new_shard_path).unwrap()).unwrap();

--- a/xet_client/src/cas_client/simulation/local_client.rs
+++ b/xet_client/src/cas_client/simulation/local_client.rs
@@ -652,7 +652,10 @@ impl Client for LocalClient {
         Ok(None)
     }
 
-    async fn acquire_upload_permit(&self) -> Result<super::super::adaptive_concurrency::ConnectionPermit> {
+    async fn acquire_upload_permit(
+        &self,
+        _size: Option<u64>,
+    ) -> Result<super::super::adaptive_concurrency::ConnectionPermit> {
         self.apply_api_delay().await;
         self.upload_concurrency_controller.acquire_connection_permit().await
     }
@@ -998,7 +1001,10 @@ impl Client for LocalClient {
         })
     }
 
-    async fn acquire_download_permit(&self) -> Result<super::super::adaptive_concurrency::ConnectionPermit> {
+    async fn acquire_download_permit(
+        &self,
+        _size: Option<u64>,
+    ) -> Result<super::super::adaptive_concurrency::ConnectionPermit> {
         self.apply_api_delay().await;
         self.upload_concurrency_controller.acquire_connection_permit().await
     }
@@ -1122,7 +1128,10 @@ mod tests {
         let hash = xorb_obj.hash;
 
         let client = LocalClient::temporary().await.unwrap();
-        let permit = client.acquire_upload_permit().await.unwrap();
+        let permit = client
+            .acquire_upload_permit(Some(xorb_obj.serialized_data.len() as u64))
+            .await
+            .unwrap();
         client.upload_xorb("default", xorb_obj, None, permit).await.unwrap();
 
         // Get the actual byte offsets for a chunk range

--- a/xet_client/src/cas_client/simulation/local_server/handlers.rs
+++ b/xet_client/src/cas_client/simulation/local_server/handlers.rs
@@ -393,7 +393,7 @@ pub async fn post_xorb(State(state): State<ServerState>, Path(key): Path<HexKey>
         footer_start: None,
     };
 
-    let permit = match state.client.acquire_upload_permit().await {
+    let permit = match state.client.acquire_upload_permit(Some(data.len() as u64)).await {
         Ok(p) => p,
         Err(e) => return error_to_response(e),
     };
@@ -419,7 +419,7 @@ pub async fn post_shard(State(state): State<ServerState>, body: Body) -> Respons
         Err(e) => return (StatusCode::BAD_REQUEST, e).into_response(),
     };
 
-    let permit = match state.client.acquire_upload_permit().await {
+    let permit = match state.client.acquire_upload_permit(Some(data.len() as u64)).await {
         Ok(p) => p,
         Err(e) => return error_to_response(e),
     };

--- a/xet_client/src/cas_client/simulation/local_server/server.rs
+++ b/xet_client/src/cas_client/simulation/local_server/server.rs
@@ -436,8 +436,11 @@ impl Client for LocalTestServer {
         self.remote_client.batch_get_reconstruction(file_ids).await
     }
 
-    async fn acquire_download_permit(&self) -> Result<crate::cas_client::adaptive_concurrency::ConnectionPermit> {
-        self.remote_client.acquire_download_permit().await
+    async fn acquire_download_permit(
+        &self,
+        size: Option<u64>,
+    ) -> Result<crate::cas_client::adaptive_concurrency::ConnectionPermit> {
+        self.remote_client.acquire_download_permit(size).await
     }
 
     async fn get_file_term_data(
@@ -460,8 +463,11 @@ impl Client for LocalTestServer {
         self.remote_client.query_for_global_dedup_shard(prefix, chunk_hash).await
     }
 
-    async fn acquire_upload_permit(&self) -> Result<crate::cas_client::adaptive_concurrency::ConnectionPermit> {
-        self.remote_client.acquire_upload_permit().await
+    async fn acquire_upload_permit(
+        &self,
+        size: Option<u64>,
+    ) -> Result<crate::cas_client::adaptive_concurrency::ConnectionPermit> {
+        self.remote_client.acquire_upload_permit(size).await
     }
 
     async fn upload_shard(

--- a/xet_client/src/cas_client/simulation/local_server/simulation_control_client.rs
+++ b/xet_client/src/cas_client/simulation/local_server/simulation_control_client.rs
@@ -104,8 +104,11 @@ impl Client for SimulationControlClient {
     }
 
     /// Delegates download permit acquisition to the internal `RemoteClient`.
-    async fn acquire_download_permit(&self) -> Result<crate::cas_client::adaptive_concurrency::ConnectionPermit> {
-        self.remote_client.acquire_download_permit().await
+    async fn acquire_download_permit(
+        &self,
+        size: Option<u64>,
+    ) -> Result<crate::cas_client::adaptive_concurrency::ConnectionPermit> {
+        self.remote_client.acquire_download_permit(size).await
     }
 
     /// Delegates file term data download to the internal `RemoteClient`.
@@ -127,8 +130,11 @@ impl Client for SimulationControlClient {
     }
 
     /// Delegates upload permit acquisition to the internal `RemoteClient`.
-    async fn acquire_upload_permit(&self) -> Result<crate::cas_client::adaptive_concurrency::ConnectionPermit> {
-        self.remote_client.acquire_upload_permit().await
+    async fn acquire_upload_permit(
+        &self,
+        size: Option<u64>,
+    ) -> Result<crate::cas_client::adaptive_concurrency::ConnectionPermit> {
+        self.remote_client.acquire_upload_permit(size).await
     }
 
     /// Delegates shard upload to the internal `RemoteClient`.

--- a/xet_client/src/cas_client/simulation/memory_client.rs
+++ b/xet_client/src/cas_client/simulation/memory_client.rs
@@ -532,7 +532,10 @@ impl Client for MemoryClient {
         Ok(dedup.get(chunk_hash).cloned())
     }
 
-    async fn acquire_upload_permit(&self) -> Result<super::super::adaptive_concurrency::ConnectionPermit> {
+    async fn acquire_upload_permit(
+        &self,
+        _size: Option<u64>,
+    ) -> Result<super::super::adaptive_concurrency::ConnectionPermit> {
         self.apply_api_delay().await;
         self.upload_concurrency_controller.acquire_connection_permit().await
     }
@@ -863,7 +866,10 @@ impl Client for MemoryClient {
         })
     }
 
-    async fn acquire_download_permit(&self) -> Result<super::super::adaptive_concurrency::ConnectionPermit> {
+    async fn acquire_download_permit(
+        &self,
+        _size: Option<u64>,
+    ) -> Result<super::super::adaptive_concurrency::ConnectionPermit> {
         self.apply_api_delay().await;
         self.upload_concurrency_controller.acquire_connection_permit().await
     }

--- a/xet_client/src/cas_client/simulation/simulation_client.rs
+++ b/xet_client/src/cas_client/simulation/simulation_client.rs
@@ -143,8 +143,8 @@ impl Client for RemoteSimulationClient {
         self.inner.batch_get_reconstruction(file_ids).await
     }
 
-    async fn acquire_download_permit(&self) -> Result<ConnectionPermit> {
-        self.inner.acquire_download_permit().await
+    async fn acquire_download_permit(&self, size: Option<u64>) -> Result<ConnectionPermit> {
+        self.inner.acquire_download_permit(size).await
     }
 
     async fn get_file_term_data(
@@ -167,8 +167,8 @@ impl Client for RemoteSimulationClient {
         self.inner.query_for_global_dedup_shard(prefix, chunk_hash).await
     }
 
-    async fn acquire_upload_permit(&self) -> Result<ConnectionPermit> {
-        self.inner.acquire_upload_permit().await
+    async fn acquire_upload_permit(&self, size: Option<u64>) -> Result<ConnectionPermit> {
+        self.inner.acquire_upload_permit(size).await
     }
 
     async fn upload_shard(&self, shard_data: Bytes, upload_permit: ConnectionPermit) -> Result<bool> {

--- a/xet_client/src/cas_client/simulation/simulation_server.rs
+++ b/xet_client/src/cas_client/simulation/simulation_server.rs
@@ -451,8 +451,11 @@ impl Client for LocalTestServer {
         self.remote_simulation_client.batch_get_reconstruction(file_ids).await
     }
 
-    async fn acquire_download_permit(&self) -> Result<super::super::adaptive_concurrency::ConnectionPermit> {
-        self.remote_simulation_client.acquire_download_permit().await
+    async fn acquire_download_permit(
+        &self,
+        size: Option<u64>,
+    ) -> Result<super::super::adaptive_concurrency::ConnectionPermit> {
+        self.remote_simulation_client.acquire_download_permit(size).await
     }
 
     async fn get_file_term_data(
@@ -477,8 +480,11 @@ impl Client for LocalTestServer {
             .await
     }
 
-    async fn acquire_upload_permit(&self) -> Result<super::super::adaptive_concurrency::ConnectionPermit> {
-        self.remote_simulation_client.acquire_upload_permit().await
+    async fn acquire_upload_permit(
+        &self,
+        size: Option<u64>,
+    ) -> Result<super::super::adaptive_concurrency::ConnectionPermit> {
+        self.remote_simulation_client.acquire_upload_permit(size).await
     }
 
     async fn upload_shard(

--- a/xet_data/src/file_reconstruction/reconstruction_terms/xorb_block.rs
+++ b/xet_data/src/file_reconstruction/reconstruction_terms/xorb_block.rs
@@ -67,7 +67,9 @@ impl XorbBlock {
         self.data
             .get_or_try_init(|| async {
                 // Acquire a CAS download permit only when actually downloading.
-                let permit = client.acquire_download_permit().await?;
+                let permit = client
+                    .acquire_download_permit(uncompressed_size_if_known.map(|s| s as u64))
+                    .await?;
 
                 let url_provider = XorbURLProvider {
                     client: client.clone(),

--- a/xet_data/src/processing/file_upload_session.rs
+++ b/xet_data/src/processing/file_upload_session.rs
@@ -326,7 +326,10 @@ impl FileUploadSession {
             .await??;
 
         let session = self.clone();
-        let upload_permit = self.client.acquire_upload_permit().await?;
+        let upload_permit = self
+            .client
+            .acquire_upload_permit(Some(xorb_obj.serialized_data.len() as u64))
+            .await?;
         let cas_prefix = session.config.data_config.prefix.clone();
         let completion_tracker = self.completion_tracker.clone();
         let xorb_hash = xorb_obj.hash;

--- a/xet_data/src/processing/shard_interface.rs
+++ b/xet_data/src/processing/shard_interface.rs
@@ -263,7 +263,7 @@ impl SessionShardInterface {
             // It's also important to acquire the permit before the task is launched; otherwise, we may spawn an
             // unlimited number of tasks that end up using up a ton of memory; this forces the pipeline to
             // block here while the upload is happening.
-            let upload_permit = shard_client.acquire_upload_permit().await?;
+            let upload_permit = shard_client.acquire_upload_permit(None).await?;
 
             shard_uploads.spawn(
                 async move {

--- a/xet_runtime/src/config/groups/client.rs
+++ b/xet_runtime/src/config/groups/client.rs
@@ -179,6 +179,17 @@ crate::config_group!({
     /// Use the environment variable `HF_XET_CLIENT_AC_MAX_REFERENCE_TRANSMISSION_SIZE` to set this value.
     ref ac_max_reference_transmission_size: ByteSize = ByteSize::from("64mb");
 
+    /// The maximum concurrency multiplier for small transfers when using scaled permits.
+    /// With permit scaling enabled, tiny transfers consume fewer semaphore permits than large
+    /// transfers, allowing up to this factor more concurrent connections for small-transfer
+    /// workloads. For example, with the default value of 2.0, a workload of very small transfers
+    /// can achieve up to 2x the concurrency of a workload of max-reference-size transfers.
+    ///
+    /// The default value is 2.0.
+    ///
+    /// Use the environment variable `HF_XET_CLIENT_AC_MAX_SMALL_TRANSFER_CONCURRENCY_FACTOR` to set this value.
+    ref ac_max_small_transfer_concurrency_factor: f64 = 2.0;
+
     /// The minimum reference transmission size used for bandwidth target checks.
     /// The dynamic reference size (estimated from observed transfer sizes) is floored at this value
     /// to prevent excessively aggressive concurrency increases with very small transfers.


### PR DESCRIPTION
Currently, small transfers count the same way in modeling and adapting the concurrency as do larger transfers.  This PR introduces a scaling model that permits smaller connections to count less towards a concurrency total, as the bulk is spent waiting for the server latency.