### PR TITLE
chore: version bump to 1.4.2

### DIFF
--- a/hf_xet/Cargo.lock
+++ b/hf_xet/Cargo.lock
@@ -1233,7 +1233,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hf_xet"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "async-trait",
  "chrono",

--- a/hf_xet/Cargo.toml
+++ b/hf_xet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hf_xet"
-version = "1.4.1"
+version = "1.4.2"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## Summary

- Bump hf_xet version from 1.4.1 to 1.4.2 in Cargo.toml and Cargo.lock
- Follows up on 1.4.1 release where the version bump PR was merged after the release artifacts were built