### PR TITLE
fix: bound file reconstruction range using file_size to prevent 416 errors

### DIFF
--- a/xet_data/src/file_reconstruction/file_reconstructor.rs
+++ b/xet_data/src/file_reconstruction/file_reconstructor.rs
@@ -37,10 +37,6 @@ pub struct FileReconstructor {
     /// When cancelled, reconstruction stops at its next check point. Long waits
     /// (such as semaphore acquisition) use `tokio::select!` so they abort promptly.
     cancellation_token: CancellationToken,
-
-    /// Known file size used to bound the reconstruction range for full-file downloads.
-    /// Prevents speculative prefetch blocks from requesting ranges beyond EOF.
-    file_size: Option<u64>,
 }
 
 impl FileReconstructor {
@@ -53,20 +49,12 @@ impl FileReconstructor {
             config: Arc::new(xet_config().reconstruction.clone()),
             custom_buffer_semaphore: None,
             cancellation_token: CancellationToken::new(),
-            file_size: None,
         }
     }
 
     pub fn with_byte_range(self, byte_range: FileRange) -> Self {
         Self {
             byte_range: Some(byte_range),
-            ..self
-        }
-    }
-
-    pub fn with_file_size(self, file_size: u64) -> Self {
-        Self {
-            file_size: Some(file_size),
             ..self
         }
     }
@@ -204,17 +192,13 @@ impl FileReconstructor {
             byte_range,
             config,
             custom_buffer_semaphore,
-            file_size,
             ..
         } = self;
 
         run_state.check_run_state()?;
 
         let file_hash = *run_state.file_hash();
-        let requested_range = byte_range.unwrap_or_else(|| match file_size {
-            Some(size) => FileRange::new(0, size),
-            None => FileRange::full(),
-        });
+        let requested_range = byte_range.unwrap_or_else(FileRange::full);
 
         let mut term_manager = ReconstructionTermManager::new(
             config.clone(),

--- a/xet_data/src/processing/file_download_session.rs
+++ b/xet_data/src/processing/file_download_session.rs
@@ -205,11 +205,8 @@ impl FileDownloadSession {
             task
         });
 
-        let mut reconstructor = FileReconstructor::new(&self.client, file_id).with_file_size(file_info.file_size());
-
-        if let Some(range) = range {
-            reconstructor = reconstructor.with_byte_range(range);
-        }
+        let effective_range = range.unwrap_or_else(|| FileRange::new(0, file_info.file_size()));
+        let mut reconstructor = FileReconstructor::new(&self.client, file_id).with_byte_range(effective_range);
 
         if let Some(tracker) = task_updater {
             reconstructor = reconstructor.with_progress_updater(tracker);

--- a/xet_data/tests/test_full_file_download.rs
+++ b/xet_data/tests/test_full_file_download.rs
@@ -1,0 +1,57 @@
+//! Regression test for the 416 Range Not Satisfiable bug.
+//!
+//! When downloading a full file without an explicit byte range, `FileReconstructor`
+//! used `FileRange::full()` (0..u64::MAX), causing `ReconstructionTermManager` to
+//! speculatively prefetch blocks beyond EOF. This made the CAS server return 416
+//! for small files.
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::sync::Arc;
+
+    use tempfile::TempDir;
+    use ulid::Ulid;
+    use xet_client::cas_client::LocalTestServerBuilder;
+    use xet_data::processing::configurations::TranslatorConfig;
+    use xet_data::processing::{FileDownloadSession, FileUploadSession, Sha256Policy, XetFileInfo};
+
+    async fn upload_bytes(upload_session: &Arc<FileUploadSession>, name: &str, data: &[u8]) -> XetFileInfo {
+        let mut cleaner = upload_session
+            .start_clean(Some(name.into()), data.len() as u64, Sha256Policy::Compute, Ulid::new())
+            .await;
+        cleaner.add_data(data).await.unwrap();
+        let (xfi, _metrics) = cleaner.finish().await.unwrap();
+        xfi
+    }
+
+    /// Uploads files of various sizes through a LocalTestServer and downloads them
+    /// without an explicit byte range, verifying no 416 errors occur.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_full_file_download_no_416() {
+        let server = LocalTestServerBuilder::new().start().await;
+        let base_dir = TempDir::new().unwrap();
+        let config = Arc::new(TranslatorConfig::test_server_config(server.http_endpoint(), base_dir.path()).unwrap());
+
+        let test_cases: &[(&str, &[u8])] = &[
+            ("one_byte", &[0x42]),
+            ("small", b"hello world"),
+            ("medium", &vec![0xAB; 4096]),
+            ("larger", &vec![0xCD; 64 * 1024]),
+        ];
+
+        let download_session = FileDownloadSession::new(config.clone(), None).await.unwrap();
+
+        for (name, data) in test_cases {
+            let upload_session = FileUploadSession::new(config.clone(), None).await.unwrap();
+            let xfi = upload_bytes(&upload_session, name, data).await;
+            upload_session.finalize().await.unwrap();
+
+            let out_path = base_dir.path().join(format!("out_{name}"));
+            let n_bytes = download_session.download_file(&xfi, &out_path, Ulid::new()).await.unwrap();
+
+            assert_eq!(n_bytes, data.len() as u64, "size mismatch for {name}");
+            assert_eq!(fs::read(&out_path).unwrap(), *data, "content mismatch for {name}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Bounds the file reconstruction range using the known file size instead of requesting beyond EOF. This prevents spurious 416 Range Not Satisfiable errors from the CAS server for small files.

When downloading a full file without an explicit byte range, `FileReconstructor` used `FileRange::full()` (0..u64::MAX). This caused `ReconstructionTermManager` to speculatively prefetch blocks beyond EOF, making the CAS server return 416 for small files. The large start values (~1.8e19) visible in production logs confirm unsigned arithmetic wrapping around u64::MAX.

## Impact (production, last 24h)

- **~32k errors/24h**: u64 overflow in range computation (`start: 18446744073709...`, `end: 15xxx`) directly caused by `FileRange::full()`
- **~29M errors/24h** (~1M/h): `range start is greater than file length` (416 responses). Likely a mix of this bug (speculative prefetch beyond EOF) and legitimate client-side range errors