### PR TITLE
feat: expose CAS client factory and chunk cache re-exports

### DIFF
--- a/xet_data/src/processing/mod.rs
+++ b/xet_data/src/processing/mod.rs
@@ -16,6 +16,9 @@ mod xet_file;
 pub use file_cleaner::{Sha256Policy, SingleFileCleaner};
 pub use file_download_session::FileDownloadSession;
 pub use file_upload_session::FileUploadSession;
+pub use remote_client_interface::create_remote_client;
+pub use xet_client::cas_client::Client as CasClient;
+pub use xet_client::chunk_cache::{CacheConfig, ChunkCache, get_cache};
 pub use xet_file::XetFileInfo;
 
 pub use crate::deduplication::RawXorbData;

--- a/xet_data/src/processing/remote_client_interface.rs
+++ b/xet_data/src/processing/remote_client_interface.rs
@@ -5,7 +5,7 @@ use xet_client::cas_client::{Client, RemoteClient};
 use super::configurations::TranslatorConfig;
 use super::errors::Result;
 
-pub(crate) async fn create_remote_client(
+pub async fn create_remote_client(
     config: &TranslatorConfig,
     session_id: &str,
     dry_run: bool,


### PR DESCRIPTION
## Context

These changes support the hf-mount project, which needs direct access to CAS client types.

## Summary

- Changed `create_remote_client` visibility from `pub(crate)` to `pub`
- Added re-exports for `CasClient`, `ChunkCache`, `CacheConfig`, and `get_cache` in `xet_data::processing`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this change only widens public API surface (function visibility and re-exports) without altering the underlying client creation logic or data handling paths.
> 
> **Overview**
> Makes `create_remote_client` publicly accessible (was `pub(crate)`) and re-exports it from `xet_data::processing`.
> 
> Also re-exports CAS client and chunk cache types/utilities (`CasClient`, `ChunkCache`, `CacheConfig`, `get_cache`) to provide a stable, convenient API surface for downstream projects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b094f21cd05c287a1b7edc42496d4420296aed96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->