### PR TITLE
feat: make start_clean size parameter optional for streaming uploads

### DIFF
--- a/xet_data/src/processing/bin/example.rs
+++ b/xet_data/src/processing/bin/example.rs
@@ -90,7 +90,7 @@ async fn clean(mut reader: impl Read, mut writer: impl Write, size: u64) -> Resu
     let translator = FileUploadSession::new(TranslatorConfig::local_config(std::env::current_dir()?)?.into()).await?;
 
     let mut size_read = 0;
-    let (_id, mut handle) = translator.start_clean(None, size, Sha256Policy::Compute)?;
+    let (_id, mut handle) = translator.start_clean(None, Some(size), Sha256Policy::Compute)?;
 
     loop {
         let bytes = reader.read(&mut read_buf)?;

--- a/xet_data/src/processing/data_client.rs
+++ b/xet_data/src/processing/data_client.rs
@@ -44,7 +44,7 @@ pub async fn clean_bytes(
     bytes: Vec<u8>,
     sha256_policy: Sha256Policy,
 ) -> Result<(XetFileInfo, DeduplicationMetrics)> {
-    let (_id, mut handle) = processor.start_clean(None, bytes.len() as u64, sha256_policy)?;
+    let (_id, mut handle) = processor.start_clean(None, Some(bytes.len() as u64), sha256_policy)?;
     handle.add_data(&bytes).await?;
     handle.finish().await
 }
@@ -64,7 +64,7 @@ pub async fn clean_file(
     let mut buffer = vec![0u8; u64::min(filesize, *xet_config().data.ingestion_block_size) as usize];
 
     let (_id, mut handle) =
-        processor.start_clean(Some(filename.as_ref().to_string_lossy().into()), filesize, sha256_policy)?;
+        processor.start_clean(Some(filename.as_ref().to_string_lossy().into()), Some(filesize), sha256_policy)?;
 
     loop {
         let bytes = reader.read(&mut buffer)?;

--- a/xet_data/src/processing/file_download_session.rs
+++ b/xet_data/src/processing/file_download_session.rs
@@ -384,7 +384,7 @@ mod tests {
             .unwrap();
 
         let (_id, mut cleaner) = upload_session
-            .start_clean(Some("test".into()), data.len() as u64, Sha256Policy::Compute)
+            .start_clean(Some("test".into()), Some(data.len() as u64), Sha256Policy::Compute)
             .unwrap();
         cleaner.add_data(data).await.unwrap();
         let (xfi, _metrics) = cleaner.finish().await.unwrap();

--- a/xet_data/src/processing/file_upload_session.rs
+++ b/xet_data/src/processing/file_upload_session.rs
@@ -208,7 +208,7 @@ impl FileUploadSession {
     pub fn start_clean(
         self: &Arc<Self>,
         tracking_name: Option<Arc<str>>,
-        size: u64,
+        size: Option<u64>,
         sha256: Sha256Policy,
     ) -> Result<(UniqueID, SingleFileCleaner)> {
         self.check_not_finalized()?;
@@ -221,11 +221,11 @@ impl FileUploadSession {
         self: &Arc<Self>,
         id: UniqueID,
         tracking_name: Option<Arc<str>>,
-        size: u64,
+        size: Option<u64>,
         sha256: Sha256Policy,
     ) -> SingleFileCleaner {
         let updater = self.progress.new_item(id, tracking_name.clone().unwrap_or_default());
-        let file_id = self.completion_tracker.register_new_file(updater, Some(size));
+        let file_id = self.completion_tracker.register_new_file(updater, size);
         SingleFileCleaner::new(tracking_name, file_id, sha256, self.clone())
     }
 
@@ -240,7 +240,7 @@ impl FileUploadSession {
         self.check_not_finalized()?;
         let file_size = std::fs::metadata(&file_path)?.len();
         let tracking_name: Arc<str> = Arc::from(file_path.to_string_lossy().as_ref());
-        let (id, cleaner) = self.start_clean(Some(tracking_name), file_size, sha256)?;
+        let (id, cleaner) = self.start_clean(Some(tracking_name), Some(file_size), sha256)?;
 
         let rt = XetRuntime::current();
         let semaphore = rt.common().file_ingestion_semaphore.clone();
@@ -262,7 +262,7 @@ impl FileUploadSession {
         tracking_name: Option<Arc<str>>,
     ) -> Result<(UniqueID, JoinHandle<Result<XetFileInfo>>)> {
         self.check_not_finalized()?;
-        let (id, mut cleaner) = self.start_clean(tracking_name, bytes.len() as u64, sha256)?;
+        let (id, mut cleaner) = self.start_clean(tracking_name, Some(bytes.len() as u64), sha256)?;
 
         let rt = XetRuntime::current();
         let semaphore = rt.common().file_ingestion_semaphore.clone();
@@ -613,7 +613,7 @@ mod tests {
             .unwrap();
 
         let (_id, mut cleaner) = upload_session
-            .start_clean(Some("test".into()), read_data.len() as u64, Sha256Policy::Compute)
+            .start_clean(Some("test".into()), Some(read_data.len() as u64), Sha256Policy::Compute)
             .unwrap();
 
         // Read blocks from the source file and hand them to the cleaning handle
@@ -699,7 +699,7 @@ mod tests {
                     .unwrap();
 
                 let (_id, mut cleaner) = upload_session
-                    .start_clean(Some("test".into()), data.len() as u64, Sha256Policy::Skip)
+                    .start_clean(Some("test".into()), Some(data.len() as u64), Sha256Policy::Skip)
                     .unwrap();
                 cleaner.add_data(data).await.unwrap();
                 cleaner.finish().await.unwrap();

--- a/xet_data/tests/test_full_file_download.rs
+++ b/xet_data/tests/test_full_file_download.rs
@@ -17,7 +17,7 @@ mod tests {
 
     async fn upload_bytes(upload_session: &Arc<FileUploadSession>, name: &str, data: &[u8]) -> XetFileInfo {
         let (_id, mut cleaner) = upload_session
-            .start_clean(Some(name.into()), data.len() as u64, Sha256Policy::Compute)
+            .start_clean(Some(name.into()), Some(data.len() as u64), Sha256Policy::Compute)
             .unwrap();
         cleaner.add_data(data).await.unwrap();
         let (xfi, _metrics) = cleaner.finish().await.unwrap();

--- a/xet_data/tests/test_range_downloads.rs
+++ b/xet_data/tests/test_range_downloads.rs
@@ -15,7 +15,7 @@ mod tests {
 
     async fn upload_bytes(upload_session: &Arc<FileUploadSession>, name: &str, data: &[u8]) -> XetFileInfo {
         let (_id, mut cleaner) = upload_session
-            .start_clean(Some(name.into()), data.len() as u64, Sha256Policy::Compute)
+            .start_clean(Some(name.into()), Some(data.len() as u64), Sha256Policy::Compute)
             .unwrap();
         cleaner.add_data(data).await.unwrap();
         let (xfi, _metrics) = cleaner.finish().await.unwrap();

--- a/xet_data/tests/test_session_resume.rs
+++ b/xet_data/tests/test_session_resume.rs
@@ -62,7 +62,7 @@ mod tests {
 
             // Feed it half the data, and checkpoint.
             let (_id, mut cleaner) = file_upload_session
-                .start_clean(Some("data".into()), data.len() as u64, Sha256Policy::Compute)
+                .start_clean(Some("data".into()), Some(data.len() as u64), Sha256Policy::Compute)
                 .unwrap();
             cleaner.add_data(&data[..half_n]).await.unwrap();
             cleaner.checkpoint().await.unwrap();
@@ -83,7 +83,7 @@ mod tests {
 
             // Feed it half the data, and checkpoint.
             let (_id, mut cleaner) = file_upload_session
-                .start_clean(Some("data".into()), data.len() as u64, Sha256Policy::Compute)
+                .start_clean(Some("data".into()), Some(data.len() as u64), Sha256Policy::Compute)
                 .unwrap();
 
             // Add all the data.  Roughly the first half should dedup.
@@ -124,7 +124,7 @@ mod tests {
 
             // Feed it half the data, and checkpoint.
             let (_id, mut cleaner) = file_upload_session
-                .start_clean(Some("data".into()), data.len() as u64, Sha256Policy::Compute)
+                .start_clean(Some("data".into()), Some(data.len() as u64), Sha256Policy::Compute)
                 .unwrap();
             cleaner.add_data(&data[..rn]).await.unwrap();
             cleaner.checkpoint().await.unwrap();
@@ -148,7 +148,7 @@ mod tests {
 
             // Feed it half the data, and checkpoint.
             let (_id, mut cleaner) = file_upload_session
-                .start_clean(Some("data".into()), data.len() as u64, Sha256Policy::Compute)
+                .start_clean(Some("data".into()), Some(data.len() as u64), Sha256Policy::Compute)
                 .unwrap();
 
             // Add all the data.  Roughly the first half should dedup.

--- a/xet_data/tests/test_unordered_download.rs
+++ b/xet_data/tests/test_unordered_download.rs
@@ -11,7 +11,7 @@ mod tests {
 
     async fn upload_bytes(upload_session: &Arc<FileUploadSession>, name: &str, data: &[u8]) -> XetFileInfo {
         let (_id, mut cleaner) = upload_session
-            .start_clean(Some(name.into()), data.len() as u64, Sha256Policy::Compute)
+            .start_clean(Some(name.into()), Some(data.len() as u64), Sha256Policy::Compute)
             .unwrap();
         cleaner.add_data(data).await.unwrap();
         let (xfi, _metrics) = cleaner.finish().await.unwrap();

--- a/xet_pkg/src/xet_session/upload_commit.rs
+++ b/xet_pkg/src/xet_session/upload_commit.rs
@@ -1345,7 +1345,8 @@ mod tests {
         let temp = tempdir()?;
         let session = local_session_sync(&temp)?;
         let commit = session.new_upload_commit_blocking()?;
-        let (handle, _cleaner) = commit.upload_file_blocking(Some("stream.bin".into()), 1024, Sha256Policy::Compute)?;
+        let (handle, _cleaner) =
+            commit.upload_file_blocking(Some("stream.bin".into()), Some(1024), Sha256Policy::Compute)?;
         assert!(handle.status().is_err());
         Ok(())
     }
@@ -1416,7 +1417,7 @@ mod tests {
         let session = XetSessionBuilder::new().build_async().await.unwrap();
         assert_eq!(session.runtime_mode, RuntimeMode::External);
         let commit = session.new_upload_commit().await.unwrap();
-        let err = commit.upload_file_blocking(None, 0, Sha256Policy::Compute).err().unwrap();
+        let err = commit.upload_file_blocking(None, Some(0), Sha256Policy::Compute).err().unwrap();
         assert!(matches!(err, XetError::WrongRuntimeMode(_)));
     }
 
@@ -1462,7 +1463,7 @@ mod tests {
         let commit = session.new_upload_commit_blocking().unwrap();
         let rt = tokio::runtime::Builder::new_multi_thread().enable_all().build().unwrap();
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            rt.block_on(async { commit.upload_file_blocking(None, 0, Sha256Policy::Compute) })
+            rt.block_on(async { commit.upload_file_blocking(None, Some(0), Sha256Policy::Compute) })
         }));
         assert!(result.is_err(), "upload_file_blocking() must panic when called from async");
     }

--- a/xet_pkg/src/xet_session/upload_commit.rs
+++ b/xet_pkg/src/xet_session/upload_commit.rs
@@ -466,12 +466,13 @@ impl UploadCommitInner {
         };
 
         let tracking_name: Option<Arc<str>> = tracking_name.as_deref().map(Arc::from);
-        let (id, cleaner) = upload_session.start_clean(tracking_name, file_size, sha256)?;
+        let (id, cleaner) = upload_session.start_clean(tracking_name, Some(file_size), sha256)?;
 
         let task_handle = TaskHandle {
             status: None,
             task_id: id,
         };
+
         Ok((task_handle, cleaner))
     }
 

--- a/xet_pkg/src/xet_session/upload_commit.rs
+++ b/xet_pkg/src/xet_session/upload_commit.rs
@@ -132,7 +132,7 @@ impl UploadCommit {
     /// # use xet::XetError;
     /// # async fn example(commit: xet::xet_session::UploadCommit, filename: &str, filesize: u64) -> anyhow::Result<()> {
     /// # use xet::xet_session::Sha256Policy;
-    /// let (handle, mut cleaner) = commit.upload_file(Some(filename.into()), filesize, Sha256Policy::Compute).await?;
+    /// let (handle, mut cleaner) = commit.upload_file(Some(filename.into()), Some(filesize), Sha256Policy::Compute).await?;
     /// let mut reader = File::open(&filename)?;
     /// let mut buffer = vec![0u8; 65536];
     /// loop {
@@ -151,8 +151,8 @@ impl UploadCommit {
     ///
     /// - `file_name`: optional display name used for progress and telemetry reporting; does not affect the upload
     ///   itself.
-    /// - `file_size`: expected total size in bytes, used for progress tracking. Pass `0` when the size is not known in
-    ///   advance.
+    /// - `file_size`: expected total size in bytes, used for progress tracking. Pass `None` when the size is not known
+    ///   in advance.
     /// - `sha256`: controls SHA-256 handling during upload. Use [`Sha256Policy::Compute`] to compute it from the data,
     ///   [`Sha256Policy::Provided`] to supply a pre-computed digest, or [`Sha256Policy::Skip`] to omit it entirely.
     ///
@@ -164,7 +164,7 @@ impl UploadCommit {
     pub async fn upload_file(
         &self,
         file_name: Option<String>,
-        file_size: u64,
+        file_size: Option<u64>,
         sha256: Sha256Policy,
     ) -> Result<(TaskHandle, SingleFileCleaner), XetError> {
         self.session.check_alive()?;
@@ -323,7 +323,7 @@ impl UploadCommit {
     pub fn upload_file_blocking(
         &self,
         file_name: Option<String>,
-        file_size: u64,
+        file_size: Option<u64>,
         sha256: Sha256Policy,
     ) -> Result<(TaskHandle, SingleFileCleaner), XetError> {
         if matches!(self.session.runtime_mode, RuntimeMode::External) {
@@ -455,7 +455,7 @@ impl UploadCommitInner {
     pub(super) async fn start_upload_file(
         &self,
         tracking_name: Option<String>,
-        file_size: u64,
+        file_size: Option<u64>,
         sha256: Sha256Policy,
     ) -> Result<(TaskHandle, SingleFileCleaner), XetError> {
         let state = self.state.lock().await;
@@ -466,7 +466,7 @@ impl UploadCommitInner {
         };
 
         let tracking_name: Option<Arc<str>> = tracking_name.as_deref().map(Arc::from);
-        let (id, cleaner) = upload_session.start_clean(tracking_name, Some(file_size), sha256)?;
+        let (id, cleaner) = upload_session.start_clean(tracking_name, file_size, sha256)?;
 
         let task_handle = TaskHandle {
             status: None,
@@ -843,7 +843,7 @@ mod tests {
         let session = XetSessionBuilder::new().build_async().await.unwrap();
         let commit = session.new_upload_commit().await.unwrap();
         let (handle, _cleaner) = commit
-            .upload_file(Some("stream.bin".into()), 1024, Sha256Policy::Compute)
+            .upload_file(Some("stream.bin".into()), Some(1024), Sha256Policy::Compute)
             .await
             .unwrap();
         assert!(handle.status().is_err());
@@ -1097,7 +1097,7 @@ mod tests {
         let data = b"streamed upload bytes";
         let commit = session.new_upload_commit().await.unwrap();
         let (_handle, mut cleaner) = commit
-            .upload_file(Some("stream.bin".into()), data.len() as u64, Sha256Policy::Compute)
+            .upload_file(Some("stream.bin".into()), Some(data.len() as u64), Sha256Policy::Compute)
             .await
             .unwrap();
         cleaner.add_data(data).await.unwrap();
@@ -1297,7 +1297,7 @@ mod tests {
         let runtime = session.runtime.clone();
         let commit = session.new_upload_commit_blocking()?;
         let (_handle, mut cleaner) =
-            commit.upload_file_blocking(Some("stream.bin".into()), data.len() as u64, Sha256Policy::Compute)?;
+            commit.upload_file_blocking(Some("stream.bin".into()), Some(data.len() as u64), Sha256Policy::Compute)?;
         let (hash, file_size) = runtime.external_run_async_task(async move {
             cleaner.add_data(data).await.unwrap();
             let (xfi, _) = cleaner.finish().await.unwrap();

--- a/xet_runtime/src/config/python.rs
+++ b/xet_runtime/src/config/python.rs
@@ -95,7 +95,7 @@ impl PythonConfigValue for ConfigEnum {
 
     fn update_from_python(&mut self, obj: &Bound<'_, PyAny>) -> PyResult<()> {
         let s: String = obj.extract()?;
-        self.try_set(&s).map_err(|e| pyo3::exceptions::PyValueError::new_err(e))
+        self.try_set(&s).map_err(pyo3::exceptions::PyValueError::new_err)
     }
 }
 

--- a/xet_runtime/src/core/par_utils.rs
+++ b/xet_runtime/src/core/par_utils.rs
@@ -257,7 +257,7 @@ mod parallel_tests {
         if let Err(ParutilsError::Join(e)) = result {
             assert!(e.is_panic());
         } else {
-            assert!(false, "Expected to panic, but got {:?}", result);
+            panic!("Expected to panic, but got {:?}", result);
         }
     }
 }

--- a/xet_runtime/src/core/sync_primatives.rs
+++ b/xet_runtime/src/core/sync_primatives.rs
@@ -173,7 +173,6 @@ mod tests {
         thread::sleep(Duration::from_millis(300));
 
         // If we reached here without panic, behavior is as intended.
-        assert!(true);
     }
 
     #[test]

--- a/xet_runtime/src/utils/configuration_utils.rs
+++ b/xet_runtime/src/utils/configuration_utils.rs
@@ -396,7 +396,7 @@ mod tests {
             0i64,
             i64::MIN,
             0.0f32,
-            3.14f32,
+            std::f32::consts::PI,
             -1.5f32,
             0.0f64,
             std::f64::consts::PI,


### PR DESCRIPTION
## Summary
Make the `size` parameter of `FileUploadSession::start_clean()` optional by changing from `u64` to `Option<u64>`. This allows FUSE streaming uploads where the final file size is unknown, preventing debug assertion panics when `completed_bytes` exceeds the initially declared `total_bytes=0`.

## Changes
- `start_clean()` signature now takes `Option<u64>` for size
- All existing callers updated to wrap size argument in `Some(...)`
- Updated public API `upload_file()` to use `Option<u64>`
- Fixed test calls to use `Some()` wrapper

## Breaking Changes
- `FileUploadSession::start_clean()` signature changed from `size: u64` to `size: Option<u64>`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking API change across upload/cleaning entry points (`start_clean`/`upload_file`) that affects progress tracking and completion accounting; incorrect `None` handling could cause misreported progress or assertions at finalize. Most call sites/tests are updated mechanically, lowering risk to runtime behavior beyond the new unknown-size path.
> 
> **Overview**
> Makes streaming upload size optional by changing `FileUploadSession::start_clean` (and `UploadCommit::upload_file` / `upload_file_blocking`) to take `Option<u64>` so callers can stream when the final size is unknown.
> 
> Updates all internal call sites, examples, and integration/unit tests to pass `Some(size)` where sizes are known, and wires the optional size through to the completion/progress tracker registration.
> 
> Includes a few small cleanup tweaks unrelated to the API change (minor error mapping simplification in python config bindings, test assertion style improvements, and replacing a float literal with `std::f32::consts::PI`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16447dae52e28c7d234f49b3c932a4cd6410aa9a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->