### PR TITLE
Avoid extra reconstruction request that returns 416

### DIFF
--- a/wasm/hf_xet_thin_wasm/Cargo.lock
+++ b/wasm/hf_xet_thin_wasm/Cargo.lock
@@ -3295,7 +3295,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "xet-client"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3333,7 +3333,7 @@ dependencies = [
 
 [[package]]
 name = "xet-core-structures"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -3368,7 +3368,7 @@ dependencies = [
 
 [[package]]
 name = "xet-data"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "xet-runtime"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/xet_data/src/file_reconstruction/reconstruction_terms/manager.rs
+++ b/xet_data/src/file_reconstruction/reconstruction_terms/manager.rs
@@ -283,6 +283,14 @@ impl ReconstructionTermManager {
         let file_hash = self.file_hash;
 
         let jh = tokio::task::spawn(async move {
+            // Check if a previously completed block has already discovered the file end,
+            // making this request unnecessary. This avoids sending a request that would
+            // return a 416 Range Not Satisfiable.
+            if prefetch_block_range.start >= known_final_byte_position.load(Ordering::Relaxed) {
+                known_final_byte_position.fetch_min(prefetch_block_range.start, Ordering::Relaxed);
+                return Ok(None);
+            }
+
             let result = retrieve_file_term_block(client, file_hash, prefetch_block_range).await;
 
             // See if we're done with the file.

--- a/xet_data/src/file_reconstruction/reconstruction_terms/manager.rs
+++ b/xet_data/src/file_reconstruction/reconstruction_terms/manager.rs
@@ -287,7 +287,6 @@ impl ReconstructionTermManager {
             // making this request unnecessary. This avoids sending a request that would
             // return a 416 Range Not Satisfiable.
             if prefetch_block_range.start >= known_final_byte_position.load(Ordering::Relaxed) {
-                known_final_byte_position.fetch_min(prefetch_block_range.start, Ordering::Relaxed);
                 return Ok(None);
             }
 


### PR DESCRIPTION
## Summary
- Prefetch tasks are spawned eagerly during file download (at least two queued upfront in `new()`), but later tasks don't check whether an earlier task has already discovered the true end of file
- This causes the last prefetch task to always send an unnecessary HTTP reconstruction request that returns a 416 Range Not Satisfiable
- Fix: check the `known_final_byte_position` atomic at the start of each spawned task, and short-circuit if a previous task has already found the file end

## Test plan
- [ ] Verify downloads complete successfully without 416 errors in logs
- [ ] Test with small files (covered by first prefetch block) and large files (multiple prefetch blocks)
- [ ] Confirm no regression in download performance

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to prefetch task scheduling that only short-circuits requests once EOF is already known, plus lockfile version bumps.
> 
> **Overview**
> Avoids sending redundant reconstruction range requests that would return `416 Range Not Satisfiable` by having each spawned prefetch task check `known_final_byte_position` and exit early when the requested start is already past the discovered EOF.
> 
> Also bumps `xet-*` crate versions from `1.4.0` to `1.5.0` in the WASM `Cargo.lock`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ff4ed6b2eb97458c846a053ed386ed4e2537390. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->