### PR TITLE
Fix git-xet Windows installer build

### DIFF
--- a/.github/workflows/git-xet-release.yml
+++ b/.github/workflows/git-xet-release.yml
@@ -11,6 +11,7 @@ on:
         description: "Semantic version for release (tag will shard the same name)"
         required: true
         default: "v0.1.0"
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/git-xet-release.yml
+++ b/.github/workflows/git-xet-release.yml
@@ -11,7 +11,6 @@ on:
         description: "Semantic version for release (tag will shard the same name)"
         required: true
         default: "v0.1.0"
-  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/git-xet-release.yml
+++ b/.github/workflows/git-xet-release.yml
@@ -117,7 +117,7 @@ jobs:
         run: |
           cp git_xet/windows_installer/Package.wxs dist/
           cd dist
-          wix build Package.wxs -o bin\git-xet-windows-installer -arch ${{ matrix.platform.wix_arch }}
+          wix build -acceptEula wix7 Package.wxs -o bin\git-xet-windows-installer -arch ${{ matrix.platform.wix_arch }}
       - name: Codesign the installer
         uses: ./.github/actions/windows-codesign
         with:


### PR DESCRIPTION
Accept the EULA after sponsoring wixtoolset: https://docs.firegiant.com/wix/osmf/#direct-acceptance

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that alters the WiX build invocation for the Windows installer; primary impact is on release CI behavior.
> 
> **Overview**
> Fixes the Windows release workflow by updating the WiX installer build step to explicitly accept the WiX Toolset EULA (via `wix build -acceptEula wix7 ...`). This unblocks `git-xet` Windows MSI generation in CI without changing the application binaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 745bb231c52230349c93915d327d7a732cad7f28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->