### PR TITLE
Add a function to serialize MDBMinimalShard with a preset timestamp

### DIFF
--- a/xet_core_structures/src/metadata_shard/streaming_shard.rs
+++ b/xet_core_structures/src/metadata_shard/streaming_shard.rs
@@ -338,6 +338,7 @@ impl MDBMinimalShard {
         writer: &mut W,
         with_file_section: bool,
         with_verification: bool,
+        timestamp: Option<SystemTime>,
         expiry: Option<SystemTime>,
         xorb_filter_fn: impl Fn(&MDBXorbInfoView) -> bool,
     ) -> Result<usize> {
@@ -409,7 +410,9 @@ impl MDBMinimalShard {
             xorb_lookup_num_entry: 0,
             chunk_lookup_offset: footer_start,
             chunk_lookup_num_entry: 0,
-            shard_creation_timestamp: current_timestamp(),
+            shard_creation_timestamp: timestamp
+                .map(|t| t.duration_since(std::time::UNIX_EPOCH).unwrap_or_default().as_secs())
+                .unwrap_or_else(current_timestamp),
             shard_key_expiry: expiry
                 .map_or(0, |t| t.duration_since(std::time::UNIX_EPOCH).unwrap_or_default().as_secs()),
             stored_bytes_on_disk,
@@ -430,7 +433,7 @@ impl MDBMinimalShard {
         writer: &mut W,
         xorb_filter_fn: impl Fn(&MDBXorbInfoView) -> bool,
     ) -> Result<usize> {
-        self.serialize_impl(writer, false, false, None, xorb_filter_fn)
+        self.serialize_impl(writer, false, false, None, None, xorb_filter_fn)
     }
 
     /// Serialize out a shard without file information, with the given expiration time set in the footer.
@@ -441,13 +444,24 @@ impl MDBMinimalShard {
         expiry: Option<SystemTime>,
         xorb_filter_fn: impl Fn(&MDBXorbInfoView) -> bool,
     ) -> Result<usize> {
-        self.serialize_impl(writer, false, false, expiry, xorb_filter_fn)
+        self.serialize_impl(writer, false, false, None, expiry, xorb_filter_fn)
     }
 
     /// Serialize out the given shard, sanitizing and updating the global dedup chunk flags and optionally
     /// dropping the file verification section.
     pub fn serialize<W: Write>(&self, writer: &mut W, with_verification: bool) -> Result<usize> {
-        self.serialize_impl(writer, true, with_verification, None, |_| true)
+        self.serialize_impl(writer, true, with_verification, None, None, |_| true)
+    }
+
+    /// Serialize out the given shard with a preset timestamp, sanitizing and updating the global dedup chunk
+    /// flags and optionally dropping the file verification section.
+    pub fn serialize_with_timestamp<W: Write>(
+        &self,
+        writer: &mut W,
+        with_verification: bool,
+        timestamp: SystemTime,
+    ) -> Result<usize> {
+        self.serialize_impl(writer, true, with_verification, Some(timestamp), None, |_| true)
     }
 
     /// Returns a list of all the global dedup eligible chunks, as given either by the hash value, file starts, or


### PR DESCRIPTION
To be used in https://github.com/huggingface-internal/xetcas/pull/1015

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shard serialization/footer metadata and changes `serialize_impl` call signatures, which could affect on-disk shard determinism and any callers relying on the previous timestamp behavior.
> 
> **Overview**
> Adds support for deterministic shard serialization by allowing `MDBMinimalShard` to be serialized with a caller-provided creation timestamp.
> 
> `serialize_impl` now accepts an optional `timestamp` and uses it to populate `MDBShardFileFooter.shard_creation_timestamp`, while existing serialization paths continue to default to `current_timestamp`; a new `serialize_with_timestamp` API is added and existing `serialize_*` helpers are updated to pass the new parameter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 687a9bcd11287b6df9c3f01e0b426da35a6ff43d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->