### PR TITLE
set version 1.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2001,7 +2001,7 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hf-xet"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "anyhow",
  "async-std",
@@ -6047,7 +6047,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "xet-client"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "anyhow",
  "approx",
@@ -6095,7 +6095,7 @@ dependencies = [
 
 [[package]]
 name = "xet-core-structures"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6134,7 +6134,7 @@ dependencies = [
 
 [[package]]
 name = "xet-data"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "xet-runtime"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 exclude = ["simulation/chunk_cache_bench", "hf_xet", "wasm/hf_xet_wasm", "wasm/hf_xet_thin_wasm"]
 
 [workspace.package]
-version = "1.5.1"
+version = "1.5.2"
 edition = "2024"
 license = "Apache-2.0"
 homepage = "https://github.com/huggingface/xet-core"

--- a/hf_xet/Cargo.lock
+++ b/hf_xet/Cargo.lock
@@ -1089,7 +1089,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hf-xet"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4088,7 +4088,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "xet-client"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4124,7 +4124,7 @@ dependencies = [
 
 [[package]]
 name = "xet-core-structures"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4159,7 +4159,7 @@ dependencies = [
 
 [[package]]
 name = "xet-data"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4190,7 +4190,7 @@ dependencies = [
 
 [[package]]
 name = "xet-runtime"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/wasm/hf_xet_thin_wasm/Cargo.lock
+++ b/wasm/hf_xet_thin_wasm/Cargo.lock
@@ -3180,7 +3180,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "xet-client"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3216,7 +3216,7 @@ dependencies = [
 
 [[package]]
 name = "xet-core-structures"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "async-trait",
  "base64",
@@ -3251,7 +3251,7 @@ dependencies = [
 
 [[package]]
 name = "xet-data"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3282,7 +3282,7 @@ dependencies = [
 
 [[package]]
 name = "xet-runtime"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/wasm/hf_xet_wasm/Cargo.lock
+++ b/wasm/hf_xet_wasm/Cargo.lock
@@ -3352,7 +3352,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "xet-client"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3388,7 +3388,7 @@ dependencies = [
 
 [[package]]
 name = "xet-core-structures"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "async-trait",
  "base64",
@@ -3423,7 +3423,7 @@ dependencies = [
 
 [[package]]
 name = "xet-data"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3454,7 +3454,7 @@ dependencies = [
 
 [[package]]
 name = "xet-runtime"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/xet_client/Cargo.toml
+++ b/xet_client/Cargo.toml
@@ -15,8 +15,8 @@ name = "xet_client"
 path = "src/lib.rs"
 
 [dependencies]
-xet-runtime = { version = "1.5.1", path = "../xet_runtime" }
-xet-core-structures = { version = "1.5.1", path = "../xet_core_structures" }
+xet-runtime = { version = "1.5.2", path = "../xet_runtime" }
+xet-core-structures = { version = "1.5.2", path = "../xet_core_structures" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/xet_core_structures/Cargo.toml
+++ b/xet_core_structures/Cargo.toml
@@ -25,7 +25,7 @@ harness = false
 bench = true
 
 [dependencies]
-xet-runtime = { version = "1.5.1", path = "../xet_runtime" }
+xet-runtime = { version = "1.5.2", path = "../xet_runtime" }
 
 async-trait = { workspace = true }
 base64 = { workspace = true }

--- a/xet_data/Cargo.toml
+++ b/xet_data/Cargo.toml
@@ -16,9 +16,9 @@ path = "src/lib.rs"
 doctest = false
 
 [dependencies]
-xet-runtime = { version = "1.5.1", path = "../xet_runtime" }
-xet-core-structures = { version = "1.5.1", path = "../xet_core_structures" }
-xet-client = { version = "1.5.1", path = "../xet_client" }
+xet-runtime = { version = "1.5.2", path = "../xet_runtime" }
+xet-core-structures = { version = "1.5.2", path = "../xet_core_structures" }
+xet-client = { version = "1.5.2", path = "../xet_client" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/xet_pkg/Cargo.toml
+++ b/xet_pkg/Cargo.toml
@@ -26,10 +26,10 @@ name = "xet"
 path = "src/lib.rs"
 
 [dependencies]
-xet-runtime = { version = "1.5.1", path = "../xet_runtime" }
-xet-core-structures = { version = "1.5.1", path = "../xet_core_structures" }
-xet-client = { version = "1.5.1", path = "../xet_client" }
-xet-data = { version = "1.5.1", path = "../xet_data" }
+xet-runtime = { version = "1.5.2", path = "../xet_runtime" }
+xet-core-structures = { version = "1.5.2", path = "../xet_core_structures" }
+xet-client = { version = "1.5.2", path = "../xet_client" }
+xet-data = { version = "1.5.2", path = "../xet_data" }
 
 async-trait = { workspace = true }
 bytes = { workspace = true }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this is a coordinated version bump across workspace manifests and lockfiles with no functional code changes.
> 
> **Overview**
> Bumps the workspace/package version to `1.5.2` and updates internal crate dependency pins (`xet-runtime`, `xet-core-structures`, `xet-client`, `xet-data`, `hf-xet`) from `1.5.1` to `1.5.2`.
> 
> Regenerates lockfiles (`Cargo.lock` plus lockfiles under `hf_xet/` and `wasm/`) to reflect the new `1.5.2` crate versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4ec15471dcc8b5e73024637b23274f71dff5c0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->