### PR TITLE
Potential fix for a couple of crates release issues

### DIFF
--- a/.github/workflows/bump-crates-version.yml
+++ b/.github/workflows/bump-crates-version.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Check workspace compiles
         run: cargo build
 
+      - name: Run tests
+        run: cargo test --workspace
+
       - uses: ./.github/actions/build-wasm
 
       - name: Build hf-xet wheel

--- a/.github/workflows/bump-crates-version.yml
+++ b/.github/workflows/bump-crates-version.yml
@@ -12,10 +12,6 @@ permissions:
   contents: write
   pull-requests: write
 
-concurrency:
-  group: crates-release
-  cancel-in-progress: false
-
 jobs:
   bump_crates_version:
     name: Bump crate versions and create PR

--- a/.github/workflows/bump-crates-version.yml
+++ b/.github/workflows/bump-crates-version.yml
@@ -57,9 +57,6 @@ jobs:
       - name: Check workspace compiles
         run: cargo build
 
-      - name: Run tests
-        run: cargo test --workspace
-
       - uses: ./.github/actions/build-wasm
 
       - name: Build hf-xet wheel

--- a/.github/workflows/crates-release.yml
+++ b/.github/workflows/crates-release.yml
@@ -14,7 +14,7 @@ permissions:
 
 concurrency:
   group: crates-release
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   publish:

--- a/.github/workflows/crates-release.yml
+++ b/.github/workflows/crates-release.yml
@@ -14,7 +14,7 @@ permissions:
 
 concurrency:
   group: crates-release
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   publish:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4176,9 +4176,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
"bump-crates-version" and "crates-release" was under the same group, and a Run https://github.com/huggingface/xet-core/actions/runs/24692834954 was stuck forever under "Queued" state likely due to a failed "bump-crates-version" run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to GitHub Actions workflow scheduling and a patch-level dependency lockfile update.
> 
> **Overview**
> **Release automation adjustment:** Removes the `concurrency` group from `.github/workflows/bump-crates-version.yml` so version-bump runs no longer block (or get blocked by) the `crates-release` workflow.
> 
> **Dependency lockfile refresh:** Updates `Cargo.lock` to bump `rustls-webpki` from `0.103.12` to `0.103.13` (checksum updated accordingly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d789473fa560281c0e9b7202cbbd109591f1b385. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->