### PR TITLE
Raise HF_XET_CLIENT_READ_TIMEOUT to 300s + clean up query_dedup 404 log

### DIFF
--- a/xet_client/src/cas_client/remote_client.rs
+++ b/xet_client/src/cas_client/remote_client.rs
@@ -582,7 +582,7 @@ impl Client for RemoteClient {
         // Use the no-read-timeout client for shard uploads. reqwest's per-request timeout()
         // does NOT override the client-level read_timeout(), so we use a separate client
         // with no read_timeout. Server-side shard processing scales linearly with file entry
-        // count and can exceed the global read_timeout (120s) for large shards.
+        // count and can exceed the global read_timeout (300s) for large shards.
         #[cfg(not(target_family = "wasm"))]
         let client = self.shard_upload_http_client.clone();
 

--- a/xet_client/src/cas_client/remote_client.rs
+++ b/xet_client/src/cas_client/remote_client.rs
@@ -155,6 +155,7 @@ impl RemoteClient {
 
         let result = RetryWrapper::new(self.ctx.clone(), api_tag)
             .with_429_no_retry()
+            .with_expected_404()
             .log_errors_as_info()
             .run(move || client.get(url.clone()).with_extension(Api(api_tag)).send())
             .await;

--- a/xet_client/src/cas_client/retry_wrapper.rs
+++ b/xet_client/src/cas_client/retry_wrapper.rs
@@ -31,6 +31,7 @@ pub struct RetryWrapper {
     no_retry_on_429: bool,
     retry_on_403: bool,
     expected_416: bool,
+    expected_404: bool,
     log_errors_as_info: bool,
     api_tag: &'static str,
     connection_permit: Option<Mutex<ConnectionPermitInfo>>,
@@ -46,6 +47,7 @@ impl RetryWrapper {
             no_retry_on_429: false,
             retry_on_403: false,
             expected_416: false,
+            expected_404: false,
             log_errors_as_info: false,
             api_tag,
             connection_permit: None,
@@ -74,6 +76,15 @@ impl RetryWrapper {
 
     pub fn with_expected_416(mut self) -> Self {
         self.expected_416 = true;
+        self
+    }
+
+    /// Mark 404 responses as expected (e.g. `query_dedup` cache miss). When set,
+    /// a 404 is still returned as a fatal (non-retried) error to the caller — which is
+    /// usually handled by the caller converting it to `Ok(None)` — but it is logged as
+    /// a cache miss instead of the misleading `"Fatal Error"`.
+    pub fn with_expected_404(mut self) -> Self {
+        self.expected_404 = true;
         self
     }
 
@@ -165,6 +176,9 @@ impl RetryWrapper {
                     Err(RetryableReqwestError::RetryableError(cas_err))
                 } else if e.status() == Some(StatusCode::RANGE_NOT_SATISFIABLE) && self.expected_416 {
                     let cas_err = process_error("Reached end of reconstruction 416 (Range Not Satisfiable)", e, true);
+                    Err(RetryableReqwestError::FatalError(cas_err))
+                } else if e.status() == Some(StatusCode::NOT_FOUND) && self.expected_404 {
+                    let cas_err = process_error("Not Found (cache miss)", e, true);
                     Err(RetryableReqwestError::FatalError(cas_err))
                 } else {
                     let cas_err = process_error("Fatal Error", e, false);
@@ -855,6 +869,37 @@ mod tests {
         check_429_no_retry(&server).await;
         check_json_reserialization(&server).await;
         check_json_unexpected_eof_retry(&server).await;
+    }
+
+    #[tokio::test]
+    async fn test_404_expected_is_fatal_and_not_retried() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/not_found"))
+            .respond_with(ResponseTemplate::new(404))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = make_client();
+        let counter = Arc::new(AtomicU32::new(0));
+        let counter_ = counter.clone();
+
+        let result = connection_wrapper("test_404_expected_is_fatal_and_not_retried")
+            .with_max_attempts(3)
+            .with_expected_404()
+            .run(move || {
+                let url = format!("{}/not_found", server.uri());
+                counter_.fetch_add(1, Ordering::Relaxed);
+                client.clone().get(&url).send()
+            })
+            .await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.status(), Some(StatusCode::NOT_FOUND));
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/xet_runtime/src/config/groups/client.rs
+++ b/xet_runtime/src/config/groups/client.rs
@@ -54,10 +54,10 @@ crate::config_group!({
     /// transfers to complete. If no data is received for this duration, the connection
     /// is considered stalled and will timeout.
     ///
-    /// The default value is 120 seconds.
+    /// The default value is 300 seconds.
     ///
     /// Use the environment variable `HF_XET_CLIENT_READ_TIMEOUT` to set this value.
-    ref read_timeout: Duration = Duration::from_secs(120);
+    ref read_timeout: Duration = Duration::from_secs(300);
 
     /// Send a report of a successful partial upload every 512kb.
     ///


### PR DESCRIPTION
Two connected cleanups from the [2026-04-21 Julien upload-stuck investigation](https://www.notion.so/huggingface2/Julien-upload-stuck-upload_xorb-120s-timeouts-2026-04-21-3491384ebcac81a19d0af5394745cfff). Closes #807. Docs PR: huggingface/hub-docs#2419.

## Change 1 — raise `HF_XET_CLIENT_READ_TIMEOUT` default 120s → 300s

**Files:** `xet_runtime/src/config/groups/client.rs`, `xet_client/src/cas_client/remote_client.rs` (stale comment).

The 120s client read timeout was firing before legitimate `upload_xorb` requests could complete on high-latency / transatlantic / bursty links. Fleet-wide this produced a **chronic 30–50% xorb POST failure rate** (1,092–4,196 `error uploading xorb` events per hour sustained over 24h, peaking at 49.1% in the investigation window). 267 successful uploads in the same 24h had latency > 120s (max 37 min), so 120s wasn't protecting anything legitimate — it was only cutting off slow-but-healthy streams.

300s preserves stall-detection semantics (still an order of magnitude under the 3600s ALB idle). The env override `HF_XET_CLIENT_READ_TIMEOUT` is unchanged.

## Change 2 — log `query_dedup` 404 as cache miss, not "Fatal Error"

**Files:** `xet_client/src/cas_client/retry_wrapper.rs`, `xet_client/src/cas_client/remote_client.rs`.

A 404 from `cas::query_dedup` is an expected cache miss — the caller converts it to `Ok(None)` and proceeds to upload. Today the retry wrapper logs it as `Fatal Error: \"cas::query_dedup\" api call failed ... 404 Not Found`, producing **20+ alarming-looking lines per upload session** with no actual failure behind them (Hoyt flagged this in the incident Slack thread).

Fix: add `RetryWrapper::with_expected_404()` — mirroring the existing `with_expected_416()` pattern — and opt `query_dedup` into it. The 404 still short-circuits retries and surfaces as a fatal error to the caller (preserving the existing `Ok(None)` conversion), but the log line now reads `Not Found (cache miss): \"cas::query_dedup\" api call failed ... 404 Not Found`.

## Test plan

- [x] `cargo +nightly fmt --all --check` clean
- [x] `cargo test -p xet-client --lib cas_client::retry_wrapper` — 5 passed (incl. new `test_404_expected_is_fatal_and_not_retried`)
- [ ] Manually verify `HF_XET_CLIENT_READ_TIMEOUT=120` still overrides via env
- [ ] Confirm a session run produces no `Fatal Error:` lines for the `query_dedup` 404s
- [ ] Watch the xorb POST error-rate panel on the [CAS Grafana dashboard](https://grafana.huggingface.tech/d/dejp4w2hael1cb/cas) after release; expect the 120s-clustered p50 to disappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts client networking defaults (read timeout) and alters retry-wrapper handling/logging for HTTP 404s, which can change behavior and observability for slow uploads and cache-miss paths.
> 
> **Overview**
> Raises the default `HF_XET_CLIENT_READ_TIMEOUT` from 120s to 300s to better tolerate slow-but-progressing transfers.
> 
> Adds `RetryWrapper::with_expected_404()` and opts `cas::query_dedup` into it so 404 responses are still non-retried/fatal to the caller but are logged as an expected *cache miss* (with a new unit test covering the no-retry behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e88f9cf8f9a4e2139caa23c883c45744aa37c65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->