### PR TITLE
Bump hf_xet rand to 0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4176,9 +4176,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ oneshot = "0.1"
 pin-project = "1"
 pyo3 = { version = "0.26", features = ["abi3-py37", "multiple-pymethods"] }
 rand = "0.10"
-rand_chacha = "0.9"
+rand_chacha = "0.10"
 regex = "1"
 reqwest = { version = "0.13.1", features = [
     "json",

--- a/hf_xet/Cargo.lock
+++ b/hf_xet/Cargo.lock
@@ -1120,7 +1120,7 @@ dependencies = [
  "lazy_static",
  "pprof",
  "pyo3",
- "rand 0.9.2",
+ "rand 0.10.1",
  "signal-hook",
  "tracing",
  "winapi",

--- a/hf_xet/Cargo.toml
+++ b/hf_xet/Cargo.toml
@@ -27,7 +27,7 @@ pyo3 = { version = "0.26", features = [
     "abi3-py37",
     "auto-initialize",
 ] }
-rand = "0.9"
+rand = "0.10"
 tracing = "0.1"
 http = "1" 
 

--- a/hf_xet/src/lib.rs
+++ b/hf_xet/src/lib.rs
@@ -13,7 +13,7 @@ use itertools::Itertools;
 use pyo3::exceptions::{PyKeyboardInterrupt, PyValueError};
 use pyo3::prelude::*;
 use pyo3::pyfunction;
-use rand::Rng;
+use rand::RngExt;
 use runtime::{async_run, get_or_init_runtime};
 use token_refresh::WrappedTokenRefresher;
 use tracing::debug;

--- a/simulation/chunk_cache_bench/Cargo.lock
+++ b/simulation/chunk_cache_bench/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
  "criterion",
  "r2d2",
  "r2d2_postgres",
- "rand 0.8.5",
+ "rand 0.10.1",
  "sccache",
  "tempfile",
  "tokio",
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "xet-client"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5235,7 +5235,7 @@ dependencies = [
 
 [[package]]
 name = "xet-core-structures"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5270,7 +5270,7 @@ dependencies = [
 
 [[package]]
 name = "xet-runtime"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/simulation/chunk_cache_bench/Cargo.lock
+++ b/simulation/chunk_cache_bench/Cargo.lock
@@ -405,6 +405,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "xet-client",
+ "xet-runtime",
 ]
 
 [[package]]

--- a/simulation/chunk_cache_bench/Cargo.toml
+++ b/simulation/chunk_cache_bench/Cargo.toml
@@ -28,4 +28,4 @@ name = "cache_resilience_test"
 
 [dev-dependencies]
 criterion = { version = "0.4", features = ["async_tokio"] }
-rand = "0.8"
+rand = "0.10"

--- a/simulation/chunk_cache_bench/Cargo.toml
+++ b/simulation/chunk_cache_bench/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 
 [dependencies]
 xet-client = { path = "../../xet_client" }
+xet-runtime = { path = "../../xet_runtime" }
 
 async-trait = "0.1"
 base64 = "0.22"

--- a/simulation/chunk_cache_bench/benches/cache_bench.rs
+++ b/simulation/chunk_cache_bench/benches/cache_bench.rs
@@ -7,7 +7,7 @@ use chunk_cache_bench::solid_cache::SolidCache;
 use chunk_cache_bench::ChunkCacheExt;
 use criterion::{criterion_group, BenchmarkId, Criterion};
 use rand::rngs::StdRng;
-use rand::{thread_rng, SeedableRng};
+use rand::{rng, SeedableRng};
 use tokio::task::JoinSet;
 
 const SEED: u64 = 42;
@@ -56,7 +56,7 @@ fn benchmark_cache_get_mt<T: ChunkCacheExt + 'static>(c: &mut Criterion) {
             for _ in 0..NUM_CONCURRENT_TASKS {
                 let c = cache.clone();
                 handles.spawn(async move {
-                    let mut rng = thread_rng();
+                    let mut rng = rng();
                     let key = random_key(&mut rng);
                     let range = random_range(&mut rng);
                     c.get(&key, &range).unwrap()
@@ -86,7 +86,7 @@ fn benchmark_cache_put_mt<T: ChunkCacheExt + 'static>(c: &mut Criterion) {
             for _ in 0..NUM_CONCURRENT_TASKS {
                 let c = cache.clone();
                 handles.spawn(async move {
-                    let mut it = RandomEntryIterator::new(thread_rng());
+                    let mut it = RandomEntryIterator::new(rng());
                     let (key, range, offsets, data) = it.next().unwrap();
                     c.put(&key, &range, &offsets, &data).unwrap();
                 });

--- a/simulation/chunk_cache_bench/benches/cache_bench.rs
+++ b/simulation/chunk_cache_bench/benches/cache_bench.rs
@@ -23,16 +23,17 @@ fn benchmark_cache_get<T: ChunkCacheExt>(c: &mut Criterion) {
     let mut rng = StdRng::seed_from_u64(SEED);
     let mut it: RandomEntryIterator<StdRng> = RandomEntryIterator::from_seed(SEED).with_range_len(RANGE_LEN);
 
+    let rt = tokio::runtime::Runtime::new().unwrap();
     for _ in 0..NUM_PUTS {
         let (key, range, offsets, data) = it.next().unwrap();
-        cache.put(&key, &range, &offsets, &data).unwrap();
+        rt.block_on(cache.put(&key, &range, &offsets, &data)).unwrap();
     }
     let name = format!("cache_get_{}", T::name());
     c.bench_function(name.as_str(), |b| {
         b.iter(|| {
             let key = random_key(&mut rng);
             let range = random_range(&mut rng);
-            cache.get(&key, &range).unwrap();
+            rt.block_on(cache.get(&key, &range)).unwrap();
         })
     });
 }
@@ -43,23 +44,23 @@ fn benchmark_cache_get_mt<T: ChunkCacheExt + 'static>(c: &mut Criterion) {
 
     let mut it: RandomEntryIterator<StdRng> = RandomEntryIterator::from_seed(SEED).with_range_len(RANGE_LEN);
 
+    let rt = tokio::runtime::Runtime::new().unwrap();
     for _ in 0..NUM_PUTS {
         let (key, range, offsets, data) = it.next().unwrap();
-        cache.put(&key, &range, &offsets, &data).unwrap();
+        rt.block_on(cache.put(&key, &range, &offsets, &data)).unwrap();
     }
-
-    let rt = tokio::runtime::Runtime::new().unwrap();
 
     c.bench_with_input(BenchmarkId::new("cache_get_mt", T::name()), &0, |b, _| {
         b.to_async(&rt).iter(|| async {
             let mut handles = JoinSet::new();
             for _ in 0..NUM_CONCURRENT_TASKS {
                 let c = cache.clone();
-                handles.spawn(async move {
+                let (key, range) = {
                     let mut rng = rng();
-                    let key = random_key(&mut rng);
-                    let range = random_range(&mut rng);
-                    c.get(&key, &range).unwrap()
+                    (random_key(&mut rng), random_range(&mut rng))
+                };
+                handles.spawn(async move {
+                    c.get(&key, &range).await.unwrap()
                 });
             }
             handles.join_all().await;
@@ -72,23 +73,25 @@ fn benchmark_cache_put_mt<T: ChunkCacheExt + 'static>(c: &mut Criterion) {
     let cache = T::_initialize(cache_root.path().to_path_buf(), CAPACITY).unwrap();
     let mut it: RandomEntryIterator<StdRng> = RandomEntryIterator::from_seed(SEED);
     let mut total_bytes = 0;
-    while total_bytes < CAPACITY {
-        let (key, range, chunk_byte_indices, data) = it.next().unwrap();
-        cache.put(&key, &range, &chunk_byte_indices, &data).unwrap();
-        total_bytes += data.len() as u64;
-    }
 
     let rt = tokio::runtime::Runtime::new().unwrap();
+    while total_bytes < CAPACITY {
+        let (key, range, chunk_byte_indices, data) = it.next().unwrap();
+        rt.block_on(cache.put(&key, &range, &chunk_byte_indices, &data)).unwrap();
+        total_bytes += data.len() as u64;
+    }
 
     c.bench_with_input(BenchmarkId::new("cache_put_mt", T::name()), &0, |b, _| {
         b.to_async(&rt).iter(|| async {
             let mut handles = JoinSet::new();
             for _ in 0..NUM_CONCURRENT_TASKS {
                 let c = cache.clone();
-                handles.spawn(async move {
+                let (key, range, offsets, data) = {
                     let mut it = RandomEntryIterator::new(rng());
-                    let (key, range, offsets, data) = it.next().unwrap();
-                    c.put(&key, &range, &offsets, &data).unwrap();
+                    it.next().unwrap()
+                };
+                handles.spawn(async move {
+                    c.put(&key, &range, &offsets, &data).await.unwrap();
                 });
             }
             handles.join_all().await;
@@ -102,9 +105,11 @@ fn benchmark_cache_put<T: ChunkCacheExt + 'static>(c: &mut Criterion) {
 
     let mut it: RandomEntryIterator<StdRng> = RandomEntryIterator::from_seed(SEED);
     let mut total_bytes = 0;
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
     while total_bytes < CAPACITY {
         let (key, range, chunk_byte_indices, data) = it.next().unwrap();
-        cache.put(&key, &range, &chunk_byte_indices, &data).unwrap();
+        rt.block_on(cache.put(&key, &range, &chunk_byte_indices, &data)).unwrap();
         total_bytes += data.len() as u64;
     }
 
@@ -112,7 +117,7 @@ fn benchmark_cache_put<T: ChunkCacheExt + 'static>(c: &mut Criterion) {
     c.bench_function(name.as_str(), |b| {
         b.iter(|| {
             let (key, range, offsets, data) = it.next().unwrap();
-            cache.put(&key, &range, &offsets, &data).unwrap();
+            rt.block_on(cache.put(&key, &range, &offsets, &data)).unwrap();
         })
     });
 }
@@ -123,10 +128,11 @@ fn benchmark_cache_get_hits<T: ChunkCacheExt + 'static>(c: &mut Criterion) {
 
     let mut it: RandomEntryIterator<StdRng> = RandomEntryIterator::from_seed(SEED).with_range_len(RANGE_LEN);
 
+    let rt = tokio::runtime::Runtime::new().unwrap();
     let mut kr = Vec::with_capacity(NUM_PUTS as usize);
     for _ in 0..NUM_PUTS {
         let (key, range, offsets, data) = it.next().unwrap();
-        cache.put(&key, &range, &offsets, &data).unwrap();
+        rt.block_on(cache.put(&key, &range, &offsets, &data)).unwrap();
         kr.push((key, range));
     }
 
@@ -135,7 +141,7 @@ fn benchmark_cache_get_hits<T: ChunkCacheExt + 'static>(c: &mut Criterion) {
     c.bench_function(name.as_str(), |b| {
         b.iter(|| {
             let (key, range) = &kr[i];
-            cache.get(key, range).unwrap().unwrap();
+            rt.block_on(cache.get(key, range)).unwrap().unwrap();
             i = (i + 1) % NUM_PUTS as usize;
         })
     });

--- a/simulation/chunk_cache_bench/src/bin/cache_resilience_test.rs
+++ b/simulation/chunk_cache_bench/src/bin/cache_resilience_test.rs
@@ -4,6 +4,7 @@ use std::time::{Duration, SystemTime};
 
 use xet_client::cas_types::{ChunkRange, Key};
 use xet_client::chunk_cache::{CacheConfig, ChunkCache, DiskCache, RandomEntryIterator};
+use xet_runtime::config::XetConfig;
 use clap::{Args, Parser, Subcommand};
 
 #[derive(Parser, Debug)]
@@ -97,7 +98,8 @@ async fn child_main(args: ChildArgs) {
         cache_directory: PathBuf::from(args.cache_root),
         cache_size: args.capacity,
     };
-    let cache = DiskCache::initialize(&config).unwrap();
+    let xet_config = XetConfig::new();
+    let cache = DiskCache::initialize(&xet_config, &config).unwrap();
 
     eprintln!("initialized id: {id} with {} entries", cache.num_items().await);
 

--- a/simulation/chunk_cache_bench/src/lib.rs
+++ b/simulation/chunk_cache_bench/src/lib.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use xet_client::chunk_cache::error::ChunkCacheError;
 use xet_client::chunk_cache::{CacheConfig, DiskCache};
+use xet_runtime::config::XetConfig;
 
 pub mod sccache;
 pub mod solid_cache;
@@ -18,7 +19,8 @@ impl ChunkCacheExt for xet_client::chunk_cache::DiskCache {
             cache_directory: cache_root,
             cache_size: capacity,
         };
-        DiskCache::initialize(&config)
+        let xet_config = XetConfig::new();
+        DiskCache::initialize(&xet_config, &config)
     }
 
     fn name() -> &'static str {

--- a/simulation/chunk_cache_bench/src/solid_cache.rs
+++ b/simulation/chunk_cache_bench/src/solid_cache.rs
@@ -106,7 +106,7 @@ impl ChunkCache for SolidCache {
 #[cfg(test)]
 mod tests {
     use xet_client::chunk_cache::{ChunkCache, RandomEntryIterator};
-    use rand::thread_rng;
+    use rand::rng;
 
     use super::SolidCache;
 
@@ -114,7 +114,7 @@ mod tests {
     #[ignore = "need a running postgres"]
     async fn test_postgres() {
         let cache = SolidCache::new();
-        let mut it = RandomEntryIterator::new(thread_rng());
+        let mut it = RandomEntryIterator::new(rng());
         let mut kr = Vec::new();
         for _ in 0..5 {
             let (key, range, chunk_byte_indices, data) = it.next().unwrap();
@@ -139,7 +139,7 @@ mod tests {
     #[ignore = "need a running postgres"]
     async fn test_postgres_get_miss() {
         let cache = SolidCache::new();
-        let mut it = RandomEntryIterator::new(thread_rng());
+        let mut it = RandomEntryIterator::new(rng());
 
         let (key, range) = it.next_key_range();
         let result = cache.get(&key, &range).await;


### PR DESCRIPTION
## Summary
- Bump the `rand` dependency in the `hf_xet` crate from `0.9` to `0.10`, matching the workspace version already pinned at `Cargo.toml:81`.
- In rand 0.10 the `random()` method moved from the `Rng` trait to the new `RngExt` trait, so `hf_xet/src/lib.rs` now imports `RngExt`.

## Test plan
- [x] `cargo check` in `hf_xet`
- [x] `cargo clippy --all-targets` in `hf_xet` (no new warnings)
- [x] `cargo test --no-run` in `hf_xet`
- [x] `cargo check --workspace` in repo root

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency/compatibility updates; the only functional code change is adapting random generation imports and updating benchmark utilities to match async cache APIs and new `DiskCache::initialize` signature.
> 
> **Overview**
> Updates dependencies to newer versions: `hf_xet` moves `rand` from `0.9` to `0.10` (and workspace `rand_chacha` to `0.10`), plus lockfile bumps like `rustls-webpki`.
> 
> Adjusts call sites for the `rand 0.10` API change by importing `RngExt` (and using `rand::rng()` in simulation code), and updates `simulation/chunk_cache_bench` to depend on `xet-runtime` and pass `XetConfig` into `DiskCache::initialize`, with benchmark code now `await`/`block_on` async `get`/`put` calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65d922977370d9ac02c03e4bc666134c6c5bb572. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->