### PR TITLE
Remove unnecessary `UniqueId` -> `UniqueID` type alias

### DIFF
--- a/hf_xet/src/lib.rs
+++ b/hf_xet/src/lib.rs
@@ -80,7 +80,7 @@ pub fn hf_xet(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyXetTaskState>()?;
 
     // ── Report types (pyclass-annotated in xet_pkg with "python" feature) ────
-    m.add_class::<xet_pkg::xet_session::UniqueID>()?;
+    m.add_class::<xet_pkg::xet_session::UniqueId>()?;
     m.add_class::<xet_pkg::xet_session::XetFileInfo>()?;
     m.add_class::<xet_pkg::xet_session::DeduplicationMetrics>()?;
     m.add_class::<xet_pkg::xet_session::XetFileMetadata>()?;

--- a/hf_xet/src/py_file_download_group.rs
+++ b/hf_xet/src/py_file_download_group.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use pyo3::prelude::*;
 use xet_pkg::xet_session::{
-    GroupProgressReport, ItemProgressReport, UniqueID, XetDownloadGroupReport, XetFileDownload, XetFileDownloadGroup,
+    GroupProgressReport, ItemProgressReport, UniqueId, XetDownloadGroupReport, XetFileDownload, XetFileDownloadGroup,
     XetFileInfo, XetSession, XetTaskState,
 };
 
@@ -61,7 +61,7 @@ pub(crate) fn build_file_download_group(
                 std::thread::sleep(interval);
                 let is_terminal = !matches!(inner.status(), Ok(XetTaskState::Running) | Ok(XetTaskState::Finalizing));
                 let group_report = inner.progress();
-                let item_reports: HashMap<UniqueID, ItemProgressReport> = handles_for_thread
+                let item_reports: HashMap<UniqueId, ItemProgressReport> = handles_for_thread
                     .read()
                     .map(|g| g.iter().filter_map(|h| h.progress().map(|p| (h.task_id(), p))).collect())
                     .unwrap_or_default();

--- a/hf_xet/src/py_file_download_handle.rs
+++ b/hf_xet/src/py_file_download_handle.rs
@@ -1,5 +1,5 @@
 use pyo3::prelude::*;
-use xet_pkg::xet_session::{ItemProgressReport, UniqueID, XetDownloadReport, XetFileDownload};
+use xet_pkg::xet_session::{ItemProgressReport, UniqueId, XetDownloadReport, XetFileDownload};
 
 use crate::utils::{progress_display, task_state_display, task_state_to_pystate};
 use crate::{PyXetTaskState, convert_xet_error};
@@ -59,7 +59,7 @@ impl PyXetFileDownload {
     /// The unique task ID for this download.
     ///
     /// Matches the keys in :attr:`XetDownloadGroupReport.downloads`.
-    pub fn task_id(&self) -> UniqueID {
+    pub fn task_id(&self) -> UniqueId {
         self.inner.task_id()
     }
 

--- a/hf_xet/src/py_file_upload_handle.rs
+++ b/hf_xet/src/py_file_upload_handle.rs
@@ -1,5 +1,5 @@
 use pyo3::prelude::*;
-use xet_pkg::xet_session::{ItemProgressReport, UniqueID, XetFileMetadata, XetFileUpload};
+use xet_pkg::xet_session::{ItemProgressReport, UniqueId, XetFileMetadata, XetFileUpload};
 
 use crate::utils::{progress_display, task_state_display, task_state_to_pystate};
 use crate::{PyXetTaskState, convert_xet_error};
@@ -54,7 +54,7 @@ impl PyXetFileUpload {
     /// The unique task ID for this upload.
     ///
     /// Matches the keys in :attr:`XetCommitReport.uploads`.
-    pub fn task_id(&self) -> UniqueID {
+    pub fn task_id(&self) -> UniqueId {
         self.inner.task_id()
     }
 }

--- a/hf_xet/src/py_stream_upload_handle.rs
+++ b/hf_xet/src/py_stream_upload_handle.rs
@@ -1,5 +1,5 @@
 use pyo3::prelude::*;
-use xet_pkg::xet_session::{ItemProgressReport, UniqueID, XetFileMetadata, XetStreamUpload};
+use xet_pkg::xet_session::{ItemProgressReport, UniqueId, XetFileMetadata, XetStreamUpload};
 
 use crate::utils::{progress_display, task_state_display, task_state_to_pystate};
 use crate::{PyXetTaskState, convert_xet_error};
@@ -66,7 +66,7 @@ impl PyXetStreamUpload {
     }
 
     /// The unique task ID for this stream.
-    pub fn task_id(&self) -> UniqueID {
+    pub fn task_id(&self) -> UniqueId {
         self.inner.task_id()
     }
 

--- a/hf_xet/src/py_upload_commit.rs
+++ b/hf_xet/src/py_upload_commit.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use pyo3::prelude::*;
 use xet_pkg::xet_session::{
-    GroupProgressReport, ItemProgressReport, Sha256Policy, UniqueID, XetCommitReport, XetFileUpload, XetSession,
+    GroupProgressReport, ItemProgressReport, Sha256Policy, UniqueId, XetCommitReport, XetFileUpload, XetSession,
     XetTaskState, XetUploadCommit,
 };
 
@@ -116,7 +116,7 @@ pub(crate) fn build_upload_commit(
                 std::thread::sleep(interval);
                 let is_terminal = !matches!(inner.status(), Ok(XetTaskState::Running) | Ok(XetTaskState::Finalizing));
                 let group_report = inner.progress();
-                let item_reports: HashMap<UniqueID, ItemProgressReport> = handles_for_thread
+                let item_reports: HashMap<UniqueId, ItemProgressReport> = handles_for_thread
                     .read()
                     .map(|g| g.iter().filter_map(|h| h.progress().map(|p| (h.task_id(), p))).collect())
                     .unwrap_or_default();

--- a/xet_data/src/processing/file_download_session.rs
+++ b/xet_data/src/processing/file_download_session.rs
@@ -12,13 +12,14 @@ use xet_client::cas_client::Client;
 use xet_client::cas_types::FileRange;
 use xet_client::chunk_cache::ChunkCache;
 use xet_runtime::core::XetContext;
+use xet_runtime::utils::UniqueId;
 
 use super::XetFileInfo;
 use super::configurations::TranslatorConfig;
 use super::remote_client_interface::create_remote_client;
 use crate::error::{DataError, Result};
 use crate::file_reconstruction::{DownloadStream, FileReconstructor, UnorderedDownloadStream};
-use crate::progress_tracking::{GroupProgress, ItemProgressUpdater, UniqueID};
+use crate::progress_tracking::{GroupProgress, ItemProgressUpdater};
 
 /// Manages the downloading of files from CAS storage.
 ///
@@ -29,7 +30,7 @@ pub struct FileDownloadSession {
     client: Arc<dyn Client>,
     chunk_cache: Option<Arc<dyn ChunkCache>>,
     progress: Arc<GroupProgress>,
-    active_stream_abort_callbacks: Mutex<HashMap<UniqueID, Box<dyn Fn() + Send + Sync>>>,
+    active_stream_abort_callbacks: Mutex<HashMap<UniqueId, Box<dyn Fn() + Send + Sync>>>,
     finalized: AtomicBool,
 }
 
@@ -40,7 +41,7 @@ impl FileDownloadSession {
             .session_id
             .as_ref()
             .map(Cow::Borrowed)
-            .unwrap_or_else(|| Cow::Owned(UniqueID::new().to_string()));
+            .unwrap_or_else(|| Cow::Owned(UniqueId::new().to_string()));
 
         let ctx = config.ctx.clone();
         let client = create_remote_client(&config, &session_id, false).await?;
@@ -84,19 +85,19 @@ impl FileDownloadSession {
         self.progress.report()
     }
 
-    pub fn item_report(&self, id: UniqueID) -> Option<crate::progress_tracking::ItemProgressReport> {
+    pub fn item_report(&self, id: UniqueId) -> Option<crate::progress_tracking::ItemProgressReport> {
         self.progress.item_report(id)
     }
 
-    pub fn item_reports(&self) -> HashMap<UniqueID, crate::progress_tracking::ItemProgressReport> {
+    pub fn item_reports(&self) -> HashMap<UniqueId, crate::progress_tracking::ItemProgressReport> {
         self.progress.item_reports()
     }
 
-    fn register_stream_abort_callback(&self, id: UniqueID, callback: Box<dyn Fn() + Send + Sync>) {
+    fn register_stream_abort_callback(&self, id: UniqueId, callback: Box<dyn Fn() + Send + Sync>) {
         self.active_stream_abort_callbacks.lock().unwrap().insert(id, callback);
     }
 
-    pub fn unregister_stream_abort_callback(&self, id: UniqueID) {
+    pub fn unregister_stream_abort_callback(&self, id: UniqueId) {
         self.active_stream_abort_callbacks.lock().unwrap().remove(&id);
     }
 
@@ -115,9 +116,9 @@ impl FileDownloadSession {
         self: &Arc<Self>,
         file_info: XetFileInfo,
         write_path: PathBuf,
-    ) -> Result<(UniqueID, JoinHandle<Result<u64>>)> {
+    ) -> Result<(UniqueId, JoinHandle<Result<u64>>)> {
         self.check_not_finalized()?;
-        let id = UniqueID::new();
+        let id = UniqueId::new();
         let session = self.clone();
         let runtime = self.ctx.runtime.clone();
         let semaphore = self.ctx.common.file_download_semaphore.clone();
@@ -130,14 +131,14 @@ impl FileDownloadSession {
 
     /// Downloads a complete file to the given path.
     #[instrument(skip_all, name = "FileDownloadSession::download_file", fields(hash = file_info.hash()))]
-    pub async fn download_file(&self, file_info: &XetFileInfo, write_path: &Path) -> Result<(UniqueID, u64)> {
+    pub async fn download_file(&self, file_info: &XetFileInfo, write_path: &Path) -> Result<(UniqueId, u64)> {
         self.check_not_finalized()?;
-        let id = UniqueID::new();
+        let id = UniqueId::new();
         let n_bytes = self.download_file_with_id(file_info, write_path, id).await?;
         Ok((id, n_bytes))
     }
 
-    async fn download_file_with_id(&self, file_info: &XetFileInfo, write_path: &Path, id: UniqueID) -> Result<u64> {
+    async fn download_file_with_id(&self, file_info: &XetFileInfo, write_path: &Path, id: UniqueId) -> Result<u64> {
         let name = Arc::from(write_path.to_string_lossy().as_ref());
         let progress_updater = self.progress.new_item(id, name);
         let reconstructor = self.setup_reconstructor(file_info, None, Some(progress_updater))?;
@@ -169,7 +170,7 @@ impl FileDownloadSession {
         file_info: &XetFileInfo,
         source_range: impl RangeBounds<u64>,
         writer: W,
-    ) -> Result<(UniqueID, u64)> {
+    ) -> Result<(UniqueId, u64)> {
         self.check_not_finalized()?;
         let range = range_bounds_to_file_range(&source_range)?;
         if let Some(ref r) = range {
@@ -177,7 +178,7 @@ impl FileDownloadSession {
             span.record("range_start", r.start);
             span.record("range_end", r.end);
         }
-        let id = UniqueID::new();
+        let id = UniqueId::new();
         let name = Arc::from("");
         let progress_updater = self.progress.new_item(id, name);
         let reconstructor = self.setup_reconstructor(file_info, range, Some(progress_updater))?;
@@ -217,9 +218,9 @@ impl FileDownloadSession {
         &self,
         file_info: &XetFileInfo,
         source_range: Option<Range<u64>>,
-    ) -> Result<(UniqueID, DownloadStream)> {
+    ) -> Result<(UniqueId, DownloadStream)> {
         self.check_not_finalized()?;
-        let id = UniqueID::new();
+        let id = UniqueId::new();
         let progress_updater = self.progress.new_item(id, "stream");
         let range = source_range.map(|r| FileRange::new(r.start, r.end));
         let reconstructor = self.setup_reconstructor(file_info, range, Some(progress_updater))?;
@@ -245,9 +246,9 @@ impl FileDownloadSession {
         &self,
         file_info: &XetFileInfo,
         source_range: Option<Range<u64>>,
-    ) -> Result<(UniqueID, UnorderedDownloadStream)> {
+    ) -> Result<(UniqueId, UnorderedDownloadStream)> {
         self.check_not_finalized()?;
-        let id = UniqueID::new();
+        let id = UniqueId::new();
         let progress_updater = self.progress.new_item(id, "unordered_stream");
         let range = source_range.map(|r| FileRange::new(r.start, r.end));
         let reconstructor = self.setup_reconstructor(file_info, range, Some(progress_updater))?;
@@ -266,10 +267,10 @@ impl FileDownloadSession {
         &self,
         file_info: &XetFileInfo,
         range: impl RangeBounds<u64>,
-    ) -> Result<(UniqueID, DownloadStream)> {
+    ) -> Result<(UniqueId, DownloadStream)> {
         self.check_not_finalized()?;
         let file_range = range_bounds_to_file_range(&range)?;
-        let id = UniqueID::new();
+        let id = UniqueId::new();
         let progress_updater = self.progress.new_item(id, "stream");
         let reconstructor = self.setup_reconstructor(file_info, file_range, Some(progress_updater))?;
         let stream = reconstructor.reconstruct_to_stream();

--- a/xet_data/src/processing/file_upload_session.rs
+++ b/xet_data/src/processing/file_upload_session.rs
@@ -16,6 +16,7 @@ use xet_client::cas_client::{Client, ProgressCallback};
 use xet_core_structures::metadata_shard::file_structs::MDBFileInfo;
 use xet_core_structures::xorb_object::SerializedXorbObject;
 use xet_runtime::core::XetContext;
+use xet_runtime::utils::UniqueId;
 
 use super::XetFileInfo;
 use super::configurations::TranslatorConfig;
@@ -26,7 +27,7 @@ use crate::deduplication::constants::{MAX_XORB_BYTES, MAX_XORB_CHUNKS};
 use crate::deduplication::{DataAggregator, DeduplicationMetrics, RawXorbData};
 use crate::error::{DataError, Result};
 use crate::progress_tracking::upload_tracking::{CompletionTracker, FileXorbDependency};
-use crate::progress_tracking::{GroupProgress, GroupProgressReport, ItemProgressReport, UniqueID};
+use crate::progress_tracking::{GroupProgress, GroupProgressReport, ItemProgressReport};
 
 /// Manages the translation of files between the
 /// MerkleDB / pointer file format and the materialized version.
@@ -75,7 +76,7 @@ impl FileUploadSession {
             .session_id
             .as_ref()
             .map(Cow::Borrowed)
-            .unwrap_or_else(|| Cow::Owned(UniqueID::new().to_string()));
+            .unwrap_or_else(|| Cow::Owned(UniqueId::new().to_string()));
 
         let progress = GroupProgress::with_speed_config(
             ctx.config.data.progress_update_speed_sampling_window,
@@ -113,7 +114,7 @@ impl FileUploadSession {
 
             let file_size = std::fs::metadata(&file_path)?.len();
 
-            let updater = self.progress.new_item(UniqueID::new(), file_name.clone());
+            let updater = self.progress.new_item(UniqueId::new(), file_name.clone());
             let file_id = self.completion_tracker.register_new_file(updater, Some(file_size));
 
             let ingestion_concurrency_limiter = self.ctx.common.file_ingestion_semaphore.clone();
@@ -214,16 +215,16 @@ impl FileUploadSession {
         tracking_name: Option<Arc<str>>,
         size: Option<u64>,
         sha256: Sha256Policy,
-    ) -> Result<(UniqueID, SingleFileCleaner)> {
+    ) -> Result<(UniqueId, SingleFileCleaner)> {
         self.check_not_finalized()?;
-        let id = UniqueID::new();
+        let id = UniqueId::new();
         let cleaner = self.start_clean_with_id(id, tracking_name, size, sha256);
         Ok((id, cleaner))
     }
 
     fn start_clean_with_id(
         self: &Arc<Self>,
-        id: UniqueID,
+        id: UniqueId,
         tracking_name: Option<Arc<str>>,
         size: Option<u64>,
         sha256: Sha256Policy,
@@ -240,7 +241,7 @@ impl FileUploadSession {
         self: &Arc<Self>,
         file_path: PathBuf,
         sha256: Sha256Policy,
-    ) -> Result<(UniqueID, JoinHandle<Result<(XetFileInfo, DeduplicationMetrics)>>)> {
+    ) -> Result<(UniqueId, JoinHandle<Result<(XetFileInfo, DeduplicationMetrics)>>)> {
         self.check_not_finalized()?;
         let file_size = std::fs::metadata(&file_path)?.len();
         let tracking_name: Arc<str> = Arc::from(file_path.to_string_lossy().as_ref());
@@ -265,7 +266,7 @@ impl FileUploadSession {
         bytes: Vec<u8>,
         sha256: Sha256Policy,
         tracking_name: Option<Arc<str>>,
-    ) -> Result<(UniqueID, JoinHandle<Result<(XetFileInfo, DeduplicationMetrics)>>)> {
+    ) -> Result<(UniqueId, JoinHandle<Result<(XetFileInfo, DeduplicationMetrics)>>)> {
         self.check_not_finalized()?;
         let (id, mut cleaner) = self.start_clean(tracking_name, Some(bytes.len() as u64), sha256)?;
 
@@ -584,11 +585,11 @@ impl FileUploadSession {
         self.progress.report()
     }
 
-    pub fn item_report(&self, id: UniqueID) -> Option<ItemProgressReport> {
+    pub fn item_report(&self, id: UniqueId) -> Option<ItemProgressReport> {
         self.progress.item_report(id)
     }
 
-    pub fn item_reports(&self) -> HashMap<UniqueID, ItemProgressReport> {
+    pub fn item_reports(&self) -> HashMap<UniqueId, ItemProgressReport> {
         self.progress.item_reports()
     }
 

--- a/xet_data/src/progress_tracking/mod.rs
+++ b/xet_data/src/progress_tracking/mod.rs
@@ -3,4 +3,3 @@ mod speed_tracker;
 pub mod upload_tracking;
 
 pub use progress_types::{GroupProgress, GroupProgressReport, ItemProgress, ItemProgressReport, ItemProgressUpdater};
-pub use xet_runtime::utils::UniqueId as UniqueID;

--- a/xet_data/src/progress_tracking/progress_types.rs
+++ b/xet_data/src/progress_tracking/progress_types.rs
@@ -4,14 +4,14 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use more_asserts::debug_assert_le;
+use xet_runtime::utils::UniqueId;
 
-use super::UniqueID;
 use super::speed_tracker::{DEFAULT_MIN_OBSERVATIONS_FOR_RATE, DEFAULT_SPEED_HALF_LIFE, SpeedTracker};
 use super::upload_tracking::CompletionTracker;
 
 /// Per-item atomic progress counters. Created by `GroupProgress::new_item()`.
 pub struct ItemProgress {
-    pub id: UniqueID,
+    pub id: UniqueId,
     pub name: Arc<str>,
     pub total_bytes: AtomicU64,
     pub bytes_completed: AtomicU64,
@@ -21,7 +21,7 @@ pub struct ItemProgress {
 }
 
 impl ItemProgress {
-    fn new(id: UniqueID, name: Arc<str>) -> Self {
+    fn new(id: UniqueId, name: Arc<str>) -> Self {
         Self {
             id,
             name,
@@ -70,7 +70,7 @@ pub struct GroupProgress {
     pub total_bytes_completed: AtomicU64,
     pub total_transfer_bytes: AtomicU64,
     pub total_transfer_bytes_completed: AtomicU64,
-    items: Mutex<HashMap<UniqueID, Arc<ItemProgress>>>,
+    items: Mutex<HashMap<UniqueId, Arc<ItemProgress>>>,
     speed_tracker: Mutex<SpeedTracker>,
 }
 
@@ -94,7 +94,7 @@ impl GroupProgress {
 
     /// Create a new tracked item and register it in the items map.
     /// Returns an `ItemProgressUpdater` handle for the caller to report progress.
-    pub fn new_item(self: &Arc<Self>, id: UniqueID, name: impl Into<Arc<str>>) -> Arc<ItemProgressUpdater> {
+    pub fn new_item(self: &Arc<Self>, id: UniqueId, name: impl Into<Arc<str>>) -> Arc<ItemProgressUpdater> {
         let item = Arc::new(ItemProgress::new(id, name.into()));
         self.items.lock().unwrap().insert(id, item.clone());
         Arc::new(ItemProgressUpdater {
@@ -141,13 +141,13 @@ impl GroupProgress {
     }
 
     /// Snapshot of all per-item progress.
-    pub fn item_reports(&self) -> HashMap<UniqueID, ItemProgressReport> {
+    pub fn item_reports(&self) -> HashMap<UniqueId, ItemProgressReport> {
         let items = self.items.lock().unwrap();
         items.iter().map(|(id, item)| (*id, item.report())).collect()
     }
 
     /// Snapshot of one item's progress.
-    pub fn item_report(&self, id: UniqueID) -> Option<ItemProgressReport> {
+    pub fn item_report(&self, id: UniqueId) -> Option<ItemProgressReport> {
         let items = self.items.lock().unwrap();
         items.get(&id).map(|item| item.report())
     }
@@ -227,7 +227,7 @@ impl ItemProgressUpdater {
     #[cfg(any(debug_assertions, test))]
     pub fn new_standalone(name: &str) -> Arc<Self> {
         let group = GroupProgress::new();
-        let item = Arc::new(ItemProgress::new(UniqueID::new(), Arc::from(name)));
+        let item = Arc::new(ItemProgress::new(UniqueId::new(), Arc::from(name)));
         Arc::new(Self { item, group })
     }
 
@@ -391,7 +391,7 @@ mod tests {
     #[test]
     fn test_group_progress_new_item() {
         let group = GroupProgress::new();
-        let updater = group.new_item(UniqueID::new(), "test.bin");
+        let updater = group.new_item(UniqueId::new(), "test.bin");
         updater.update_item_size(100, true);
 
         assert_eq!(group.total_bytes.load(Ordering::Relaxed), 100);
@@ -400,7 +400,7 @@ mod tests {
     #[test]
     fn test_item_progress_updater_bytes() {
         let group = GroupProgress::new();
-        let updater = group.new_item(UniqueID::new(), "test.bin");
+        let updater = group.new_item(UniqueId::new(), "test.bin");
         updater.update_item_size(100, true);
         updater.report_bytes_completed(50);
 
@@ -411,7 +411,7 @@ mod tests {
     #[test]
     fn test_item_progress_updater_transfer() {
         let group = GroupProgress::new();
-        let updater = group.new_item(UniqueID::new(), "test.bin");
+        let updater = group.new_item(UniqueId::new(), "test.bin");
         updater.update_item_size(100, true);
         updater.update_transfer_size(80);
         updater.report_transfer_bytes_completed(30);
@@ -423,7 +423,7 @@ mod tests {
     #[test]
     fn test_update_item_size_finalized() {
         let group = GroupProgress::new();
-        let updater = group.new_item(UniqueID::new(), "test.bin");
+        let updater = group.new_item(UniqueId::new(), "test.bin");
         updater.update_item_size(100, true);
         updater.update_item_size(200, false);
 
@@ -434,7 +434,7 @@ mod tests {
     #[test]
     fn test_update_item_size_monotonic_increase() {
         let group = GroupProgress::new();
-        let updater = group.new_item(UniqueID::new(), "test.bin");
+        let updater = group.new_item(UniqueId::new(), "test.bin");
         updater.update_item_size(100, false);
         updater.update_item_size(300, false);
 
@@ -445,7 +445,7 @@ mod tests {
     #[test]
     fn test_update_item_size_same_value_noop() {
         let group = GroupProgress::new();
-        let updater = group.new_item(UniqueID::new(), "test.bin");
+        let updater = group.new_item(UniqueId::new(), "test.bin");
         updater.update_item_size(100, false);
         updater.update_item_size(100, false);
 
@@ -455,7 +455,7 @@ mod tests {
     #[test]
     fn test_report_snapshot() {
         let group = GroupProgress::new();
-        let updater = group.new_item(UniqueID::new(), "file.bin");
+        let updater = group.new_item(UniqueId::new(), "file.bin");
         updater.update_item_size(1000, true);
         updater.update_transfer_size(800);
         updater.report_bytes_completed(500);
@@ -471,8 +471,8 @@ mod tests {
     #[test]
     fn test_item_reports() {
         let group = GroupProgress::new();
-        let id1 = UniqueID::new();
-        let id2 = UniqueID::new();
+        let id1 = UniqueId::new();
+        let id2 = UniqueId::new();
 
         let u1 = group.new_item(id1, "a.bin");
         let u2 = group.new_item(id2, "b.bin");
@@ -491,8 +491,8 @@ mod tests {
     #[test]
     fn test_multiple_items_group_totals() {
         let group = GroupProgress::new();
-        let u1 = group.new_item(UniqueID::new(), "a.bin");
-        let u2 = group.new_item(UniqueID::new(), "b.bin");
+        let u1 = group.new_item(UniqueId::new(), "a.bin");
+        let u2 = group.new_item(UniqueId::new(), "b.bin");
 
         u1.update_item_size(100, true);
         u2.update_item_size(200, true);
@@ -506,7 +506,7 @@ mod tests {
     #[test]
     fn test_assert_complete() {
         let group = GroupProgress::new();
-        let updater = group.new_item(UniqueID::new(), "test.bin");
+        let updater = group.new_item(UniqueId::new(), "test.bin");
         updater.update_item_size(100, true);
         updater.update_transfer_size(80);
         updater.report_bytes_completed(100);
@@ -519,7 +519,7 @@ mod tests {
     #[test]
     fn test_zero_increment_noop() {
         let group = GroupProgress::new();
-        let updater = group.new_item(UniqueID::new(), "test.bin");
+        let updater = group.new_item(UniqueId::new(), "test.bin");
         updater.update_item_size(100, true);
         updater.report_bytes_completed(0);
 
@@ -530,7 +530,7 @@ mod tests {
     #[test]
     fn test_report_bytes_written_alias() {
         let group = GroupProgress::new();
-        let updater = group.new_item(UniqueID::new(), "test.bin");
+        let updater = group.new_item(UniqueId::new(), "test.bin");
         updater.update_item_size(100, true);
         updater.report_bytes_written(50);
 
@@ -540,7 +540,7 @@ mod tests {
     #[test]
     fn test_report_transfer_progress_alias() {
         let group = GroupProgress::new();
-        let updater = group.new_item(UniqueID::new(), "test.bin");
+        let updater = group.new_item(UniqueId::new(), "test.bin");
         updater.update_item_size(100, true);
         updater.update_transfer_size(90);
         updater.report_transfer_progress(40);
@@ -554,7 +554,7 @@ mod tests {
         pause();
 
         let group = GroupProgress::with_speed_config(Duration::from_secs(10), 3);
-        let updater = group.new_item(UniqueID::new(), "test.bin");
+        let updater = group.new_item(UniqueId::new(), "test.bin");
         updater.update_item_size(10_000, true);
         updater.update_transfer_size(10_000);
 

--- a/xet_data/src/progress_tracking/upload_tracking.rs
+++ b/xet_data/src/progress_tracking/upload_tracking.rs
@@ -7,8 +7,8 @@ use std::sync::{Arc, Mutex};
 use more_asserts::{debug_assert_ge, debug_assert_le};
 use xet_core_structures::MerkleHashMap;
 use xet_core_structures::merklehash::MerkleHash;
+use xet_runtime::utils::UniqueId;
 
-use super::UniqueID;
 use super::progress_types::{GroupProgress, ItemProgressUpdater};
 
 pub struct FileXorbDependency {
@@ -47,7 +47,7 @@ struct XorbPartCompletionStats {
 
 /// Represents a file that depends on one or more xorbs.
 struct FileDependency {
-    tracking_id: UniqueID,
+    tracking_id: UniqueId,
     updater: Arc<ItemProgressUpdater>,
     name: Arc<str>,
     total_bytes: u64,
@@ -422,10 +422,10 @@ mod tests {
         let group = GroupProgress::new();
         let tracker = CompletionTracker::new(group.clone());
 
-        let updater_a = group.new_item(UniqueID::new(), "fileA");
+        let updater_a = group.new_item(UniqueId::new(), "fileA");
         let file_a = tracker.register_new_file(updater_a, Some(100));
 
-        let updater_b = group.new_item(UniqueID::new(), "fileB");
+        let updater_b = group.new_item(UniqueId::new(), "fileB");
         let file_b = tracker.register_new_file(updater_b, Some(50));
 
         let (done, total) = tracker.status();
@@ -475,10 +475,10 @@ mod tests {
         let group = GroupProgress::new();
         let tracker = CompletionTracker::new(group.clone());
 
-        let updater_a = group.new_item(UniqueID::new(), "fileA");
+        let updater_a = group.new_item(UniqueId::new(), "fileA");
         let file_a = tracker.register_new_file(updater_a, Some(200));
 
-        let updater_b = group.new_item(UniqueID::new(), "fileB");
+        let updater_b = group.new_item(UniqueId::new(), "fileB");
         let file_b = tracker.register_new_file(updater_b, Some(300));
 
         let (done, total) = tracker.status();
@@ -557,7 +557,7 @@ mod tests {
         let group = GroupProgress::new();
         let tracker = CompletionTracker::new(group.clone());
 
-        let updater = group.new_item(UniqueID::new(), "bigFile");
+        let updater = group.new_item(UniqueId::new(), "bigFile");
         let f = tracker.register_new_file(updater, Some(300));
 
         let x1 = MerkleHash::random_from_seed(1);
@@ -614,7 +614,7 @@ mod tests {
         let group = GroupProgress::new();
         let tracker = CompletionTracker::new(group.clone());
 
-        let updater = group.new_item(UniqueID::new(), "lateFile");
+        let updater = group.new_item(UniqueId::new(), "lateFile");
         let file_id = tracker.register_new_file(updater, Some(50));
 
         let x = MerkleHash::random_from_seed(999);
@@ -643,7 +643,7 @@ mod tests {
         let group = GroupProgress::new();
         let tracker = CompletionTracker::new(group.clone());
 
-        let updater = group.new_item(UniqueID::new(), "someFile");
+        let updater = group.new_item(UniqueId::new(), "someFile");
         let file_id = tracker.register_new_file(updater, Some(100));
         let x = MerkleHash::random_from_seed(123);
 
@@ -672,7 +672,7 @@ mod tests {
         let group = GroupProgress::new();
         let tracker = CompletionTracker::new(group.clone());
 
-        let updater = group.new_item(UniqueID::new(), "growingFile");
+        let updater = group.new_item(UniqueId::new(), "growingFile");
         let file_id = tracker.register_new_file(updater, None);
 
         let (done, total) = tracker.status();
@@ -716,7 +716,7 @@ mod tests {
         let group = GroupProgress::new();
         let tracker = CompletionTracker::new(group.clone());
 
-        let updater = group.new_item(UniqueID::new(), "streamFile");
+        let updater = group.new_item(UniqueId::new(), "streamFile");
         let file_id = tracker.register_new_file(updater, None);
 
         let x1 = MerkleHash::random_from_seed(10);
@@ -769,10 +769,10 @@ mod tests {
         let group = GroupProgress::new();
         let tracker = CompletionTracker::new(group.clone());
 
-        let updater_a = group.new_item(UniqueID::new(), "fileA");
+        let updater_a = group.new_item(UniqueId::new(), "fileA");
         let file_a = tracker.register_new_file(updater_a, Some(100));
 
-        let updater_b = group.new_item(UniqueID::new(), "fileB");
+        let updater_b = group.new_item(UniqueId::new(), "fileB");
         let file_b = tracker.register_new_file(updater_b, None);
 
         let (done, total) = tracker.status();
@@ -821,7 +821,7 @@ mod tests {
         let group = GroupProgress::new();
         let tracker = CompletionTracker::new(group.clone());
 
-        let updater = group.new_item(UniqueID::new(), "fixedFile");
+        let updater = group.new_item(UniqueId::new(), "fixedFile");
         let file_id = tracker.register_new_file(updater, Some(100));
 
         tracker.increment_file_size(file_id, 999);
@@ -846,7 +846,7 @@ mod tests {
         let group = GroupProgress::new();
         let tracker = CompletionTracker::new(group.clone());
 
-        let updater = group.new_item(UniqueID::new(), "partialFile");
+        let updater = group.new_item(UniqueId::new(), "partialFile");
         let file_id = tracker.register_new_file(updater, None);
 
         let x = MerkleHash::random_from_seed(42);

--- a/xet_pkg/src/error.rs
+++ b/xet_pkg/src/error.rs
@@ -3,8 +3,8 @@ use xet_client::ClientError;
 use xet_core_structures::CoreError;
 use xet_data::DataError;
 use xet_data::file_reconstruction::FileReconstructionError;
-use xet_data::progress_tracking::UniqueID;
 use xet_runtime::RuntimeError;
+use xet_runtime::utils::UniqueId;
 
 /// Unified error type for the Xet public API.
 ///
@@ -37,7 +37,7 @@ pub enum XetError {
 
     /// A task ID that doesn't correspond to any queued file.
     #[error("Invalid task ID: {0}")]
-    InvalidTaskID(UniqueID),
+    InvalidTaskID(UniqueId),
 
     // -- User-facing error categories ------------------------------------
     /// Token refresh or credential failures.

--- a/xet_pkg/src/legacy/progress_tracking/callback_bridge.rs
+++ b/xet_pkg/src/legacy/progress_tracking/callback_bridge.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::sync::Notify;
-use xet_data::progress_tracking::{GroupProgressReport, ItemProgressReport, UniqueID};
+use xet_data::progress_tracking::{GroupProgressReport, ItemProgressReport};
+use xet_runtime::utils::UniqueId;
 
 use super::{ItemProgressUpdate, ProgressUpdate, TrackingProgressUpdater};
 
@@ -14,8 +15,8 @@ use super::{ItemProgressUpdate, ProgressUpdate, TrackingProgressUpdater};
 /// legacy `TrackingProgressUpdater` callbacks.
 pub trait ProgressReporter: Send + Sync {
     fn report(&self) -> GroupProgressReport;
-    fn item_reports(&self) -> HashMap<UniqueID, ItemProgressReport>;
-    fn item_report(&self, id: UniqueID) -> Option<ItemProgressReport> {
+    fn item_reports(&self) -> HashMap<UniqueId, ItemProgressReport>;
+    fn item_report(&self, id: UniqueId) -> Option<ItemProgressReport> {
         self.item_reports().remove(&id)
     }
 }
@@ -24,10 +25,10 @@ impl ProgressReporter for xet_data::processing::FileDownloadSession {
     fn report(&self) -> GroupProgressReport {
         self.report()
     }
-    fn item_reports(&self) -> HashMap<UniqueID, ItemProgressReport> {
+    fn item_reports(&self) -> HashMap<UniqueId, ItemProgressReport> {
         self.item_reports()
     }
-    fn item_report(&self, id: UniqueID) -> Option<ItemProgressReport> {
+    fn item_report(&self, id: UniqueId) -> Option<ItemProgressReport> {
         self.item_report(id)
     }
 }
@@ -36,7 +37,7 @@ impl ProgressReporter for xet_data::processing::FileUploadSession {
     fn report(&self) -> GroupProgressReport {
         self.report()
     }
-    fn item_reports(&self) -> HashMap<UniqueID, ItemProgressReport> {
+    fn item_reports(&self) -> HashMap<UniqueId, ItemProgressReport> {
         self.item_reports()
     }
 }
@@ -45,7 +46,7 @@ impl ProgressReporter for xet_data::processing::FileUploadSession {
 
 struct GroupBridgeState {
     prev_group: GroupProgressReport,
-    prev_items: HashMap<UniqueID, ItemProgressReport>,
+    prev_items: HashMap<UniqueId, ItemProgressReport>,
 }
 
 impl GroupBridgeState {
@@ -59,7 +60,7 @@ impl GroupBridgeState {
     fn compute_diff(
         &mut self,
         group: GroupProgressReport,
-        items: HashMap<UniqueID, ItemProgressReport>,
+        items: HashMap<UniqueId, ItemProgressReport>,
     ) -> ProgressUpdate {
         let total_bytes_increment = group.total_bytes.saturating_sub(self.prev_group.total_bytes);
         let total_bytes_completion_increment = group
@@ -120,7 +121,7 @@ impl ItemBridgeState {
         Self { prev: None }
     }
 
-    fn compute_diff(&mut self, item_id: UniqueID, report: ItemProgressReport) -> ProgressUpdate {
+    fn compute_diff(&mut self, item_id: UniqueId, report: ItemProgressReport) -> ProgressUpdate {
         let prev_completed = self.prev.as_ref().map_or(0, |p| p.bytes_completed);
         let prev_total = self.prev.as_ref().map_or(0, |p| p.total_bytes);
 
@@ -265,7 +266,7 @@ impl ItemProgressCallbackUpdater {
     /// diffs to `updater`.
     pub fn start(
         reporter: Arc<dyn ProgressReporter>,
-        item_id: UniqueID,
+        item_id: UniqueId,
         updater: Arc<dyn TrackingProgressUpdater>,
     ) -> Self {
         let (updater, _verifier) = wrap_updater(updater);
@@ -353,7 +354,7 @@ mod tests {
     #[test]
     fn test_group_bridge_first_diff() {
         let mut state = GroupBridgeState::new();
-        let id = UniqueID::new();
+        let id = UniqueId::new();
 
         let group = make_group_report(1000, 200, 800, 100);
         let items = HashMap::from([(id, make_item_report("a.bin", 1000, 200))]);
@@ -377,7 +378,7 @@ mod tests {
     #[test]
     fn test_group_bridge_incremental_diff() {
         let mut state = GroupBridgeState::new();
-        let id = UniqueID::new();
+        let id = UniqueId::new();
 
         let group1 = make_group_report(1000, 200, 800, 100);
         let items1 = HashMap::from([(id, make_item_report("a.bin", 1000, 200))]);
@@ -398,7 +399,7 @@ mod tests {
     #[test]
     fn test_group_bridge_no_change_is_empty() {
         let mut state = GroupBridgeState::new();
-        let id = UniqueID::new();
+        let id = UniqueId::new();
 
         let group = make_group_report(1000, 500, 800, 300);
         let items = HashMap::from([(id, make_item_report("a.bin", 1000, 500))]);
@@ -412,8 +413,8 @@ mod tests {
     #[test]
     fn test_group_bridge_new_item_appears() {
         let mut state = GroupBridgeState::new();
-        let id1 = UniqueID::new();
-        let id2 = UniqueID::new();
+        let id1 = UniqueId::new();
+        let id2 = UniqueId::new();
 
         let group1 = make_group_report(100, 50, 0, 0);
         let items1 = HashMap::from([(id1, make_item_report("a.bin", 100, 50))]);
@@ -435,7 +436,7 @@ mod tests {
     #[test]
     fn test_item_bridge_first_diff() {
         let mut state = ItemBridgeState::new();
-        let id = UniqueID::new();
+        let id = UniqueId::new();
         let report = make_item_report("file.bin", 500, 100);
 
         let update = state.compute_diff(id, report);
@@ -451,7 +452,7 @@ mod tests {
     #[test]
     fn test_item_bridge_incremental_diff() {
         let mut state = ItemBridgeState::new();
-        let id = UniqueID::new();
+        let id = UniqueId::new();
 
         state.compute_diff(id, make_item_report("file.bin", 500, 100));
 
@@ -465,7 +466,7 @@ mod tests {
     #[test]
     fn test_item_bridge_no_change_is_empty() {
         let mut state = ItemBridgeState::new();
-        let id = UniqueID::new();
+        let id = UniqueId::new();
 
         state.compute_diff(id, make_item_report("file.bin", 500, 200));
         let update = state.compute_diff(id, make_item_report("file.bin", 500, 200));
@@ -476,7 +477,7 @@ mod tests {
     #[test]
     fn test_item_bridge_total_grows() {
         let mut state = ItemBridgeState::new();
-        let id = UniqueID::new();
+        let id = UniqueId::new();
 
         state.compute_diff(id, make_item_report("file.bin", 500, 100));
         let update = state.compute_diff(id, make_item_report("file.bin", 800, 100));

--- a/xet_pkg/src/legacy/progress_tracking/mod.rs
+++ b/xet_pkg/src/legacy/progress_tracking/mod.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 pub use callback_bridge::{GroupProgressCallbackUpdater, ItemProgressCallbackUpdater, ProgressReporter};
 pub use progress_verification_wrapper::ProgressUpdaterVerificationWrapper;
-use xet_data::progress_tracking::UniqueID;
+use xet_runtime::utils::UniqueId;
 
 /// The trait that a progress updater that reports per-item progress completion.
 #[async_trait]
@@ -23,7 +23,7 @@ pub trait TrackingProgressUpdater: Send + Sync {
 /// A class to make all the bookkeeping clear with progress updating.
 #[derive(Clone, Debug)]
 pub struct ItemProgressUpdate {
-    pub tracking_id: UniqueID,
+    pub tracking_id: UniqueId,
     pub item_name: Arc<str>,
 
     // The total bytes in this item, independent from the total bytes of all items.

--- a/xet_pkg/src/legacy/progress_tracking/progress_verification_wrapper.rs
+++ b/xet_pkg/src/legacy/progress_tracking/progress_verification_wrapper.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use more_asserts::{assert_ge, assert_le};
 use tokio::sync::Mutex;
-use xet_data::progress_tracking::UniqueID;
+use xet_runtime::utils::UniqueId;
 
 use super::{ProgressUpdate, TrackingProgressUpdater};
 
@@ -17,7 +17,7 @@ struct ItemProgressData {
 
 #[derive(Debug, Default)]
 pub struct ProgressUpdaterVerificationWrapperImpl {
-    items: HashMap<UniqueID, (Arc<str>, ItemProgressData)>,
+    items: HashMap<UniqueId, (Arc<str>, ItemProgressData)>,
     total_transfer_bytes: u64,
     total_transfer_bytes_completed: u64,
     total_bytes: u64,
@@ -211,8 +211,8 @@ mod tests {
         let logger = Arc::new(DummyLogger::default());
         let wrapper = ProgressUpdaterVerificationWrapper::new(logger.clone());
 
-        let file_a = (UniqueID::new(), "fileA");
-        let file_b = (UniqueID::new(), "fileB");
+        let file_a = (UniqueId::new(), "fileA");
+        let file_b = (UniqueId::new(), "fileB");
 
         wrapper
             .register_updates(ProgressUpdate {

--- a/xet_pkg/src/xet_session/download_stream_group.rs
+++ b/xet_pkg/src/xet_session/download_stream_group.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 use tracing::info;
 use xet_data::processing::{FileDownloadSession, XetFileInfo};
-use xet_data::progress_tracking::UniqueID;
+use xet_runtime::utils::UniqueId;
 
 use super::auth_group_builder::{AuthGroupBuilder, AuthOptions};
 use super::common::create_translator_config;
@@ -106,7 +106,7 @@ pub struct XetDownloadStreamGroup {
 #[doc(hidden)]
 pub(super) struct XetDownloadStreamGroupInner {
     session: XetSession,
-    group_id: UniqueID,
+    group_id: UniqueId,
     download_session: Arc<FileDownloadSession>,
 }
 
@@ -123,7 +123,7 @@ impl XetDownloadStreamGroup {
         task_runtime: Arc<TaskRuntime>,
         auth_options: AuthOptions,
     ) -> Result<Self, XetError> {
-        let group_id = UniqueID::new();
+        let group_id = UniqueId::new();
         let config = create_translator_config(&session, auth_options).await?;
         let download_session = FileDownloadSession::new(Arc::new(config), None).await?;
 
@@ -137,7 +137,7 @@ impl XetDownloadStreamGroup {
     }
 
     /// Returns the unique ID for this stream group.
-    pub(super) fn id(&self) -> UniqueID {
+    pub(super) fn id(&self) -> UniqueId {
         self.inner.group_id
     }
 

--- a/xet_pkg/src/xet_session/download_stream_handle.rs
+++ b/xet_pkg/src/xet_session/download_stream_handle.rs
@@ -4,7 +4,8 @@ use bytes::Bytes;
 use tracing::{debug, info};
 use xet_data::DataError;
 use xet_data::processing::{DownloadStream, FileDownloadSession, UnorderedDownloadStream};
-use xet_data::progress_tracking::{ItemProgressReport, UniqueID};
+use xet_data::progress_tracking::ItemProgressReport;
+use xet_runtime::utils::UniqueId;
 
 use super::errors::SessionError;
 use super::task_runtime::TaskRuntime;
@@ -26,7 +27,7 @@ use super::task_runtime::TaskRuntime;
 pub struct XetDownloadStream {
     inner: DownloadStream,
     download_session: Arc<FileDownloadSession>,
-    id: UniqueID,
+    id: UniqueId,
     task_runtime: Arc<TaskRuntime>,
 }
 
@@ -34,7 +35,7 @@ impl XetDownloadStream {
     pub(super) fn new(
         inner: DownloadStream,
         download_session: Arc<FileDownloadSession>,
-        id: UniqueID,
+        id: UniqueId,
         task_runtime: Arc<TaskRuntime>,
     ) -> Self {
         Self {
@@ -89,7 +90,7 @@ impl XetDownloadStream {
     }
 
     /// Returns the unique task ID for this stream.
-    pub fn task_id(&self) -> UniqueID {
+    pub fn task_id(&self) -> UniqueId {
         self.id
     }
 
@@ -127,7 +128,7 @@ impl Drop for XetDownloadStream {
 pub struct XetUnorderedDownloadStream {
     inner: UnorderedDownloadStream,
     download_session: Arc<FileDownloadSession>,
-    id: UniqueID,
+    id: UniqueId,
     task_runtime: Arc<TaskRuntime>,
 }
 
@@ -135,7 +136,7 @@ impl XetUnorderedDownloadStream {
     pub(super) fn new(
         inner: UnorderedDownloadStream,
         download_session: Arc<FileDownloadSession>,
-        id: UniqueID,
+        id: UniqueId,
         task_runtime: Arc<TaskRuntime>,
     ) -> Self {
         Self {
@@ -191,7 +192,7 @@ impl XetUnorderedDownloadStream {
     }
 
     /// Returns the unique task ID for this stream.
-    pub fn task_id(&self) -> UniqueID {
+    pub fn task_id(&self) -> UniqueId {
         self.id
     }
 

--- a/xet_pkg/src/xet_session/file_download_group.rs
+++ b/xet_pkg/src/xet_session/file_download_group.rs
@@ -6,7 +6,8 @@ use std::sync::{Arc, RwLock};
 
 use tracing::info;
 use xet_data::processing::{FileDownloadSession, XetFileInfo};
-use xet_data::progress_tracking::{GroupProgressReport, ItemProgressReport, UniqueID};
+use xet_data::progress_tracking::{GroupProgressReport, ItemProgressReport};
+use xet_runtime::utils::UniqueId;
 
 use super::auth_group_builder::{AuthGroupBuilder, AuthOptions};
 use super::common::create_translator_config;
@@ -64,7 +65,7 @@ impl AuthGroupBuilder<XetFileDownloadGroup> {
 
 /// Report returned by [`XetFileDownloadGroup::finish`].
 ///
-/// Contains final progress and per-file results keyed by [`UniqueID`].
+/// Contains final progress and per-file results keyed by [`UniqueId`].
 /// Only created when all downloads succeed; any failure propagates as an error.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "python", pyo3::pyclass(get_all))]
@@ -72,7 +73,7 @@ pub struct XetDownloadGroupReport {
     /// Final progress snapshot at the time the group finished.
     pub progress: GroupProgressReport,
     /// Per-file download reports keyed by task ID.
-    pub downloads: HashMap<UniqueID, XetDownloadReport>,
+    pub downloads: HashMap<UniqueId, XetDownloadReport>,
 }
 
 #[cfg(feature = "python")]
@@ -147,7 +148,7 @@ impl XetFileDownloadGroup {
         task_runtime: Arc<TaskRuntime>,
         auth_options: AuthOptions,
     ) -> Result<Self, XetError> {
-        let group_id = UniqueID::new();
+        let group_id = UniqueId::new();
         let config = create_translator_config(&session, auth_options).await?;
         let download_session = FileDownloadSession::new(Arc::new(config), None).await?;
 
@@ -165,7 +166,7 @@ impl XetFileDownloadGroup {
     }
 
     /// Unique identifier for this download group.
-    pub fn id(&self) -> UniqueID {
+    pub fn id(&self) -> UniqueId {
         self.inner.group_id
     }
 
@@ -233,7 +234,7 @@ impl XetFileDownloadGroup {
     ///
     /// `progress` is `None` if the download has not started reporting yet.
     /// Used for display and diagnostics (e.g. `__repr__`).
-    pub fn active_download_info(&self) -> Vec<(UniqueID, PathBuf, Option<ItemProgressReport>)> {
+    pub fn active_download_info(&self) -> Vec<(UniqueId, PathBuf, Option<ItemProgressReport>)> {
         self.inner
             .active_tasks
             .read()
@@ -314,8 +315,8 @@ impl XetFileDownloadGroup {
 }
 
 pub(super) struct XetFileDownloadGroupInner {
-    group_id: UniqueID,
-    active_tasks: RwLock<HashMap<UniqueID, XetFileDownload>>,
+    group_id: UniqueId,
+    active_tasks: RwLock<HashMap<UniqueId, XetFileDownload>>,
     pub(super) download_session: Arc<FileDownloadSession>,
 }
 
@@ -387,7 +388,7 @@ impl XetFileDownloadGroupInner {
         Ok(XetFileDownload { inner, task_runtime })
     }
 
-    pub(super) async fn handle_finish(self: &Arc<Self>) -> Result<HashMap<UniqueID, XetDownloadReport>, XetError> {
+    pub(super) async fn handle_finish(self: &Arc<Self>) -> Result<HashMap<UniqueId, XetDownloadReport>, XetError> {
         let active_tasks = std::mem::take(&mut *self.active_tasks.write()?);
 
         let mut results = HashMap::new();

--- a/xet_pkg/src/xet_session/file_download_handle.rs
+++ b/xet_pkg/src/xet_session/file_download_handle.rs
@@ -5,7 +5,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use xet_data::processing::{FileDownloadSession, XetFileInfo};
-use xet_data::progress_tracking::{ItemProgressReport, UniqueID};
+use xet_data::progress_tracking::ItemProgressReport;
+use xet_runtime::utils::UniqueId;
 
 use super::task_runtime::{BackgroundTaskState, TaskRuntime, XetTaskState};
 use crate::error::XetError;
@@ -16,7 +17,7 @@ use crate::error::XetError;
 #[cfg_attr(feature = "python", pyo3::pyclass(get_all))]
 pub struct XetDownloadReport {
     /// Unique identifier for this download task.
-    pub task_id: UniqueID,
+    pub task_id: UniqueId,
     /// Local path where the file was written.
     pub path: PathBuf,
     /// Xet file hash and size of the downloaded file.
@@ -41,7 +42,7 @@ impl XetDownloadReport {
 // ── XetFileDownloadInner ────────────────────────────────────────────────────
 
 pub(super) struct XetFileDownloadInner {
-    pub(super) task_id: UniqueID,
+    pub(super) task_id: UniqueId,
     pub(super) dest_path: PathBuf,
     pub(super) download_session: Arc<FileDownloadSession>,
     pub(super) state: tokio::sync::Mutex<BackgroundTaskState<XetDownloadReport>>,
@@ -65,7 +66,7 @@ pub struct XetFileDownload {
 }
 
 impl XetFileDownload {
-    pub fn task_id(&self) -> UniqueID {
+    pub fn task_id(&self) -> UniqueId {
         self.inner.task_id
     }
 

--- a/xet_pkg/src/xet_session/mod.rs
+++ b/xet_pkg/src/xet_session/mod.rs
@@ -275,5 +275,6 @@ pub use upload_file_handle::XetFileUpload;
 pub use upload_stream_handle::XetStreamUpload;
 pub use xet_data::deduplication::DeduplicationMetrics;
 pub use xet_data::processing::{Sha256Policy, XetFileInfo};
-pub use xet_data::progress_tracking::{GroupProgressReport, ItemProgressReport, UniqueID};
+pub use xet_data::progress_tracking::{GroupProgressReport, ItemProgressReport};
 pub use xet_runtime::config::XetConfig;
+pub use xet_runtime::utils::UniqueId;

--- a/xet_pkg/src/xet_session/session.rs
+++ b/xet_pkg/src/xet_session/session.rs
@@ -5,11 +5,11 @@ use std::sync::{Arc, Mutex, Weak};
 
 use tracing::info;
 use uuid::Uuid;
-use xet_data::progress_tracking::UniqueID;
 use xet_runtime::config::XetConfig;
 use xet_runtime::core::XetContext;
 #[cfg(feature = "fd-track")]
 use xet_runtime::fd_diagnostics::{report_fd_count, track_fd_scope};
+use xet_runtime::utils::UniqueId;
 
 use super::download_stream_group::{
     XetDownloadStreamGroup, XetDownloadStreamGroupBuilder, XetDownloadStreamGroupInner,
@@ -38,7 +38,7 @@ pub struct XetSessionInner {
     // Weak references so that dropping all user-held XetDownloadStreamGroup clones frees the group
     // immediately, without needing an explicit finalization call. abort() upgrades live weak refs
     // to cancel active streams.
-    pub(super) active_download_stream_groups: Mutex<HashMap<UniqueID, Weak<XetDownloadStreamGroupInner>>>,
+    pub(super) active_download_stream_groups: Mutex<HashMap<UniqueId, Weak<XetDownloadStreamGroupInner>>>,
 
     // "id" is used to identify a group of activities on our server, and so needs to be globally unique
     pub(super) id: Uuid,

--- a/xet_pkg/src/xet_session/upload_commit.rs
+++ b/xet_pkg/src/xet_session/upload_commit.rs
@@ -7,7 +7,8 @@ use std::sync::{Arc, Mutex, OnceLock};
 use tracing::{error, info};
 use xet_data::deduplication::DeduplicationMetrics;
 use xet_data::processing::{FileUploadSession, Sha256Policy, XetFileInfo};
-use xet_data::progress_tracking::{GroupProgressReport, ItemProgressReport, UniqueID};
+use xet_data::progress_tracking::{GroupProgressReport, ItemProgressReport};
+use xet_runtime::utils::UniqueId;
 
 use super::auth_group_builder::{AuthGroupBuilder, AuthOptions};
 use super::common::create_translator_config;
@@ -69,7 +70,7 @@ impl AuthGroupBuilder<XetUploadCommit> {
 ///
 /// Contains aggregate deduplication metrics, final progress, and per-file
 /// [`XetFileMetadata`] for every file that was successfully ingested,
-/// keyed by [`UniqueID`].
+/// keyed by [`UniqueId`].
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "python", pyo3::pyclass(get_all))]
 pub struct XetCommitReport {
@@ -78,7 +79,7 @@ pub struct XetCommitReport {
     /// Final progress snapshot at the time the commit completed.
     pub progress: GroupProgressReport,
     /// Per-file metadata keyed by task ID, one entry per successfully ingested file.
-    pub uploads: HashMap<UniqueID, XetFileMetadata>,
+    pub uploads: HashMap<UniqueId, XetFileMetadata>,
 }
 
 #[cfg(feature = "python")]
@@ -111,7 +112,7 @@ impl XetCommitReport {
 pub struct XetFileMetadata {
     /// Unique identifier for the task that produced this metadata.
     #[serde(skip)]
-    pub task_id: UniqueID,
+    pub task_id: UniqueId,
     /// Xet file information: hash, size, and optional SHA-256.
     pub xet_info: XetFileInfo,
     /// Per-file deduplication and chunking metrics.
@@ -137,7 +138,7 @@ impl XetFileMetadata {
 // ── XetUploadCommitInner ────────────────────────────────────────────────────
 
 pub(super) struct XetUploadCommitInner {
-    commit_id: UniqueID,
+    commit_id: UniqueId,
     pub(super) session: XetSession,
     pub(super) task_runtime: Arc<TaskRuntime>,
     upload_session: Arc<FileUploadSession>,
@@ -200,7 +201,7 @@ impl XetUploadCommitInner {
 
     fn register_spawned_task(
         &self,
-        task_id: UniqueID,
+        task_id: UniqueId,
         join_handle: tokio::task::JoinHandle<Result<(XetFileInfo, DeduplicationMetrics), xet_data::DataError>>,
         tracking_name: Option<String>,
         file_path: Option<PathBuf>,
@@ -360,7 +361,7 @@ impl XetUploadCommit {
         task_runtime: Arc<TaskRuntime>,
         auth_options: AuthOptions,
     ) -> Result<Self, XetError> {
-        let commit_id = UniqueID::new();
+        let commit_id = UniqueId::new();
         let config = create_translator_config(&session, auth_options).await?;
         let upload_session = FileUploadSession::new(Arc::new(config)).await?;
 
@@ -377,7 +378,7 @@ impl XetUploadCommit {
     }
 
     /// Unique identifier for this upload commit.
-    pub fn id(&self) -> UniqueID {
+    pub fn id(&self) -> UniqueId {
         self.inner.commit_id
     }
 
@@ -472,7 +473,7 @@ impl XetUploadCommit {
     /// `file_path` is `Some` for path/bytes uploads and `None` for stream uploads.
     /// `progress` is `None` if the upload has not started reporting yet.
     /// Used for display and diagnostics (e.g. `__repr__`).
-    pub fn active_upload_info(&self) -> Vec<(UniqueID, Option<PathBuf>, Option<ItemProgressReport>)> {
+    pub fn active_upload_info(&self) -> Vec<(UniqueId, Option<PathBuf>, Option<ItemProgressReport>)> {
         self.inner
             .file_handles
             .lock()

--- a/xet_pkg/src/xet_session/upload_file_handle.rs
+++ b/xet_pkg/src/xet_session/upload_file_handle.rs
@@ -6,7 +6,8 @@ use std::sync::Arc;
 
 use tracing::info;
 use xet_data::processing::FileUploadSession;
-use xet_data::progress_tracking::{ItemProgressReport, UniqueID};
+use xet_data::progress_tracking::ItemProgressReport;
+use xet_runtime::utils::UniqueId;
 
 use super::task_runtime::{BackgroundTaskState, TaskRuntime, XetTaskState};
 use super::upload_commit::XetFileMetadata;
@@ -15,7 +16,7 @@ use crate::error::XetError;
 // ── XetFileUploadInner ──────────────────────────────────────────────────────
 
 pub(super) struct XetFileUploadInner {
-    pub(super) task_id: UniqueID,
+    pub(super) task_id: UniqueId,
     pub(super) file_path: Option<PathBuf>,
     pub(super) upload_session: Arc<FileUploadSession>,
     pub(super) state: tokio::sync::Mutex<BackgroundTaskState<XetFileMetadata>>,
@@ -49,7 +50,7 @@ impl fmt::Debug for XetFileUpload {
 
 impl XetFileUpload {
     /// Unique identifier for this upload task, usable for progress lookups.
-    pub fn task_id(&self) -> UniqueID {
+    pub fn task_id(&self) -> UniqueId {
         self.inner.task_id
     }
 

--- a/xet_pkg/src/xet_session/upload_stream_handle.rs
+++ b/xet_pkg/src/xet_session/upload_stream_handle.rs
@@ -6,7 +6,8 @@ use std::sync::{Arc, OnceLock};
 use bytes::Bytes;
 use tracing::{debug, info};
 use xet_data::processing::{FileUploadSession, SingleFileCleaner};
-use xet_data::progress_tracking::{ItemProgressReport, UniqueID};
+use xet_data::progress_tracking::ItemProgressReport;
+use xet_runtime::utils::UniqueId;
 
 use super::task_runtime::{TaskRuntime, XetTaskState};
 use super::upload_commit::XetFileMetadata;
@@ -19,7 +20,7 @@ type CleanerState = Option<(SingleFileCleaner, Option<String>)>;
 // ── XetStreamUploadInner ─────────────────────────────────────────────────
 
 pub(super) struct XetStreamUploadInner {
-    pub(super) task_id: UniqueID,
+    pub(super) task_id: UniqueId,
     pub(super) result: Arc<OnceLock<XetFileMetadata>>,
     pub(super) cleaner: Arc<tokio::sync::Mutex<CleanerState>>,
     pub(super) upload_session: Arc<FileUploadSession>,
@@ -95,7 +96,7 @@ impl fmt::Debug for XetStreamUpload {
 
 impl XetStreamUpload {
     /// Unique identifier for this upload task, usable for progress lookups.
-    pub fn task_id(&self) -> UniqueID {
+    pub fn task_id(&self) -> UniqueId {
         self.inner.task_id
     }
 


### PR DESCRIPTION
In response to https://github.com/huggingface/xet-core/pull/792#discussion_r3119356452, this removes the \`UniqueID\` type alias that re-exported \`xet_runtime::utils::UniqueId\` under a screaming-snake-case name from \`xet_data::progress_tracking\`. This type alias is unnecessary and caused confusion for reviewers (both human beings and agents).

## Changes

- Drop \`pub use xet_runtime::utils::UniqueId as UniqueID\` from \`xet_data/src/progress_tracking/mod.rs\`
- Update all 24 call sites across \`xet_data\`, \`xet_pkg\`, and \`hf_xet\` to import \`xet_runtime::utils::UniqueId\` directly and use the canonical \`UniqueId\` name
- Re-export \`UniqueId\` (not \`UniqueID\`) from \`xet_pkg::xet_session\` for downstream consumers


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure type/name refactor across Rust and PyO3 bindings; low functional risk but may break downstream code that referenced the `UniqueID` re-export or Python type name.
> 
> **Overview**
> Removes the `UniqueID` type alias re-export from `xet_data::progress_tracking` and updates all callers across `xet_data`, `xet_pkg`, and `hf_xet` to use `xet_runtime::utils::UniqueId` directly.
> 
> Updates public API surface accordingly: task/group IDs in progress reports, upload/download handles, and error variants now use `UniqueId`, and `xet_pkg::xet_session` re-exports `UniqueId` (not `UniqueID`) for downstream consumers, including Python class registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06ff20f72e64721e8790b1826a4e5479394598c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->