### PR TITLE
Add context manager for upload stream

### DIFF
--- a/hf_xet/src/py_stream_upload_handle.rs
+++ b/hf_xet/src/py_stream_upload_handle.rs
@@ -9,8 +9,20 @@ use crate::{PyXetTaskState, convert_xet_error};
 /// Handle for a streaming upload within an :class:`XetUploadCommit`.
 ///
 /// Returned by :meth:`XetUploadCommit.start_upload_stream`.  Feed data incrementally
-/// with :meth:`write`, then call :meth:`finish` to finalise ingestion.
-/// **:meth:`finish` must be called before** :meth:`XetUploadCommit.wait_to_finish`.
+/// with :meth:`write`, then finalise with either:
+///
+/// - :meth:`finish` (explicit call), or
+/// - the context manager, which calls :meth:`finish` automatically on normal exit and :meth:`abort` on exception.
+///
+/// **:meth:`finish` (or the context manager) must complete before**
+/// :meth:`XetUploadCommit.wait_to_finish` is called.
+///
+/// ```python
+/// with commit.start_upload_stream(name="big.bin") as stream:
+///     for chunk in produce_chunks():
+///         stream.write(chunk)
+/// # finish() was called automatically
+/// ```
 #[pyclass(name = "XetStreamUpload")]
 #[derive(Clone)]
 pub struct PyXetStreamUpload {
@@ -35,9 +47,8 @@ impl PyXetStreamUpload {
         slf
     }
 
-    /// On normal exit: finalise the stream (equivalent to calling :meth:`finish`).
-    /// On exception: abort the upload.
-    /// Never suppresses the exception (returns ``False``).
+    /// Calls :meth:`finish` on normal exit (idempotent if already finished) or :meth:`abort` on
+    /// exception; never suppresses the exception.
     fn __exit__(
         &self,
         py: Python<'_>,
@@ -46,9 +57,11 @@ impl PyXetStreamUpload {
         _exc_tb: Bound<'_, pyo3::PyAny>,
     ) -> PyResult<bool> {
         if exc_type.is_none() {
-            // Normal exit: finalise the stream (GIL-releasing).
-            let inner = self.inner.clone();
-            py.detach(|| inner.finish_blocking().map_err(convert_xet_error))?;
+            // Normal exit: finalise the stream only if not already done (idempotent — avoids a
+            // double-finish error when the caller explicitly called finish() inside the with-block).
+            if self.inner.try_finish().is_none() {
+                self.finish(py)?;
+            }
         } else {
             // Exception path: cancel the upload (infallible).
             self.inner.abort();

--- a/hf_xet/src/py_stream_upload_handle.rs
+++ b/hf_xet/src/py_stream_upload_handle.rs
@@ -29,6 +29,35 @@ impl PyXetStreamUpload {
         format!("XetStreamUpload(task_id={}, status=\"{}\", bytes_completed={})", self.inner.task_id(), status, prog)
     }
 
+    // ── Context manager ──────────────────────────────────────────────────────
+
+    fn __enter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    /// On normal exit: finalise the stream (equivalent to calling :meth:`finish`).
+    /// On exception: abort the upload.
+    /// Never suppresses the exception (returns ``False``).
+    fn __exit__(
+        &self,
+        py: Python<'_>,
+        exc_type: Bound<'_, pyo3::PyAny>,
+        _exc_val: Bound<'_, pyo3::PyAny>,
+        _exc_tb: Bound<'_, pyo3::PyAny>,
+    ) -> PyResult<bool> {
+        if exc_type.is_none() {
+            // Normal exit: finalise the stream (GIL-releasing).
+            let inner = self.inner.clone();
+            py.detach(|| inner.finish_blocking().map_err(convert_xet_error))?;
+        } else {
+            // Exception path: cancel the upload (infallible).
+            self.inner.abort();
+        }
+        Ok(false) // do not suppress the exception
+    }
+
+    // ── Upload methods ───────────────────────────────────────────────────────
+
     /// Feed a chunk of data into the upload pipeline.
     ///
     /// May be called any number of times before :meth:`finish`.

--- a/hf_xet/tests/test_upload_commit.py
+++ b/hf_xet/tests/test_upload_commit.py
@@ -221,4 +221,24 @@ class TestUploadStream:
         stream.write(b"to be aborted")
         stream.abort()  # should not raise
 
+    def test_context_manager_finishes_on_normal_exit(self, endpoint):
+        commit = hf_xet.XetSession().new_upload_commit(endpoint=endpoint)
+        with commit.start_upload_stream(name="cm.bin") as stream:
+            stream.write(b"context manager data")
+        # finish() was called automatically; result is accessible via try_finish()
+        result = stream.try_finish()
+        assert result is not None
+        assert result.xet_info.file_size == len(b"context manager data")
+
+    def test_context_manager_aborts_on_exception(self, endpoint):
+        raised = False
+        commit = hf_xet.XetSession().new_upload_commit(endpoint=endpoint)
+        try:
+            with commit.start_upload_stream(name="abort.bin") as stream:
+                stream.write(b"will be aborted")
+                raise ValueError("intentional error")
+        except ValueError:
+            raised = True
+        assert raised  # exception must propagate
+
 

--- a/hf_xet/tests/test_upload_commit.py
+++ b/hf_xet/tests/test_upload_commit.py
@@ -240,5 +240,15 @@ class TestUploadStream:
         except ValueError:
             raised = True
         assert raised  # exception must propagate
+        assert stream.try_finish() is None  # abort() ran, not finish()
+
+    def test_context_manager_idempotent_when_finish_called_inside(self, endpoint):
+        # Calling finish() explicitly inside the with-block must not cause a double-finish error.
+        commit = hf_xet.XetSession().new_upload_commit(endpoint=endpoint)
+        with commit.start_upload_stream(name="early.bin") as stream:
+            stream.write(b"early finish")
+            result = stream.finish()  # explicit finish inside the block
+        # __exit__ skipped the second finish; result is still valid
+        assert result.xet_info.file_size == len(b"early finish")
 
 


### PR DESCRIPTION
## Summary

Addresses the review [comment](https://github.com/huggingface/xet-core/pull/792#issuecomment-4305213150) on #792: adds a context manager to `XetStreamUpload` so callers no longer need an explicit `finish()` call.

```python
# Before
stream = commit.start_upload_stream(name="big.bin")
for chunk in produce_chunks():
    stream.write(chunk)
stream.finish()  # must be called explicitly

# After
with commit.start_upload_stream(name="big.bin") as stream:
    for chunk in produce_chunks():
        stream.write(chunk)
# finish() called automatically on normal exit
# abort() called automatically on exception
```

## Changes

- **`hf_xet/src/py_stream_upload_handle.rs`** — add `__enter__` / `__exit__` to `PyXetStreamUpload`:
  - Normal exit: calls `finish()` (GIL-releasing via `py.detach()`), idempotent — skips if `finish()` was already called inside the `with`-block
  - Exception: calls `abort()` (infallible)
  - Updated class docstring with usage example
- **`hf_xet/tests/test_upload_commit.py`** — three new tests in `TestUploadStream`:
  - `test_context_manager_finishes_on_normal_exit` — verifies `try_finish()` is non-`None` after the block
  - `test_context_manager_aborts_on_exception` — verifies exception propagates and `try_finish()` is `None`
  - `test_context_manager_idempotent_when_finish_called_inside` — verifies calling `finish()` explicitly inside the block does not cause a double-finish error on exit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds Python context-manager semantics around stream finalization/abort; behavior is largely additive but could affect edge cases around finishing/aborting if callers rely on exceptions during cleanup.
> 
> **Overview**
> `XetStreamUpload` can now be used as a Python context manager: `__exit__` auto-calls `finish()` on normal exit and `abort()` when exiting due to an exception, without suppressing errors.
> 
> The implementation is explicitly *idempotent* by skipping `finish()` in `__exit__` if the stream already reports finished, and docs/tests were updated to cover normal-exit finishing, exception-triggered abort, and the “finish inside with-block” case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34c6f67272f5681437ea1d2c1a3df7a1cddeafbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->