### PR TITLE
Fix spelling typos in comments and docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -10,7 +10,7 @@ body:
     id: bug-description
     attributes:
       label: Describe the bug
-      description: A clear and concise description of what the bug is and details about your machine (e.g., network capcity, file system, disk type, etc.).
+      description: A clear and concise description of what the bug is and details about your machine (e.g., network capacity, file system, disk type, etc.).
       placeholder: Bug description
     validations:
       required: true

--- a/api_changes/README.md
+++ b/api_changes/README.md
@@ -1,6 +1,6 @@
 # API changes
 
-This folder contains a record of API changes in main.  It's indended for AI agents
+This folder contains a record of API changes in main.  It's intended for AI agents
 to read in order to correctly apply merges or update dependencies and PRs. 
 
 The updates are listed by date in the form: `update_<yymmdd>_<description>.md`

--- a/git_xet/src/auth.rs
+++ b/git_xet/src/auth.rs
@@ -36,7 +36,7 @@ pub use ssh::{GitLFSAuthentationResponseHeader, GitLFSAuthenticateResponse};
 // If set to "basic" then credentials will be requested before making batch requests to this url,
 // otherwise a public request will initially be attempted.
 // If set to "none" then credentials are not needed. For this case we don't want to prompt the user
-// for any crendential.
+// for any credential.
 //
 // See https://github.com/git-lfs/git-lfs/blob/main/docs/man/git-lfs-config.adoc and
 // https://github.com/git-lfs/git-lfs/blob/463ed9727d21155585721489fdb8cc81030f979b/lfsapi/auth.go#L151

--- a/git_xet/src/lfs_agent_protocol/progress_updater.rs
+++ b/git_xet/src/lfs_agent_protocol/progress_updater.rs
@@ -10,7 +10,7 @@ use super::{LFSProtocolResponseEvent, ProgressResponse, to_line_delimited_json_s
 /// This updater ensures that these messages contain monotonic increasing progress
 /// regardless of reordered/unordered underlying progress registrations due to scheduling.
 ///
-/// The implemention handles concurrent updates correctly and is "wait-free": concurrent callers
+/// The implementation handles concurrent updates correctly and is "wait-free": concurrent callers
 /// to `update_bytes_so_far` don't wait for turns to use the update message channel, only the
 /// first that acquires the lock gets to send a message with the latest progress.
 pub struct ProgressUpdater<W: Write + Send + Sync + 'static> {

--- a/hf_xet/src/logging.rs
+++ b/hf_xet/src/logging.rs
@@ -42,5 +42,5 @@ pub fn init_logging(py: Python) {
 
     xet_runtime::logging::init(cfg);
 
-    info!("hf_xet logging cofigured.");
+    info!("hf_xet logging configured.");
 }

--- a/xet_client/src/cas_client/retry_wrapper.rs
+++ b/xet_client/src/cas_client/retry_wrapper.rs
@@ -391,7 +391,7 @@ impl RetryWrapper {
     ///
     /// The `make_request` function returns a future that resolves to a Result<Response> object as is returned by the
     /// client middleware.  For example, `|| client.clone().get(url).send()` returns a future (as `send()` is async)
-    /// that will then be evaluatated to get the response.
+    /// that will then be evaluated to get the response.
     ///
     /// This functions acts just like the bytes() function on a client response, but retries the entire connection on
     /// transient errors.

--- a/xet_client/src/cas_types/mod.rs
+++ b/xet_client/src/cas_types/mod.rs
@@ -206,7 +206,7 @@ pub struct QueryReconstructionResponse {
     // For range query [a, b) into a file content, the location
     // of "a" into the first range.
     pub offset_into_first_range: u64,
-    // Series of terms describing a xorb hash and chunk range to be retreived
+    // Series of terms describing a xorb hash and chunk range to be retrieved
     // to reconstruct the file
     pub terms: Vec<XorbReconstructionTerm>,
     // information to fetch xorb ranges to reconstruct the file
@@ -284,7 +284,7 @@ pub type BatchQueryReconstructionRequest = HashSet<HexKey>;
 // Response type for querying reconstruction for a batch of files
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct BatchQueryReconstructionResponse {
-    // Map of FileID to series of terms describing a xorb hash and chunk range to be retreived
+    // Map of FileID to series of terms describing a xorb hash and chunk range to be retrieved
     // to reconstruct the file
     pub files: HashMap<HexMerkleHash, Vec<XorbReconstructionTerm>>,
     // information to fetch xorb ranges to reconstruct the file

--- a/xet_client/src/chunk_cache/disk.rs
+++ b/xet_client/src/chunk_cache/disk.rs
@@ -636,7 +636,7 @@ fn read_dir(path: impl AsRef<Path>) -> OptionResult<std::fs::ReadDir, ChunkCache
 
 // returns Ok(Some(_)) if result dirent is a directory, Ok(None) if was removed
 // also returns an Ok(None) if the dirent is not a directory, in which case we should
-//   not remove it in case the user put something inadvertantly or intentionally,
+//   not remove it in case the user put something inadvertently or intentionally,
 //   but not attempt to parse it as a valid cache directory.
 // Err(_) if an unrecoverable error occurred
 fn is_ok_dir(dir_result: Result<DirEntry, io::Error>) -> OptionResult<DirEntry, ChunkCacheError> {

--- a/xet_core_structures/src/metadata_shard/interpolation_search.rs
+++ b/xet_core_structures/src/metadata_shard/interpolation_search.rs
@@ -4,7 +4,7 @@ use std::mem::size_of;
 
 use crate::serialization_utils::*;
 
-/// Performs an interpolation search on a block of sorted, possibly multile
+/// Performs an interpolation search on a block of sorted, possibly multiple
 /// u64 hash keys with a simple payload.
 ///
 /// read_start: The byte offset in the reader that gives the start of the data.

--- a/xet_core_structures/src/metadata_shard/session_directory.rs
+++ b/xet_core_structures/src/metadata_shard/session_directory.rs
@@ -90,7 +90,7 @@ pub fn merge_shards(
             return Err(RuntimeError::KeyboardInterrupt.into());
         }
 
-        // Now, load the new shard data in.  To be resiliant to the possibility of shards
+        // Now, load the new shard data in.  To be resilient to the possibility of shards
         // being deleted under us (as can happen in shard session resume with multiple
         // processes running), always load it all into memory at the start and write it out
         // at the end.

--- a/xet_core_structures/src/metadata_shard/shard_file_handle.rs
+++ b/xet_core_structures/src/metadata_shard/shard_file_handle.rs
@@ -27,7 +27,7 @@ pub struct MDBShardFile {
     pub shard: MDBShardInfo,
     pub last_modified_time: SystemTime,
 
-    // On occation, to test a corrupt shard, we need to disable the verification process.
+    // On occasion, to test a corrupt shard, we need to disable the verification process.
     #[cfg(debug_assertions)]
     pub disable_verifications: std::sync::atomic::AtomicBool,
 }
@@ -307,7 +307,7 @@ impl MDBShardFile {
 
             s.verify_shard_integrity_debug_only();
             callback(s)?;
-            debug!("Registerd shard file '{file_name:?}'.");
+            debug!("Registered shard file '{file_name:?}'.");
             Ok(())
         };
 

--- a/xet_core_structures/src/metadata_shard/shard_file_manager.rs
+++ b/xet_core_structures/src/metadata_shard/shard_file_manager.rs
@@ -788,7 +788,7 @@ mod tests {
                 // Make sure two queries return same results.
                 assert_eq!(result_m.is_some(), result_f.is_some());
 
-                // Make sure retriving the expected file.
+                // Make sure retrieving the expected file.
                 if let (Some(result_m), Some(result_f)) = (result_m, result_f) {
                     assert_eq!(result_m.metadata.file_hash, *k);
                     assert_eq!(result_f.0.metadata.file_hash, *k);

--- a/xet_core_structures/src/metadata_shard/shard_format.rs
+++ b/xet_core_structures/src/metadata_shard/shard_format.rs
@@ -1586,7 +1586,7 @@ pub mod test_routines {
             // Make sure two queries return same results.
             assert_eq!(result_m, result_f);
 
-            // Make sure retriving the expected file.
+            // Make sure retrieving the expected file.
             if let Some(rm) = result_m {
                 assert_eq!(rm.metadata.file_hash, *k);
                 assert_eq!(result_f.unwrap().metadata.file_hash, *k);

--- a/xet_core_structures/src/metadata_shard/xorb_structs.rs
+++ b/xet_core_structures/src/metadata_shard/xorb_structs.rs
@@ -131,7 +131,7 @@ impl XorbChunkSequenceEntry {
         }
     }
 
-    // Is this chunk elegible for a global dedup query?
+    // Is this chunk eligible for a global dedup query?
     pub fn is_global_dedup_eligible(&self) -> bool {
         (self.flags & MDB_CHUNK_WITH_GLOBAL_DEDUP_FLAG) != 0 || hash_is_global_dedup_eligible(&self.chunk_hash)
     }

--- a/xet_core_structures/src/xorb_object/byte_grouping/bg4_prediction.rs
+++ b/xet_core_structures/src/xorb_object/byte_grouping/bg4_prediction.rs
@@ -67,7 +67,7 @@ impl BG4Predictor {
 
     /// This is a reference version that uses the SWAR bit twiddling trick; see Hacker's delight for reference.
     /// A lot of very cheap operations on 16 bytes at a time is likely faster than running popcnt on each byte.
-    /// On other archetectures, used as the fallback method.
+    /// On other architectures, used as the fallback method.
     #[inline(always)]
     fn popcnt_u128_swar(v: u128) -> u128 {
         const M1: u128 = 0x5555_5555_5555_5555_5555_5555_5555_5555u128;
@@ -148,7 +148,7 @@ impl BG4Predictor {
                 // We can add the counts directly here; as long as 9 * BLOCK_SIZE < 256 so each byte doesn't overflow
                 // into the next byte over.
                 for i in 0..raw_input.len() {
-                    // Ensure we're handling endianess correctly.  Should optimize out endian switching calls on
+                    // Ensure we're handling endianness correctly.  Should optimize out endian switching calls on
                     // little-endian machines.
                     *popcnt_v.get_unchecked_mut(i) =
                         calc_u128_popcnt(u128::from_le_bytes(raw_input.get_unchecked(i).to_ne_bytes()));

--- a/xet_data/src/deduplication/chunking.rs
+++ b/xet_data/src/deduplication/chunking.rs
@@ -111,7 +111,7 @@ impl Chunker {
                 // We must enforce that the next boundary is actually past the minimum chunk size.
                 // Because of how the rolling hash is computed, bytes before HASH_WINDOW_SIZE don't affect the hash,
                 // so with the above skip we depend on it running for at least HASH_WINDOW_SIZE bytes before triggering
-                // a boundary.   However, in rare occurances, there can be a boundary triggered before HASH_WINDOW_SIZE
+                // a boundary.   However, in rare occurrences, there can be a boundary triggered before HASH_WINDOW_SIZE
                 // bytes have been processed, which means the boundary is triggered based on the previous state of the
                 // hasher rather than on the current chunk content.  Thus we ensure this can't happen by ensuring that
                 // we have processed at least HASH_WINDOW_SIZE bytes.
@@ -144,7 +144,7 @@ impl Chunker {
     }
 
     fn reset_state(&mut self) {
-        // Strictly speaking, this is unneccesary, as we should always hash 64 bytes out making the previous state
+        // Strictly speaking, this is unnecessary, as we should always hash 64 bytes out making the previous state
         // of the hasher irrelevant.  However, this explicitly declares we're resetting things to the
         // initial state.
         self.hash.set_hash(0);
@@ -561,7 +561,7 @@ mod tests {
     fn create_random_data(n: usize, seed: u64) -> Vec<u8> {
         // This test will actually need to be run in different environments, so to generate
         // the table below, create random data using a simple SplitMix rng that can be ported here
-        // as is without dependening on other po
+        // as is without depending on other po
         let mut ret = Vec::with_capacity(n + 7);
 
         let mut state = seed;

--- a/xet_data/src/deduplication/data_aggregator.rs
+++ b/xet_data/src/deduplication/data_aggregator.rs
@@ -121,7 +121,7 @@ impl DataAggregator {
             for fi in file_info.0.segments.iter_mut() {
                 // To transfer the cas chunks from the other data aggregator to this one,
                 // shift chunk indices so the new index start and end values reflect the
-                // append opperation above.
+                // append operation above.
                 if fi.xorb_hash == MerkleHash::marker() {
                     fi.chunk_index_start += shift;
                     fi.chunk_index_end += shift;

--- a/xet_data/src/deduplication/file_deduplication.rs
+++ b/xet_data/src/deduplication/file_deduplication.rs
@@ -137,7 +137,7 @@ impl<DataInterfaceType: DeduplicationDataInterface> FileDeduper<DataInterfaceTyp
                     self.data_mng.chunk_hash_dedup_query(&chunk_hashes[local_chunk_index..]).await?
                 {
                     if !first_pass {
-                        // This means new shards were discovered; so these are global dedup elegible.  We'll record
+                        // This means new shards were discovered; so these are global dedup eligible.  We'll record
                         // the rest later on
                         dedup_metrics.deduped_chunks_by_global_dedup += n_deduped as u64;
                         dedup_metrics.deduped_bytes_by_global_dedup += fse.unpacked_segment_bytes as u64;

--- a/xet_data/src/deduplication/interface.rs
+++ b/xet_data/src/deduplication/interface.rs
@@ -41,7 +41,7 @@ pub trait DeduplicationDataInterface: Send + Sync + 'static {
 
     /// Register a set of xorb dependencies; this is called periodically during the dedup
     /// process with a list of (xorb hash, n_bytes).  As the final bit may get
-    /// returned as a partial xorb without a hash yet, it is not gauranteed that the
+    /// returned as a partial xorb without a hash yet, it is not guaranteed that the
     /// sum of the n_bytes across all the dependencies will equal the size of the file.
     async fn register_xorb_dependencies(&mut self, dependencies: &[FileXorbDependency]);
 }


### PR DESCRIPTION
## Summary
- Run codespell across tracked files in the repo and fix unambiguous spelling typos
- All edits are in comments, doc strings, an issue template, and one log message — no logic changes
- 22 typos fixed across 19 files (e.g. retreived→retrieved, elegible→eligible, occurances→occurrences, gauranteed→guaranteed, endianess→endianness, archetectures→architectures, etc.)

## Cases left for follow-up (not in this PR)
A few hits were ambiguous and need human judgment:
- \`xet_core_structures/src/metadata_shard/shard_file_manager.rs:1400\` — comment "but delet" appears truncated
- \`xet_core_structures/src/metadata_shard/shard_format.rs:1577\` — "invalid somes" likely meant "invalid ones"
- \`xet_data/src/deduplication/chunking.rs:564\` — comment trails off ("on other po")

False positives left untouched: \`serde::ser::*\` module paths, "process-global statics" (Rust \`static\` items), "implementor(s)" (valid alternate of "implementer"), "re-used", "unparseable".

## Test plan
- [x] \`cargo check --workspace --lib --all-features\` passes
- [ ] CI green on the draft PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to spelling fixes in comments/docs, an issue template string, and a single log message, with no functional code modifications.
> 
> **Overview**
> Fixes a set of unambiguous spelling typos across the repo (primarily Rust comments/docstrings plus `.github/ISSUE_TEMPLATE/bug-report.yml` and `api_changes/README.md`).
> 
> Also corrects one user-facing log line in `hf_xet` ("cofigured" -> "configured"); otherwise behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e615df87a8a5d31ab98f85bde227db3555a8a729. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->