### PR TITLE
Remove third party codesign & notarize action

### DIFF
--- a/.github/actions/macos-codesign-notarize/action.yml
+++ b/.github/actions/macos-codesign-notarize/action.yml
@@ -1,0 +1,106 @@
+name: "macOS Codesign and Notarize"
+description: "Sign and notarize a macOS binary using local tools only (no external action dependencies)"
+
+inputs:
+  file:
+    description: "The file to sign (relative or absolute path)"
+    required: true
+  certificate-data:
+    description: "Base64-encoded p12 certificate contents"
+    required: true
+  certificate-password:
+    description: "Password to unlock the certificate"
+    required: true
+  certificate-id:
+    description: "Signing identity (Apple Team ID); used as -s argument for codesign and --team-id for notarytool"
+    required: true
+  apple-notary-user:
+    description: "Apple Developer account email for notarization"
+    required: true
+  apple-notary-password:
+    description: "Apple Developer account app-specific password for notarization"
+    required: true
+  options:
+    description: "Extra options to pass to codesign (e.g. --options runtime --entitlements path/to/entitlements.xml)"
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve absolute file path
+      id: resolve
+      shell: bash
+      env:
+        INPUT_FILE: ${{ inputs.file }}
+      run: echo "file=$(realpath "$INPUT_FILE")" >> "$GITHUB_OUTPUT"
+
+    - name: Codesign
+      shell: bash
+      env:
+        FILE: ${{ steps.resolve.outputs.file }}
+        INPUT_CERT_DATA: ${{ inputs.certificate-data }}
+        INPUT_CERT_PWD: ${{ inputs.certificate-password }}
+        INPUT_CERT_ID: ${{ inputs.certificate-id }}
+        INPUT_OPTIONS: ${{ inputs.options }}
+      run: |
+        if [ ! -f "$FILE" ]; then
+          echo "::error::File does not exist: $FILE"
+          exit 1
+        fi
+
+        CERT_PATH="$RUNNER_TEMP/signcert.p12"
+        echo "$INPUT_CERT_DATA" | base64 --decode > "$CERT_PATH"
+
+        security create-keychain -p actions macos-build.keychain
+        security default-keychain -s macos-build.keychain
+        security unlock-keychain -p actions macos-build.keychain
+        security set-keychain-settings -t 3600 -u macos-build.keychain
+
+        # Fallback for non-standard p12 formats: split into key + cert and import separately
+        if ! security import "$CERT_PATH" -k ~/Library/Keychains/macos-build.keychain \
+            -P "$INPUT_CERT_PWD" -T /usr/bin/codesign -T /usr/bin/productsign; then
+          openssl pkcs12 -in "$CERT_PATH" -nocerts -out "$RUNNER_TEMP/codesign.key" \
+            -nodes -password pass:"$INPUT_CERT_PWD"
+          openssl pkcs12 -in "$CERT_PATH" -clcerts -nokeys -out "$RUNNER_TEMP/codesign.crt" \
+            -password pass:"$INPUT_CERT_PWD"
+          security import "$RUNNER_TEMP/codesign.key" -k ~/Library/Keychains/macos-build.keychain \
+            -T /usr/bin/codesign
+          security import "$RUNNER_TEMP/codesign.crt" -k ~/Library/Keychains/macos-build.keychain \
+            -T /usr/bin/codesign
+        fi
+
+        # Required to allow codesign to access the keychain without an interactive prompt
+        security set-key-partition-list -S apple-tool:,apple: -s -k actions macos-build.keychain
+
+        # shellcheck disable=SC2086
+        codesign --force $INPUT_OPTIONS -s "$INPUT_CERT_ID" "$FILE"
+        codesign -v "$FILE" --verbose
+
+    - name: Notarize
+      shell: bash
+      env:
+        FILE: ${{ steps.resolve.outputs.file }}
+        INPUT_CERT_ID: ${{ inputs.certificate-id }}
+        INPUT_NOTARY_USER: ${{ inputs.apple-notary-user }}
+        INPUT_NOTARY_PWD: ${{ inputs.apple-notary-password }}
+      run: |
+        # notarytool requires .app/.pkg/.dmg or a .zip; -j strips directory paths from the archive
+        ZIP_PATH="$RUNNER_TEMP/notarize-submit.zip"
+        zip -j "$ZIP_PATH" "$FILE"
+
+        xcrun notarytool submit "$ZIP_PATH" \
+          --apple-id "$INPUT_NOTARY_USER" \
+          --password "$INPUT_NOTARY_PWD" \
+          --team-id "$INPUT_CERT_ID" \
+          --wait
+
+        rm -f "$ZIP_PATH"
+
+    - name: Verify notarization
+      shell: bash
+      env:
+        FILE: ${{ steps.resolve.outputs.file }}
+      run: |
+        # Stapling is not possible for plain binaries; verify notarization status online instead
+        codesign -vvvv -R="notarized" --check-notarization "$FILE"

--- a/.github/workflows/git-xet-release.yml
+++ b/.github/workflows/git-xet-release.yml
@@ -11,6 +11,7 @@ on:
         description: "Semantic version for release (tag will shard the same name)"
         required: true
         default: "v0.1.0"
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/git-xet-release.yml
+++ b/.github/workflows/git-xet-release.yml
@@ -11,7 +11,6 @@ on:
         description: "Semantic version for release (tag will shard the same name)"
         required: true
         default: "v0.1.0"
-  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/git-xet-release.yml
+++ b/.github/workflows/git-xet-release.yml
@@ -64,7 +64,7 @@ jobs:
           cp target/release/git-xet dist/
           cp git_xet/entitlements.xml dist/
       - name: Codesign and Notarization
-        uses: lando/code-sign-action@a5703d3b5486ada6e8efd08912110f8756e873e8  # v3
+        uses: ./.github/actions/macos-codesign-notarize
         with:
           file: dist/git-xet
           certificate-data: ${{ secrets.CLI_MACOS_CERTIFICATE }}
@@ -72,7 +72,6 @@ jobs:
           certificate-password: ${{ secrets.CLI_MACOS_CERTIFICATE_PWD }}
           apple-notary-user: ${{ secrets.CLI_MACOS_NOTARY_USER }}
           apple-notary-password: ${{ secrets.CLI_MACOS_NOTARY_PWD }}
-          apple-product-id: co.huggingface.gitxet
           options: --options runtime --entitlements dist/entitlements.xml
       - name: Upload binary
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6


### PR DESCRIPTION
Fix issue https://github.com/huggingface/xet-core/issues/822.

## Problem

`lando/code-sign-action` (used to codesign and notarize the macOS `git-xet` binary) does not pin its transitive dependency `cognitedata/code-sign-action@v3` & `lando/notarize-action@v2` to a commit SHA. This repo enforces SHA-pinning for all third-party actions, so the workflow was failing for a while.

## Solution

My attempt PR to pin its transitive dependencies met with no response, so this PR extracts the macOS codesign + notarize logic into a local composite action `.github/actions/macos-codesign-notarize` — mirroring the existing `.github/actions/windows-codesign` pattern — with zero external `uses:` dependencies.

The new action:
1. **Codesigns** the binary: decodes the p12 cert, creates a temporary keychain, imports the cert (with an openssl fallback for non-standard p12 formats), and calls `codesign --force`
2. **Notarizes** via `xcrun notarytool submit --wait`: zips the binary first (required since `notarytool` does not accept raw binaries), submits to Apple, and waits for approval
3. **Verifies** with `codesign --check-notarization`: stapling is not possible for plain binaries, so verification is done online

## Test plan

In this PR, trigger the `git-xet Release` workflow by modifying the `git-xet-release.yml` trigger condition to add `pull_requset:` (commit https://github.com/huggingface/xet-core/pull/829/commits/d233f4416048188dee0910c4ee382c4e27f12bb3):

- [x] macOS jobs complete the **Codesign** step without identity errors
- [x] macOS jobs complete the **Notarize** step (`xcrun notarytool submit --wait` exits 0)
- [x] macOS jobs complete the **Verify notarization** step (`codesign --check-notarization` returns clean)
- [x] Both `git-xet-macos-x86_64` and `git-xet-macos-aarch64` artifacts are uploaded

To manually verify a downloaded artifact on macOS:

```bash
# Confirm it is signed with a Developer ID
codesign -dv --verbose=4 ./git-xet

# Confirm Apple has notarized it (requires network access)
codesign -vvvv -R="notarized" --check-notarization ./git-xet
```

## Manual changes to the repo settings:

- [x] Remove `lando/code-sign-action@*` from the actions allow list
- [x] Remove `cognitedata/code-sign-action@*` from the actions allow list
- [x] Remove `lando/notarize-action@*` from the actions allow list
- [x] Remove `digicert/ssm-code-signing@*` from the actions allow list

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the macOS release signing/notarization pipeline and keychain/certificate handling, which could break artifact publishing if the new steps differ from the previous action behavior.
> 
> **Overview**
> Replaces the `git-xet` macOS release workflow’s third-party `lando/code-sign-action` step with a repo-local composite action to satisfy SHA-pinning/no-transitive-deps requirements.
> 
> Adds `.github/actions/macos-codesign-notarize`, which creates a temporary keychain, imports the p12 (with an `openssl` fallback), runs `codesign`, submits a zipped binary to `xcrun notarytool --wait`, and verifies notarization via `codesign --check-notarization`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36db8e1ec5866e29bc40aba3fa806af1e5ba341a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->