### PR TITLE
fix(ci): export __heap_base in WASM build to fix wasm-bindgen threading

### DIFF
--- a/wasm/hf_xet_wasm/build_wasm.sh
+++ b/wasm/hf_xet_wasm/build_wasm.sh
@@ -32,6 +32,7 @@ TARGET_RUSTFLAGS="-C target-feature=+atomics,+bulk-memory,+mutable-globals \
   -C link-arg=--export=__tls_size \
   -C link-arg=--export=__tls_align \
   -C link-arg=--export=__tls_base \
+  -C link-arg=--export=__heap_base \
   --cfg getrandom_backend=\"wasm_js\"" \
 CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS="$TARGET_RUSTFLAGS" \
 cargo +nightly build \


### PR DESCRIPTION
## Summary

- Add `-C link-arg=--export=__heap_base` to WASM RUSTFLAGS in `build_wasm.sh`

## Context

`nightly-2026-05-06` (`365c0e1d7`) stopped exporting `__heap_base` by default when `--import-memory` is used, which breaks `wasm-bindgen`'s thread ID injection:

```
error: failed to prepare module for threading
Caused by: failed to find `__heap_base` for injecting thread id
```

Rather than pinning the nightly, explicitly exporting the symbol keeps us on latest nightly and is forward-compatible (the flag is a no-op when the symbol is already exported).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a build-script-only change that adjusts WASM linker exports; main risk is unintended side effects in the generated WASM module layout or compatibility, but it is limited to the wasm build pipeline.
> 
> **Overview**
> Updates `wasm/hf_xet_wasm/build_wasm.sh` to explicitly export the `__heap_base` symbol via an additional linker arg in `TARGET_RUSTFLAGS` when building the `wasm32-unknown-unknown` artifact.
> 
> This is intended to keep `wasm-bindgen` threading support working under newer nightly toolchains when `--import-memory` is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 638ca13c801acc37f38ccdbc60af9135752190ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->