### PR TITLE
feat(xet_client): fall back to single-range GETs when a multi-range URL 403s

### DIFF
--- a/xet_client/src/cas_client/interface.rs
+++ b/xet_client/src/cas_client/interface.rs
@@ -69,9 +69,7 @@ impl URLProvider for SingleRangeURLProvider {
 ///
 /// Returns an empty vec if the inner provider has no ranges (caller should treat this as an
 /// error condition).
-pub async fn split_into_single_range_providers(
-    inner: Arc<Box<dyn URLProvider>>,
-) -> Result<Vec<Box<dyn URLProvider>>> {
+pub async fn split_into_single_range_providers(inner: Arc<Box<dyn URLProvider>>) -> Result<Vec<Box<dyn URLProvider>>> {
     let (_, ranges) = inner.retrieve_url().await?;
     Ok((0..ranges.len())
         .map(|i| Box::new(SingleRangeURLProvider::new(inner.clone(), i)) as Box<dyn URLProvider>)

--- a/xet_client/src/cas_client/interface.rs
+++ b/xet_client/src/cas_client/interface.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use bytes::Bytes;
 use xet_core_structures::merklehash::MerkleHash;
 use xet_core_structures::metadata_shard::file_structs::MDBFileInfo;
@@ -17,6 +19,63 @@ pub trait URLProvider: Send + Sync {
 
     /// Asks for a refresh of the URL; triggered on 403 errors.
     async fn refresh_url(&self) -> Result<()>;
+}
+
+/// A `URLProvider` wrapper that exposes exactly one of the byte ranges returned by an inner
+/// provider as if it were a single-range fetch.
+///
+/// This is used by `RemoteClient::get_file_term_data` as a fallback when a multi-range signed
+/// URL is rejected by the storage backend (some CDN edges reject multi-range Range headers
+/// with 403 before the request reaches the origin). Splitting the failed multi-range fetch
+/// into N independent single-range GETs against the same URL travels the same single-range
+/// code path that V1 reconstruction already uses, and avoids the broken multi-range path.
+///
+/// `refresh_url` is delegated to the inner provider so that signature refresh semantics are
+/// preserved.
+pub struct SingleRangeURLProvider {
+    inner: Arc<Box<dyn URLProvider>>,
+    range_index: usize,
+}
+
+impl SingleRangeURLProvider {
+    pub fn new(inner: Arc<Box<dyn URLProvider>>, range_index: usize) -> Self {
+        Self { inner, range_index }
+    }
+}
+
+#[async_trait::async_trait]
+impl URLProvider for SingleRangeURLProvider {
+    async fn retrieve_url(&self) -> Result<(String, Vec<HttpRange>)> {
+        let (url, ranges) = self.inner.retrieve_url().await?;
+        // The inner provider's range count can change across a refresh; clamp defensively
+        // rather than panic. If the index is out of bounds we fall back to a single-range
+        // request using the last available range, which keeps the fetch a valid GET — the
+        // caller will detect a content-length mismatch if anything is off.
+        let range = ranges
+            .get(self.range_index)
+            .copied()
+            .or_else(|| ranges.last().copied())
+            .ok_or_else(|| crate::error::ClientError::Other("URLProvider returned no ranges".to_string()))?;
+        Ok((url, vec![range]))
+    }
+
+    async fn refresh_url(&self) -> Result<()> {
+        self.inner.refresh_url().await
+    }
+}
+
+/// Build a fan-out of single-range URL providers from a multi-range provider, one per range
+/// reported by the inner provider's most recent `retrieve_url()` call.
+///
+/// Returns an empty vec if the inner provider has no ranges (caller should treat this as an
+/// error condition).
+pub async fn split_into_single_range_providers(
+    inner: Arc<Box<dyn URLProvider>>,
+) -> Result<Vec<Box<dyn URLProvider>>> {
+    let (_, ranges) = inner.retrieve_url().await?;
+    Ok((0..ranges.len())
+        .map(|i| Box::new(SingleRangeURLProvider::new(inner.clone(), i)) as Box<dyn URLProvider>)
+        .collect())
 }
 
 /// A Client to the Shard service. The shard service

--- a/xet_client/src/cas_client/mod.rs
+++ b/xet_client/src/cas_client/mod.rs
@@ -1,4 +1,4 @@
-pub use interface::{Client, URLProvider};
+pub use interface::{Client, SingleRangeURLProvider, URLProvider, split_into_single_range_providers};
 pub use remote_client::RemoteClient;
 pub use simulation::{ClientTestingUtils, DirectAccessClient, MemoryClient, RandomFileContents, RandomXorb};
 #[cfg(not(target_family = "wasm"))]

--- a/xet_client/src/cas_client/remote_client.rs
+++ b/xet_client/src/cas_client/remote_client.rs
@@ -856,13 +856,20 @@ impl Client for RemoteClient {
 #[cfg(test)]
 #[cfg(not(target_family = "wasm"))]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use async_trait::async_trait;
     use tracing_test::traced_test;
-    use xet_core_structures::xorb_object::CompressionScheme;
+    use wiremock::matchers::{header, headers, method, path_regex};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
     use xet_core_structures::xorb_object::xorb_format_test_utils::{
         ChunkSize, build_and_verify_xorb_object, build_raw_xorb,
     };
+    use xet_core_structures::xorb_object::{CompressionScheme, serialize_chunk};
+    use xet_runtime::config::XetConfig;
 
     use super::*;
+    use crate::cas_client::interface::URLProvider;
 
     #[ignore = "requires a running CAS server"]
     #[traced_test]
@@ -888,5 +895,234 @@ mod tests {
 
         // Assert
         assert!(result.is_ok());
+    }
+
+    // --- multi-range 403 fallback tests --------------------------------------------------
+
+    /// Test-only URLProvider that returns a fixed URL + ranges. `refresh_url` is a no-op
+    /// counter so tests can assert how many times refresh was triggered without forcing a
+    /// real reconstruction re-query.
+    struct StaticURLProvider {
+        url: String,
+        ranges: Vec<HttpRange>,
+        refresh_count: AtomicUsize,
+    }
+
+    impl StaticURLProvider {
+        fn new(url: String, ranges: Vec<HttpRange>) -> Self {
+            Self {
+                url,
+                ranges,
+                refresh_count: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl URLProvider for StaticURLProvider {
+        async fn retrieve_url(&self) -> Result<(String, Vec<HttpRange>)> {
+            Ok((self.url.clone(), self.ranges.clone()))
+        }
+
+        async fn refresh_url(&self) -> Result<()> {
+            self.refresh_count.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+    }
+
+    /// Build a single uncompressed chunk in xorb chunk format (header + body). Each "subrange"
+    /// in the multi-range fetch is independently parseable by `deserialize_chunks`.
+    fn build_one_chunk(payload: &[u8]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        serialize_chunk(payload, &mut buf, CompressionScheme::None).expect("serialize_chunk");
+        buf
+    }
+
+    fn test_remote_client() -> Arc<RemoteClient> {
+        // Tight retry budget to keep the failure-path tests fast.
+        let config = XetConfig::new()
+            .with_config("client.retry_max_attempts", "2")
+            .unwrap()
+            .with_config("client.retry_base_delay", "5ms")
+            .unwrap();
+        let ctx = XetContext::from_external(tokio::runtime::Handle::current(), config);
+        // The CAS endpoint isn't exercised in get_file_term_data tests (we call the storage GET
+        // path directly via a URLProvider pointing at the mock server).
+        RemoteClient::new(ctx, "http://unused", &None, "test-session", false, None)
+    }
+
+    #[tokio::test]
+    async fn test_get_file_term_data_multi_range_happy_path() {
+        let server = MockServer::start().await;
+
+        let chunk_a = b"chunk-a-payload-bytes!".to_vec();
+        let chunk_b = b"chunk-b-payload-bytes!!!".to_vec();
+        let serialized_a = build_one_chunk(&chunk_a);
+        let serialized_b = build_one_chunk(&chunk_b);
+
+        // The mock storage object is the two serialized chunks concatenated. The multi-range
+        // GET asks for [0..serialized_a.len()-1] and [serialized_a.len()..total-1].
+        let len_a = serialized_a.len();
+        let object = [serialized_a.as_slice(), serialized_b.as_slice()].concat();
+        let total = object.len();
+
+        // wiremock's `header()` matcher splits the actual header value on commas, so a
+        // multi-range header `bytes=0-29,30-61` is matched as two parts: `bytes=0-29` and
+        // `30-61`. Use the `headers()` (multi-value) matcher to match accordingly.
+        let multi_range_parts = vec![format!("bytes=0-{}", len_a - 1), format!("{}-{}", len_a, total - 1)];
+
+        // Build a multipart/byteranges response so the multi-range parser path is exercised.
+        let boundary = "TESTBOUNDARY";
+        let mut body = Vec::new();
+        for (start, end, slice) in [
+            (0u64, (len_a - 1) as u64, &object[..len_a]),
+            (len_a as u64, (total - 1) as u64, &object[len_a..]),
+        ] {
+            body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+            body.extend_from_slice(b"Content-Type: application/octet-stream\r\n");
+            body.extend_from_slice(format!("Content-Range: bytes {start}-{end}/{total}\r\n\r\n").as_bytes());
+            body.extend_from_slice(slice);
+            body.extend_from_slice(b"\r\n");
+        }
+        body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
+
+        Mock::given(method("GET"))
+            .and(path_regex(r"^/storage/xorb$"))
+            .and(headers("range", multi_range_parts))
+            .respond_with(
+                ResponseTemplate::new(206)
+                    .insert_header("content-type", format!("multipart/byteranges; boundary={boundary}"))
+                    .set_body_bytes(body),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let url = format!("{}/storage/xorb", server.uri());
+        let provider: Box<dyn URLProvider> = Box::new(StaticURLProvider::new(
+            url,
+            vec![
+                HttpRange::new(0, (len_a - 1) as u64),
+                HttpRange::new(len_a as u64, (total - 1) as u64),
+            ],
+        ));
+
+        let client = test_remote_client();
+        let permit = client.acquire_download_permit().await.unwrap();
+        let (bytes, _indices) = client.get_file_term_data(provider, permit, None, None).await.unwrap();
+
+        // Concatenated uncompressed chunk bodies.
+        let expected: Vec<u8> = [chunk_a.as_slice(), chunk_b.as_slice()].concat();
+        assert_eq!(bytes.as_ref(), expected.as_slice(), "happy-path bytes should match");
+    }
+
+    #[tokio::test]
+    async fn test_get_file_term_data_multi_range_403_falls_back_to_single_range() {
+        let server = MockServer::start().await;
+
+        let chunk_a = b"first-range-bytes".to_vec();
+        let chunk_b = b"second-range-bytes!!".to_vec();
+        let serialized_a = build_one_chunk(&chunk_a);
+        let serialized_b = build_one_chunk(&chunk_b);
+
+        let len_a = serialized_a.len();
+        let len_b = serialized_b.len();
+        let total = len_a + len_b;
+
+        let multi_range_parts = vec![format!("bytes=0-{}", len_a - 1), format!("{}-{}", len_a, total - 1)];
+        let single_range_header_a = format!("bytes=0-{}", len_a - 1);
+        let single_range_header_b = format!("bytes={}-{}", len_a, total - 1);
+
+        // The multi-range request always 403s — modeling the CloudFront-edge behavior.
+        Mock::given(method("GET"))
+            .and(path_regex(r"^/storage/xorb$"))
+            .and(headers("range", multi_range_parts))
+            .respond_with(ResponseTemplate::new(403).set_body_string("Invalid Range Specified"))
+            // 2 retry_max_attempts => up to 3 attempts on the multi-range path.
+            .expect(1..=3)
+            .mount(&server)
+            .await;
+
+        // Each single-range subrange GET returns its slice as a plain 206.
+        Mock::given(method("GET"))
+            .and(path_regex(r"^/storage/xorb$"))
+            .and(header("range", single_range_header_a.as_str()))
+            .respond_with(ResponseTemplate::new(206).set_body_bytes(serialized_a.clone()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path_regex(r"^/storage/xorb$"))
+            .and(header("range", single_range_header_b.as_str()))
+            .respond_with(ResponseTemplate::new(206).set_body_bytes(serialized_b.clone()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let url = format!("{}/storage/xorb", server.uri());
+        let provider: Box<dyn URLProvider> = Box::new(StaticURLProvider::new(
+            url,
+            vec![
+                HttpRange::new(0, (len_a - 1) as u64),
+                HttpRange::new(len_a as u64, (total - 1) as u64),
+            ],
+        ));
+
+        let client = test_remote_client();
+        let permit = client.acquire_download_permit().await.unwrap();
+        let (bytes, _indices) = client.get_file_term_data(provider, permit, None, None).await.unwrap();
+
+        let expected: Vec<u8> = [chunk_a.as_slice(), chunk_b.as_slice()].concat();
+        assert_eq!(bytes.as_ref(), expected.as_slice(), "fallback should concatenate single-range results in order");
+    }
+
+    #[tokio::test]
+    async fn test_get_file_term_data_single_range_fallback_errors_propagate() {
+        let server = MockServer::start().await;
+
+        // Use tiny payloads — they don't have to decode successfully, since the test exits with
+        // a 403 before reaching the parser.
+        let len_a: usize = 16;
+        let len_b: usize = 32;
+        let total = len_a + len_b;
+
+        let multi_range_parts = vec![format!("bytes=0-{}", len_a - 1), format!("{}-{}", len_a, total - 1)];
+
+        // The multi-range request 403s.
+        Mock::given(method("GET"))
+            .and(path_regex(r"^/storage/xorb$"))
+            .and(headers("range", multi_range_parts))
+            .respond_with(ResponseTemplate::new(403))
+            .mount(&server)
+            .await;
+
+        // Every single-range request also 403s — fallback should propagate, not recurse.
+        Mock::given(method("GET"))
+            .and(path_regex(r"^/storage/xorb$"))
+            .respond_with(ResponseTemplate::new(403))
+            .mount(&server)
+            .await;
+
+        let url = format!("{}/storage/xorb", server.uri());
+        let provider: Box<dyn URLProvider> = Box::new(StaticURLProvider::new(
+            url,
+            vec![
+                HttpRange::new(0, (len_a - 1) as u64),
+                HttpRange::new(len_a as u64, (total - 1) as u64),
+            ],
+        ));
+
+        let client = test_remote_client();
+        let permit = client.acquire_download_permit().await.unwrap();
+        let result = client.get_file_term_data(provider, permit, None, None).await;
+
+        assert!(result.is_err(), "expected error when all paths 403, got Ok");
+        let err = result.unwrap_err();
+        assert_eq!(err.status(), Some(StatusCode::FORBIDDEN), "error should preserve 403 status: {err:?}");
+
+        // Sanity: the server received a bounded number of requests overall — no infinite loop.
+        let recv_count = server.received_requests().await.unwrap().len();
+        assert!(recv_count < 20, "too many requests, possible loop: {recv_count}");
     }
 }

--- a/xet_client/src/cas_client/remote_client.rs
+++ b/xet_client/src/cas_client/remote_client.rs
@@ -16,7 +16,7 @@ use xet_runtime::core::XetContext;
 
 use super::adaptive_concurrency::{AdaptiveConcurrencyController, ConnectionPermit};
 use super::auth::AuthConfig;
-use super::interface::URLProvider;
+use super::interface::{URLProvider, split_into_single_range_providers};
 use super::progress_tracked_streams::{
     DownloadProgressStream, ProgressCallback, StreamProgressReporter, UploadProgressStream,
 };
@@ -304,70 +304,21 @@ impl RemoteClient {
             other => Err(ClientError::InternalError(anyhow!("unsupported reconstruction API version: {other}"))),
         }
     }
-}
 
-#[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
-#[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
-impl Client for RemoteClient {
-    async fn get_reconstruction(
+    /// Issue a (possibly multi-range) GET against `url_info`, parse the response into
+    /// decompressed bytes + chunk byte indices, retrying on transient errors.
+    ///
+    /// This is the per-xorb fetch primitive used both by the default multi-range path and
+    /// by the multi-range 403 fallback (which calls this once per subrange).
+    async fn fetch_xorb_via_provider(
         &self,
-        file_id: &MerkleHash,
-        bytes_range: Option<FileRange>,
-    ) -> Result<Option<QueryReconstructionResponseV2>> {
-        let forced_version = self.ctx.config.client.reconstruction_api_version;
-        self.get_reconstruction_with_version_override(file_id, bytes_range, forced_version)
-            .await
-    }
-
-    async fn batch_get_reconstruction(&self, file_ids: &[MerkleHash]) -> Result<BatchQueryReconstructionResponse> {
-        let mut url_str = format!("{}/reconstructions?", self.endpoint);
-        let mut is_first = true;
-        let mut file_id_list = Vec::new();
-        for hash in file_ids {
-            file_id_list.push(hash.hex());
-            if is_first {
-                is_first = false;
-            } else {
-                url_str.push('&');
-            }
-            url_str.push_str("file_id=");
-            url_str.push_str(hash.hex().as_str());
-        }
-        let url: Url = url_str.parse()?;
-
-        let call_id = FN_CALL_ID.fetch_add(1, Ordering::Relaxed);
-        info!(call_id, file_ids=?file_id_list, "Starting batch_get_reconstruction API call");
-
-        let api_tag = "cas::batch_get_reconstruction";
-        let client = self.authenticated_http_client.clone();
-
-        let response: BatchQueryReconstructionResponse = RetryWrapper::new(self.ctx.clone(), api_tag)
-            .run_and_extract_json(move || client.get(url.clone()).with_extension(Api(api_tag)).send())
-            .await?;
-
-        info!(call_id,
-            file_ids=?file_id_list,
-            response_count=response.files.len(),
-            "Completed batch_get_reconstruction API call",
-        );
-
-        Ok(response)
-    }
-
-    async fn acquire_download_permit(&self) -> Result<ConnectionPermit> {
-        self.download_concurrency_controller.acquire_connection_permit().await
-    }
-
-    async fn get_file_term_data(
-        &self,
-        url_info: Box<dyn URLProvider>,
+        url_info: Arc<Box<dyn URLProvider>>,
         download_permit: ConnectionPermit,
         progress_callback: Option<ProgressCallback>,
         uncompressed_size_if_known: Option<usize>,
     ) -> Result<(Bytes, Vec<u32>)> {
         let api_tag = "s3::get_range";
         let http_client = self.http_client.clone();
-        let url_info = Arc::new(url_info);
 
         let (_, url_ranges) = url_info.retrieve_url().await?;
         let total_download_bytes: u64 = url_ranges.iter().map(|r| r.length()).sum();
@@ -378,7 +329,7 @@ impl Client for RemoteClient {
             transfer_reporter = transfer_reporter.with_progress_callback(cb);
         }
 
-        let result = RetryWrapper::new(self.ctx.clone(), api_tag)
+        RetryWrapper::new(self.ctx.clone(), api_tag)
             .with_retry_on_403()
             .with_connection_permit(download_permit, None)
             .run_and_extract_custom(
@@ -510,9 +461,162 @@ impl Client for RemoteClient {
                     }
                 },
             )
+            .await
+    }
+
+    /// Multi-range 403 fallback: split the multi-range provider into N single-range providers
+    /// and fetch each as an independent single-range GET. Concatenate the decompressed bytes
+    /// in range order to produce the same result the original multi-range fetch would have.
+    ///
+    /// Each subrange fetch goes through the standard single-range retry path. If any subrange
+    /// fetch ultimately fails (including 403 after retries), the error is propagated rather
+    /// than recursively re-attempted — there is no further client-side fallback.
+    async fn fetch_xorb_via_single_range_fallback(
+        &self,
+        url_info: Arc<Box<dyn URLProvider>>,
+        progress_callback: Option<ProgressCallback>,
+        uncompressed_size_if_known: Option<usize>,
+    ) -> Result<(Bytes, Vec<u32>)> {
+        let single_range_providers = split_into_single_range_providers(url_info).await?;
+        if single_range_providers.is_empty() {
+            return Err(ClientError::Other(
+                "multi-range 403 fallback: URLProvider returned no ranges to split".to_string(),
+            ));
+        }
+
+        let mut all_decompressed = Vec::with_capacity(uncompressed_size_if_known.unwrap_or(0));
+        let mut all_chunk_indices = Vec::<u32>::new();
+
+        for (idx, provider) in single_range_providers.into_iter().enumerate() {
+            // Each subrange fetch gets its own permit so that the adaptive concurrency
+            // controller observes each as an independent successful/failed transfer.
+            let permit = self.acquire_download_permit_internal().await?;
+            let provider_arc: Arc<Box<dyn URLProvider>> = Arc::new(provider);
+
+            // Pass through the original progress callback; it observes only `delta` so it is
+            // safe to share across the N subrange fetches.
+            let (data, chunk_indices) = self
+                .fetch_xorb_via_provider(provider_arc, permit, progress_callback.clone(), None)
+                .await
+                .map_err(|e| {
+                    info!("multi-range 403 fallback: subrange {idx} fetch failed: {e}");
+                    e
+                })?;
+
+            xet_core_structures::xorb_object::append_chunk_segment(
+                &mut all_decompressed,
+                &mut all_chunk_indices,
+                &data,
+                &chunk_indices,
+            );
+        }
+
+        if let Some(expected) = uncompressed_size_if_known
+            && expected != all_decompressed.len()
+        {
+            return Err(ClientError::Other(format!(
+                "get_file_term_data: expected {expected} uncompressed bytes after single-range fallback, got {}",
+                all_decompressed.len()
+            )));
+        }
+
+        Ok((Bytes::from(all_decompressed), all_chunk_indices))
+    }
+
+    async fn acquire_download_permit_internal(&self) -> Result<ConnectionPermit> {
+        self.download_concurrency_controller.acquire_connection_permit().await
+    }
+}
+
+#[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
+impl Client for RemoteClient {
+    async fn get_reconstruction(
+        &self,
+        file_id: &MerkleHash,
+        bytes_range: Option<FileRange>,
+    ) -> Result<Option<QueryReconstructionResponseV2>> {
+        let forced_version = self.ctx.config.client.reconstruction_api_version;
+        self.get_reconstruction_with_version_override(file_id, bytes_range, forced_version)
+            .await
+    }
+
+    async fn batch_get_reconstruction(&self, file_ids: &[MerkleHash]) -> Result<BatchQueryReconstructionResponse> {
+        let mut url_str = format!("{}/reconstructions?", self.endpoint);
+        let mut is_first = true;
+        let mut file_id_list = Vec::new();
+        for hash in file_ids {
+            file_id_list.push(hash.hex());
+            if is_first {
+                is_first = false;
+            } else {
+                url_str.push('&');
+            }
+            url_str.push_str("file_id=");
+            url_str.push_str(hash.hex().as_str());
+        }
+        let url: Url = url_str.parse()?;
+
+        let call_id = FN_CALL_ID.fetch_add(1, Ordering::Relaxed);
+        info!(call_id, file_ids=?file_id_list, "Starting batch_get_reconstruction API call");
+
+        let api_tag = "cas::batch_get_reconstruction";
+        let client = self.authenticated_http_client.clone();
+
+        let response: BatchQueryReconstructionResponse = RetryWrapper::new(self.ctx.clone(), api_tag)
+            .run_and_extract_json(move || client.get(url.clone()).with_extension(Api(api_tag)).send())
             .await?;
 
-        Ok(result)
+        info!(call_id,
+            file_ids=?file_id_list,
+            response_count=response.files.len(),
+            "Completed batch_get_reconstruction API call",
+        );
+
+        Ok(response)
+    }
+
+    async fn acquire_download_permit(&self) -> Result<ConnectionPermit> {
+        self.download_concurrency_controller.acquire_connection_permit().await
+    }
+
+    async fn get_file_term_data(
+        &self,
+        url_info: Box<dyn URLProvider>,
+        download_permit: ConnectionPermit,
+        progress_callback: Option<ProgressCallback>,
+        uncompressed_size_if_known: Option<usize>,
+    ) -> Result<(Bytes, Vec<u32>)> {
+        let url_info = Arc::new(url_info);
+
+        let (_, url_ranges) = url_info.retrieve_url().await?;
+        let is_multi_range = url_ranges.len() > 1;
+
+        // Try the multi-range fetch first. This is the fast path that minimizes the number
+        // of storage requests; if the URL is single-range to begin with, this is the only
+        // path we take.
+        match self
+            .fetch_xorb_via_provider(
+                url_info.clone(),
+                download_permit,
+                progress_callback.clone(),
+                uncompressed_size_if_known,
+            )
+            .await
+        {
+            Ok(result) => Ok(result),
+            Err(e) if is_multi_range && e.status() == Some(StatusCode::FORBIDDEN) => {
+                // Some storage backends (CloudFront edges in particular) reject multi-range
+                // Range headers with 403 before the request reaches the origin. After the
+                // multi-range retry budget (`with_retry_on_403`) is exhausted, fall back to
+                // fetching each subrange as an independent single-range GET against the
+                // same xorb. This travels the existing V1 single-range code path.
+                info!("Multi-range GET 403'd after retries; falling back to {} single-range fetches", url_ranges.len());
+                self.fetch_xorb_via_single_range_fallback(url_info, progress_callback, uncompressed_size_if_known)
+                    .await
+            },
+            Err(e) => Err(e),
+        }
     }
 
     #[instrument(skip_all, name = "RemoteClient::get_file_reconstruction", fields(file.hash = file_hash.hex()


### PR DESCRIPTION
## Context

V2 reconstruction (`QueryReconstructionResponseV2`) packs multiple byte ranges per xorb into a single signed URL (`XorbMultiRangeFetch.ranges` may have `len > 1`). One storage backend rejects multi-range Range headers at the edge with `403 Invalid Range Specified` before the request reaches the origin. Today's retry path on 403 (`xet_client/src/cas_client/remote_client.rs`) refreshes the URL via `URLProvider::refresh_url` and retries with the same multi-range shape, so retries are doomed against that backend. This PR adds client-side resilience that is independent of any server-side fix.

## What changed

- `xet_client/src/cas_client/interface.rs`: new `SingleRangeURLProvider` wrapping a multi-range `URLProvider` plus a range index, exposing exactly one of the inner ranges as a single-range fetch. `refresh_url` is delegated to the inner provider so signature-refresh semantics are unchanged. A `split_into_single_range_providers` helper fans a multi-range provider out into N single-range providers. The `URLProvider` trait itself is unchanged — this is purely additive.
- `xet_client/src/cas_client/remote_client.rs`: `RemoteClient::get_file_term_data` is split into a per-provider `fetch_xorb_via_provider` helper and the public entry point. When the multi-range fetch returns a `ClientError` with status `403 Forbidden` after the `with_retry_on_403` retry budget is exhausted and `url_ranges.len() > 1`, the entry point fans the request out into N independent single-range GETs (each with its own retry budget and download permit), concatenating the decompressed bytes + chunk indices via `append_chunk_segment` in the same order the multi-range fetch would have produced.

## Behavior

- Single-range URLs and successful multi-range URLs are untouched (no extra requests on healthy paths).
- The fallback only triggers after the multi-range retry budget is exhausted with a 403; it never triggers on transient errors, timeouts, or any non-403 failure.
- Scope of the fallback is per failing `XorbMultiRangeFetch`, not the whole file.
- Tradeoff: a failing xorb now costs N storage requests instead of 1. This is acceptable since (a) the alternative is failing the download, and (b) the trigger condition is narrow.

## Test plan

Added three unit tests in `xet_client/src/cas_client/remote_client.rs` against a wiremock storage backend:
- `test_get_file_term_data_multi_range_happy_path`: multi-range 206 multipart/byteranges succeeds first try; verifies no fallback is invoked and bytes round-trip.
- `test_get_file_term_data_multi_range_403_falls_back_to_single_range`: multi-range URL always 403s; each subrange GET succeeds; verifies the fallback produces the correctly-concatenated bytes.
- `test_get_file_term_data_single_range_fallback_errors_propagate`: every GET 403s; verifies the error propagates with 403 status, the request count is bounded (no infinite loop).

Local verification:
- `cargo +nightly fmt --all -- --check`
- `cargo clippy -r -p xet-client -- -D warnings` (release CI invocation)
- `cargo test -p xet-client --features simulation`
- `cargo test -p xet-data`
- `cargo +nightly check --target wasm32-unknown-unknown` for both `wasm/hf_xet_thin_wasm` and `wasm/hf_xet_wasm`