### PR TITLE
ci: declare empty permissions on hf-xet prerelease testing workflow

### DIFF
--- a/.github/workflows/pre-release-testing.yml
+++ b/.github/workflows/pre-release-testing.yml
@@ -10,6 +10,9 @@ on:
       tag:
         description: "Tag to test (e.g., v1.0.3-rc2)"
         required: true
+
+permissions: {}
+
 jobs:
   trigger_rc_testing:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `hf-xet prerelease testing` workflow currently doesn't declare a `permissions:` block, so the workflow `GITHUB_TOKEN` falls back to the repository default. Every step in `trigger_rc_testing` authenticates via `TOKEN_HUGGINGFACE_HUB_AUTO_BY_XET` (a PAT scoped for the hf-hub auto-update flow):

- the `actions/checkout` step pulls `huggingface/${{ matrix.target-repo }}` with `token: ${{ secrets.TOKEN_HUGGINGFACE_HUB_AUTO_BY_XET }}`
- `git push` reuses the credentials persisted by checkout

So the workflow's own `GITHUB_TOKEN` is unused. `permissions: {}` (workflow scope) pins that.

Pattern matches the workflow-level permissions blocks already used in this repo. With it set:

- the workflow token can't be widened by a future change to the repo default
- the SLSA / OpenSSF Scorecard `Token-Permissions` check passes for this file
- a hypothetical compromise of any third-party action reachable from this workflow (cf. `tj-actions/changed-files` CVE-2025-30066) has nothing to do with the workflow token

`ci.yml` is deliberately out of scope. It uses the local `./.github/actions/cache-rust-build` composite + sccache, and tightening permissions there needs to account for the cache write path. Worth a separate look.

No behavioural change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that just restricts default `GITHUB_TOKEN` permissions and should not affect workflow behavior unless a step implicitly relied on those permissions.
> 
> **Overview**
> This pins the `hf-xet prerelease testing` workflow’s `GITHUB_TOKEN` to **no permissions** by adding `permissions: {}` at the workflow level, preventing future repo-default permission widening and satisfying token-permissions checks.
> 
> No functional workflow logic changes are introduced; it only tightens the default authentication surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2a0d3d41271d6648a5e43fb1a9150e562acf2fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->