### PR TITLE
feat: expose FileUploadSession low-level functions

### DIFF
--- a/xet_data/src/processing/file_upload_session.rs
+++ b/xet_data/src/processing/file_upload_session.rs
@@ -13,6 +13,8 @@ use tokio::sync::Mutex;
 use tokio::task::{JoinHandle, JoinSet};
 use tracing::{Instrument, Span, info_span, instrument};
 use xet_client::cas_client::{Client, ProgressCallback};
+use xet_client::cas_types::{FileChunkHashesResponse, FileRange};
+use xet_core_structures::merklehash::MerkleHash;
 use xet_core_structures::metadata_shard::file_structs::MDBFileInfo;
 use xet_core_structures::xorb_object::SerializedXorbObject;
 use xet_runtime::core::XetContext;
@@ -611,8 +613,23 @@ impl FileUploadSession {
     /// Register a pre-composed file reconstruction plan (MDBFileInfo) with this session.
     /// Used for append-aware writes where the caller builds the reconstruction plan
     /// from existing segments + newly uploaded segments.
-    pub(crate) async fn register_composed_file(self: &Arc<Self>, file_info: MDBFileInfo) -> Result<()> {
+    pub async fn register_composed_file(self: &Arc<Self>, file_info: MDBFileInfo) -> Result<()> {
         self.shard_interface.add_file_reconstruction_info(file_info).await
+    }
+
+    pub async fn get_file_chunk_hashes(
+        &self,
+        file_id: &MerkleHash,
+        dirty_ranges: Vec<FileRange>,
+    ) -> Result<FileChunkHashesResponse> {
+        Ok(self.client.get_file_chunk_hashes(file_id, dirty_ranges).await?)
+    }
+
+    pub async fn get_file_reconstruction_info(
+        &self,
+        file_hash: &MerkleHash,
+    ) -> Result<Option<(MDBFileInfo, Option<MerkleHash>)>> {
+        Ok(self.client.get_file_reconstruction_info(file_hash).await?)
     }
 
     fn check_not_finalized(&self) -> Result<()> {

--- a/xet_data/src/processing/file_upload_session.rs
+++ b/xet_data/src/processing/file_upload_session.rs
@@ -614,6 +614,7 @@ impl FileUploadSession {
     /// Used for append-aware writes where the caller builds the reconstruction plan
     /// from existing segments + newly uploaded segments.
     pub async fn register_composed_file(self: &Arc<Self>, file_info: MDBFileInfo) -> Result<()> {
+        self.check_not_finalized()?;
         self.shard_interface.add_file_reconstruction_info(file_info).await
     }
 
@@ -622,6 +623,11 @@ impl FileUploadSession {
         file_id: &MerkleHash,
         dirty_ranges: Vec<FileRange>,
     ) -> Result<FileChunkHashesResponse> {
+        if dirty_ranges.is_empty() {
+            return Err(DataError::InvalidOperation(
+                "get_file_chunk_hashes requires at least one dirty range".to_string(),
+            ));
+        }
         Ok(self.client.get_file_chunk_hashes(file_id, dirty_ranges).await?)
     }
 

--- a/xet_data/src/processing/file_upload_session.rs
+++ b/xet_data/src/processing/file_upload_session.rs
@@ -623,8 +623,8 @@ impl FileUploadSession {
         Ok(())
     }
 
-    pub fn client(&self) -> &Arc<dyn Client + Send + Sync> {
-        &self.client
+    pub fn client(&self) -> Arc<dyn Client + Send + Sync> {
+        Arc::clone(&self.client)
     }
 
     pub fn progress(&self) -> &Arc<GroupProgress> {

--- a/xet_data/src/processing/file_upload_session.rs
+++ b/xet_data/src/processing/file_upload_session.rs
@@ -13,8 +13,6 @@ use tokio::sync::Mutex;
 use tokio::task::{JoinHandle, JoinSet};
 use tracing::{Instrument, Span, info_span, instrument};
 use xet_client::cas_client::{Client, ProgressCallback};
-use xet_client::cas_types::{FileChunkHashesResponse, FileRange};
-use xet_core_structures::merklehash::MerkleHash;
 use xet_core_structures::metadata_shard::file_structs::MDBFileInfo;
 use xet_core_structures::xorb_object::SerializedXorbObject;
 use xet_runtime::core::XetContext;
@@ -618,31 +616,15 @@ impl FileUploadSession {
         self.shard_interface.add_file_reconstruction_info(file_info).await
     }
 
-    pub async fn get_file_chunk_hashes(
-        &self,
-        file_id: &MerkleHash,
-        dirty_ranges: Vec<FileRange>,
-    ) -> Result<FileChunkHashesResponse> {
-        if dirty_ranges.is_empty() {
-            return Err(DataError::InvalidOperation(
-                "get_file_chunk_hashes requires at least one dirty range".to_string(),
-            ));
-        }
-        Ok(self.client.get_file_chunk_hashes(file_id, dirty_ranges).await?)
-    }
-
-    pub async fn get_file_reconstruction_info(
-        &self,
-        file_hash: &MerkleHash,
-    ) -> Result<Option<(MDBFileInfo, Option<MerkleHash>)>> {
-        Ok(self.client.get_file_reconstruction_info(file_hash).await?)
-    }
-
     fn check_not_finalized(&self) -> Result<()> {
         if self.finalized.load(Ordering::Acquire) {
             return Err(DataError::InvalidOperation("FileUploadSession already finalized".to_string()));
         }
         Ok(())
+    }
+
+    pub fn client(&self) -> &Arc<dyn Client + Send + Sync> {
+        &self.client
     }
 
     pub fn progress(&self) -> &Arc<GroupProgress> {


### PR DESCRIPTION
A few functions on the FileUploadSession are useful for clients building composite files that aren't natively supported yet in xet-core. For example, when concatenating multiple existing xet files into a single one, having the ability to pull chunk/reconstruction info to build the composite file's reconstruction info and then register that with the session are needed. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small visibility and guard changes on upload-session helpers; no auth or data-path redesign.
> 
> **Overview**
> Makes **`FileUploadSession`** usable for advanced composite uploads by exposing a few session APIs that were previously crate-private.
> 
> **`register_composed_file`** is now **public** and rejects calls after **`finalize()`** via **`check_not_finalized()`**, matching other mutating entry points. A new **`client()`** accessor returns a clone of the session’s CAS **`Client`**, so callers can fetch chunk/reconstruction data while building an **`MDBFileInfo`** plan before registering it on the session.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d264d3c0888c32b65acae84fe991016d93d90632. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->