### PR TITLE
hf-xet BackgroundProgress poller with condvar shutdown and final callback

### DIFF
--- a/hf_xet/src/background_progress.rs
+++ b/hf_xet/src/background_progress.rs
@@ -1,0 +1,168 @@
+//! Background progress callbacks for upload commits and download groups.
+//!
+//! A dedicated thread polls Rust-side progress atomics and invokes a Python
+//! callable via [`Python::try_attach`].  The poller sleeps on a condvar so
+//! [`BackgroundProgress::stop_and_join`] can wake it immediately instead of
+//! waiting for the full poll interval.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
+use xet_pkg::xet_session::{GroupProgressReport, ItemProgressReport, UniqueId};
+
+fn lock_poisoned_err() -> PyErr {
+    PyRuntimeError::new_err("progress poller lock poisoned")
+}
+
+fn poller_panicked_err() -> PyErr {
+    PyRuntimeError::new_err("progress poller thread panicked")
+}
+
+/// Background thread that polls progress and invokes a Python callback.
+pub(crate) struct BackgroundProgress {
+    /// ``false`` while the poller is running; set to ``true`` in ``stop_and_join``.
+    /// Paired with the condvar so setting shutdown wakes a thread blocked in
+    /// ``wait_timeout`` (the mutex is released for the duration of the wait).
+    wake: Arc<(Mutex<bool>, Condvar)>,
+    join: Mutex<Option<JoinHandle<PyResult<()>>>>,
+    callback: Py<PyAny>,
+}
+
+impl BackgroundProgress {
+    /// Spawn a thread that calls ``snapshot`` every ``interval_ms`` until shutdown,
+    /// the snapshot reports a terminal task state, or the callback fails.
+    pub(crate) fn spawn<F>(py: Python<'_>, callback: Py<PyAny>, interval_ms: u64, mut snapshot: F) -> Self
+    where
+        F: FnMut() -> (GroupProgressReport, HashMap<UniqueId, ItemProgressReport>, bool) + Send + 'static,
+    {
+        let wake = Arc::new((Mutex::new(false), Condvar::new()));
+        let wake_for_thread = Arc::clone(&wake);
+        let callback_for_thread = callback.clone_ref(py);
+        let interval = Duration::from_millis(interval_ms);
+
+        let join = std::thread::spawn(move || {
+            progress_thread_loop(callback_for_thread, interval, &wake_for_thread, &mut snapshot)
+        });
+
+        Self {
+            wake,
+            join: Mutex::new(Some(join)),
+            callback,
+        }
+    }
+
+    /// Request shutdown, wake the poller if it is sleeping, and block until the thread exits.
+    pub(crate) fn stop_and_join(&self) -> PyResult<()> {
+        {
+            let mut guard = self.wake.0.lock().map_err(|_| lock_poisoned_err())?;
+            *guard = true;
+        }
+        self.wake.1.notify_one();
+        let handle = self.join.lock().map_err(|_| lock_poisoned_err())?.take();
+        if let Some(handle) = handle {
+            match handle.join() {
+                Ok(result) => result,
+                Err(_) => Err(poller_panicked_err()),
+            }
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Stop the poller, then invoke the callback once on the calling thread (final snapshot).
+    pub(crate) fn stop_and_emit<F>(&self, py: Python<'_>, snapshot: F) -> PyResult<()>
+    where
+        F: FnOnce() -> (GroupProgressReport, HashMap<UniqueId, ItemProgressReport>),
+    {
+        self.stop_and_join()?;
+        let (group_report, item_reports) = snapshot();
+        self.callback.call1(py, (group_report, item_reports))?;
+        Ok(())
+    }
+}
+
+fn progress_thread_loop<F>(
+    callback: Py<PyAny>,
+    interval: Duration,
+    wake: &Arc<(Mutex<bool>, Condvar)>,
+    snapshot: &mut F,
+) -> PyResult<()>
+where
+    F: FnMut() -> (GroupProgressReport, HashMap<UniqueId, ItemProgressReport>, bool),
+{
+    loop {
+        // Sleep up to `interval`, but return promptly when stop_and_join sets shutdown and notifies.
+        let shutdown = {
+            let guard = wake.0.lock().map_err(|_| lock_poisoned_err())?;
+            let (guard, _) = wake.1.wait_timeout(guard, interval).map_err(|_| lock_poisoned_err())?;
+            *guard
+        };
+
+        if shutdown {
+            break;
+        }
+
+        // Mutex is not held across snapshot or the Python callback.
+        let (group_report, item_reports, is_terminal) = snapshot();
+
+        match Python::try_attach(|py| callback.call1(py, (group_report, item_reports))) {
+            None => break, // interpreter shutting down
+            Some(Ok(_)) => {},
+            Some(Err(e)) => {
+                let _ = Python::try_attach(|py| e.print(py));
+                break;
+            },
+        }
+
+        if is_terminal {
+            break;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::time::{Duration, Instant};
+
+    use pyo3::Python;
+    use pyo3::ffi::c_str;
+    use xet_pkg::xet_session::GroupProgressReport;
+
+    use super::*;
+
+    #[test]
+    fn stop_and_join_returns_before_poll_interval_elapses() {
+        /// Poll interval long enough that a blocking sleep would fail the test.
+        const LONG_INTERVAL_MS: u64 = 60_000;
+        const STOP_DEADLINE: Duration = Duration::from_secs(2);
+
+        Python::attach(|py| -> PyResult<()> {
+            py.run(c_str!("def _bg_progress_test_cb(_group, _items): pass"), None, None)?;
+            let callback: Py<PyAny> = py.eval(c_str!("_bg_progress_test_cb"), None, None)?.unbind();
+
+            let progress = BackgroundProgress::spawn(py, callback, LONG_INTERVAL_MS, || {
+                (GroupProgressReport::default(), HashMap::new(), false)
+            });
+
+            // Let the poller enter its timed wait on the condvar.
+            std::thread::sleep(Duration::from_millis(50));
+
+            let start = Instant::now();
+            progress.stop_and_join()?;
+            let elapsed = start.elapsed();
+
+            assert!(
+                elapsed < STOP_DEADLINE,
+                "stop_and_join took {elapsed:?}; expected prompt return (poll interval is {LONG_INTERVAL_MS}ms)"
+            );
+            Ok(())
+        })
+        .unwrap();
+    }
+}

--- a/hf_xet/src/background_progress.rs
+++ b/hf_xet/src/background_progress.rs
@@ -56,21 +56,25 @@ impl BackgroundProgress {
     }
 
     /// Request shutdown, wake the poller if it is sleeping, and block until the thread exits.
-    pub(crate) fn stop_and_join(&self) -> PyResult<()> {
+    pub(crate) fn stop_and_join(&self, py: Python<'_>) -> PyResult<()> {
         {
             let mut guard = self.wake.0.lock().map_err(|_| lock_poisoned_err())?;
             *guard = true;
         }
         self.wake.1.notify_one();
         let handle = self.join.lock().map_err(|_| lock_poisoned_err())?.take();
-        if let Some(handle) = handle {
-            match handle.join() {
-                Ok(result) => result,
-                Err(_) => Err(poller_panicked_err()),
+        // Releases the GIL while joining so the poller can acquire it inside
+        // [`Python::try_attach`] without deadlocking the caller.
+        py.detach(|| {
+            if let Some(handle) = handle {
+                match handle.join() {
+                    Ok(result) => result,
+                    Err(_) => Err(poller_panicked_err()),
+                }
+            } else {
+                Ok(())
             }
-        } else {
-            Ok(())
-        }
+        })
     }
 
     /// Stop the poller, then invoke the callback once on the calling thread (final snapshot).
@@ -78,7 +82,7 @@ impl BackgroundProgress {
     where
         F: FnOnce() -> (GroupProgressReport, HashMap<UniqueId, ItemProgressReport>),
     {
-        self.stop_and_join()?;
+        self.stop_and_join(py)?;
         let (group_report, item_reports) = snapshot();
         self.callback.call1(py, (group_report, item_reports))?;
         Ok(())
@@ -95,10 +99,13 @@ where
     F: FnMut() -> (GroupProgressReport, HashMap<UniqueId, ItemProgressReport>, bool),
 {
     loop {
-        // Sleep up to `interval`, but return promptly when stop_and_join sets shutdown and notifies.
+        // Sleep up to `interval`, but return promptly when shutdown is already set or notified.
         let shutdown = {
             let guard = wake.0.lock().map_err(|_| lock_poisoned_err())?;
-            let (guard, _) = wake.1.wait_timeout(guard, interval).map_err(|_| lock_poisoned_err())?;
+            let (guard, _) = wake
+                .1
+                .wait_timeout_while(guard, interval, |shutdown| !*shutdown)
+                .map_err(|_| lock_poisoned_err())?;
             *guard
         };
 
@@ -150,11 +157,8 @@ mod tests {
                 (GroupProgressReport::default(), HashMap::new(), false)
             });
 
-            // Let the poller enter its timed wait on the condvar.
-            std::thread::sleep(Duration::from_millis(50));
-
             let start = Instant::now();
-            progress.stop_and_join()?;
+            progress.stop_and_join(py)?;
             let elapsed = start.elapsed();
 
             assert!(

--- a/hf_xet/src/background_progress.rs
+++ b/hf_xet/src/background_progress.rs
@@ -84,7 +84,10 @@ impl BackgroundProgress {
     {
         self.stop_and_join(py)?;
         let (group_report, item_reports) = snapshot();
-        self.callback.call1(py, (group_report, item_reports))?;
+        match self.callback.call1(py, (group_report, item_reports)) {
+            Ok(_) => {},
+            Err(e) => e.print(py),
+        }
         Ok(())
     }
 }
@@ -200,7 +203,7 @@ mod tests {
     }
 
     #[test]
-    fn abort_path_does_not_invoke_callback() {
+    fn stop_and_join_does_not_invoke_callback() {
         // Long interval means the poller won't fire before we abort.
         // stop_and_join must not fire the callback itself.
         const LONG_INTERVAL_MS: u64 = 60_000;

--- a/hf_xet/src/background_progress.rs
+++ b/hf_xet/src/background_progress.rs
@@ -116,6 +116,10 @@ where
         // Mutex is not held across snapshot or the Python callback.
         let (group_report, item_reports, is_terminal) = snapshot();
 
+        if is_terminal {
+            break;
+        }
+
         match Python::try_attach(|py| callback.call1(py, (group_report, item_reports))) {
             None => break, // interpreter shutting down
             Some(Ok(_)) => {},
@@ -123,10 +127,6 @@ where
                 let _ = Python::try_attach(|py| e.print(py));
                 break;
             },
-        }
-
-        if is_terminal {
-            break;
         }
     }
     Ok(())
@@ -139,19 +139,29 @@ mod tests {
 
     use pyo3::Python;
     use pyo3::ffi::c_str;
+    use pyo3::types::PyDict;
     use xet_pkg::xet_session::GroupProgressReport;
 
     use super::*;
 
+    fn make_counter_callback<'py>(py: Python<'py>) -> PyResult<(Py<PyAny>, Bound<'py, PyDict>)> {
+        let ns = PyDict::new(py);
+        py.run(c_str!("calls = []\ndef cb(group, items): calls.append(1)"), Some(&ns), None)?;
+        let callback: Py<PyAny> = ns.get_item("cb")?.unwrap().unbind();
+        Ok((callback, ns))
+    }
+
+    fn call_count(py: Python<'_>, ns: &Bound<'_, PyDict>) -> PyResult<usize> {
+        py.eval(c_str!("len(calls)"), Some(ns), None)?.extract()
+    }
+
     #[test]
     fn stop_and_join_returns_before_poll_interval_elapses() {
-        /// Poll interval long enough that a blocking sleep would fail the test.
         const LONG_INTERVAL_MS: u64 = 60_000;
         const STOP_DEADLINE: Duration = Duration::from_secs(2);
 
         Python::attach(|py| -> PyResult<()> {
-            py.run(c_str!("def _bg_progress_test_cb(_group, _items): pass"), None, None)?;
-            let callback: Py<PyAny> = py.eval(c_str!("_bg_progress_test_cb"), None, None)?.unbind();
+            let (callback, _ns) = make_counter_callback(py)?;
 
             let progress = BackgroundProgress::spawn(py, callback, LONG_INTERVAL_MS, || {
                 (GroupProgressReport::default(), HashMap::new(), false)
@@ -165,6 +175,47 @@ mod tests {
                 elapsed < STOP_DEADLINE,
                 "stop_and_join took {elapsed:?}; expected prompt return (poll interval is {LONG_INTERVAL_MS}ms)"
             );
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn final_callback_fires_exactly_once_via_stop_and_emit() {
+        // Snapshot immediately signals terminal so the poller breaks without calling
+        // the callback.  stop_and_emit should then fire it exactly once.
+        Python::attach(|py| -> PyResult<()> {
+            let (callback, ns) = make_counter_callback(py)?;
+
+            let progress =
+                BackgroundProgress::spawn(py, callback, 1, || (GroupProgressReport::default(), HashMap::new(), true));
+
+            progress.stop_and_emit(py, || (GroupProgressReport::default(), HashMap::new()))?;
+
+            let n = call_count(py, &ns)?;
+            assert_eq!(n, 1, "expected exactly one final callback, got {n}");
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn abort_path_does_not_invoke_callback() {
+        // Long interval means the poller won't fire before we abort.
+        // stop_and_join must not fire the callback itself.
+        const LONG_INTERVAL_MS: u64 = 60_000;
+
+        Python::attach(|py| -> PyResult<()> {
+            let (callback, ns) = make_counter_callback(py)?;
+
+            let progress = BackgroundProgress::spawn(py, callback, LONG_INTERVAL_MS, || {
+                (GroupProgressReport::default(), HashMap::new(), false)
+            });
+
+            progress.stop_and_join(py)?;
+
+            let n = call_count(py, &ns)?;
+            assert_eq!(n, 0, "abort path must not invoke the callback, got {n}");
             Ok(())
         })
         .unwrap();

--- a/hf_xet/src/lib.rs
+++ b/hf_xet/src/lib.rs
@@ -1,3 +1,4 @@
+mod background_progress;
 pub mod config;
 mod headers;
 mod legacy;

--- a/hf_xet/src/py_file_download_group.rs
+++ b/hf_xet/src/py_file_download_group.rs
@@ -195,7 +195,7 @@ impl PyXetFileDownloadGroup {
         let result = blocking_call_with_signal_check(py, move || group.finish_blocking());
         if let (Some(handles), Some(progress)) = (&self.download_handles, &self.progress) {
             // ignore any error from progress update
-            let _ = if result.is_ok() {
+            let progress_join_ret = if result.is_ok() {
                 progress.stop_and_emit(py, || {
                     let item_reports = item_reports_from_download_handles(handles);
                     (self.inner.progress(), item_reports)
@@ -203,6 +203,9 @@ impl PyXetFileDownloadGroup {
             } else {
                 progress.stop_and_join(py)
             };
+            if let Err(e) = progress_join_ret {
+                tracing::warn!(id = self.inner.id().0, error = ?e, "PyXetFileDownloadGroup progress thread join failed");
+            }
         }
         result
     }

--- a/hf_xet/src/py_file_download_group.rs
+++ b/hf_xet/src/py_file_download_group.rs
@@ -143,7 +143,7 @@ impl PyXetFileDownloadGroup {
             // Normal exit: wait for all downloads (signal-interruptible).
             self.wait_to_finish(py)?;
         } else {
-            if let Err(e) = self.abort() {
+            if let Err(e) = self.abort(py) {
                 tracing::warn!("abort() failed during __exit__ exception path: {e}");
             }
         }
@@ -204,9 +204,10 @@ impl PyXetFileDownloadGroup {
     }
 
     /// Cancel all active downloads in this group.
-    pub fn abort(&self) -> PyResult<()> {
+    pub fn abort(&self, py: Python<'_>) -> PyResult<()> {
         if let Some(progress) = &self.progress {
-            progress.stop_and_join()?;
+            // ignore any error from progress update
+            let _ = progress.stop_and_join(py);
         }
         self.inner.abort().map_err(convert_xet_error)
     }
@@ -275,7 +276,7 @@ mod tests {
         };
 
         Python::attach(|py| {
-            group.abort().unwrap();
+            group.abort(py).unwrap();
             assert!(group.wait_to_finish(py).is_err());
         });
     }

--- a/hf_xet/src/py_file_download_group.rs
+++ b/hf_xet/src/py_file_download_group.rs
@@ -195,10 +195,14 @@ impl PyXetFileDownloadGroup {
         let result = blocking_call_with_signal_check(py, move || group.finish_blocking());
         if let (Some(handles), Some(progress)) = (&self.download_handles, &self.progress) {
             // ignore any error from progress update
-            let _ = progress.stop_and_emit(py, || {
-                let item_reports = item_reports_from_download_handles(handles);
-                (self.inner.progress(), item_reports)
-            });
+            let _ = if result.is_ok() {
+                progress.stop_and_emit(py, || {
+                    let item_reports = item_reports_from_download_handles(handles);
+                    (self.inner.progress(), item_reports)
+                })
+            } else {
+                progress.stop_and_join(py)
+            };
         }
         result
     }

--- a/hf_xet/src/py_file_download_group.rs
+++ b/hf_xet/src/py_file_download_group.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
-use std::time::Duration;
 
 use pyo3::prelude::*;
 use xet_pkg::xet_session::{
@@ -8,10 +7,21 @@ use xet_pkg::xet_session::{
     XetFileInfo, XetSession, XetTaskState,
 };
 
+use crate::background_progress::BackgroundProgress;
 use crate::headers::{build_header_map, build_headers_with_user_agent};
 use crate::py_file_download_handle::PyXetFileDownload;
 use crate::utils::{progress_display, task_state_display, task_state_to_pystate};
 use crate::{PyXetTaskState, blocking_call_with_signal_check, convert_xet_error};
+
+#[inline]
+fn item_reports_from_download_handles(
+    handles: &Arc<RwLock<Vec<XetFileDownload>>>,
+) -> HashMap<UniqueId, ItemProgressReport> {
+    handles
+        .read()
+        .map(|g| g.iter().filter_map(|h| h.progress().map(|p| (h.task_id(), p))).collect())
+        .unwrap_or_default()
+}
 
 // ── build_file_download_group ─────────────────────────────────────────────────
 
@@ -51,38 +61,24 @@ pub(crate) fn build_file_download_group(
             .map_err(convert_xet_error)
     })?;
 
-    let download_handles = if let Some(callback) = progress_callback {
+    let (download_handles, progress) = if let Some(callback) = progress_callback {
         let handles: Arc<RwLock<Vec<XetFileDownload>>> = Arc::new(RwLock::new(Vec::new()));
         let inner = group.clone();
         let handles_for_thread = Arc::clone(&handles);
-        let interval = Duration::from_millis(progress_interval_ms);
-        std::thread::spawn(move || {
-            loop {
-                std::thread::sleep(interval);
-                let is_terminal = !matches!(inner.status(), Ok(XetTaskState::Running) | Ok(XetTaskState::Finalizing));
-                let group_report = inner.progress();
-                let item_reports: HashMap<UniqueId, ItemProgressReport> = handles_for_thread
-                    .read()
-                    .map(|g| g.iter().filter_map(|h| h.progress().map(|p| (h.task_id(), p))).collect())
-                    .unwrap_or_default();
-                let result = Python::attach(|py| callback.call1(py, (group_report, item_reports)));
-                if let Err(e) = result {
-                    Python::attach(|py| e.print(py));
-                    break;
-                }
-                if is_terminal {
-                    break;
-                }
-            }
+        let progress = BackgroundProgress::spawn(py, callback, progress_interval_ms, move || {
+            let is_terminal = !matches!(inner.status(), Ok(XetTaskState::Running) | Ok(XetTaskState::Finalizing));
+            let item_reports = item_reports_from_download_handles(&handles_for_thread);
+            (inner.progress(), item_reports, is_terminal)
         });
-        Some(handles)
+        (Some(handles), Some(progress))
     } else {
-        None
+        (None, None)
     };
 
     Ok(PyXetFileDownloadGroup {
         inner: group,
         download_handles,
+        progress,
     })
 }
 
@@ -103,6 +99,9 @@ pub struct PyXetFileDownloadGroup {
     pub(crate) inner: XetFileDownloadGroup,
     /// Per-file handles shared with the progress thread; None when no callback was registered.
     download_handles: Option<Arc<RwLock<Vec<XetFileDownload>>>>,
+    /// Background thread that polls progress and invokes the Python callback; None when no
+    /// callback was registered. Stopped and joined from ``wait_to_finish`` and ``abort``.
+    progress: Option<BackgroundProgress>,
 }
 
 #[pymethods]
@@ -144,7 +143,7 @@ impl PyXetFileDownloadGroup {
             // Normal exit: wait for all downloads (signal-interruptible).
             self.wait_to_finish(py)?;
         } else {
-            if let Err(e) = self.inner.abort() {
+            if let Err(e) = self.abort() {
                 tracing::warn!("abort() failed during __exit__ exception path: {e}");
             }
         }
@@ -188,13 +187,27 @@ impl PyXetFileDownloadGroup {
     ///
     /// Releases the GIL while waiting, polling for ``KeyboardInterrupt`` every
     /// 100 ms so that Ctrl-C is delivered promptly.
+    ///
+    /// When a progress callback was registered, it is invoked once more on the
+    /// calling thread with the final snapshot after all work completes.
     pub fn wait_to_finish(&self, py: Python<'_>) -> PyResult<XetDownloadGroupReport> {
         let group = self.inner.clone();
-        blocking_call_with_signal_check(py, move || group.finish_blocking())
+        let result = blocking_call_with_signal_check(py, move || group.finish_blocking());
+        if let (Some(handles), Some(progress)) = (&self.download_handles, &self.progress) {
+            // ignore any error from progress update
+            let _ = progress.stop_and_emit(py, || {
+                let item_reports = item_reports_from_download_handles(handles);
+                (self.inner.progress(), item_reports)
+            });
+        }
+        result
     }
 
     /// Cancel all active downloads in this group.
     pub fn abort(&self) -> PyResult<()> {
+        if let Some(progress) = &self.progress {
+            progress.stop_and_join()?;
+        }
         self.inner.abort().map_err(convert_xet_error)
     }
 
@@ -236,6 +249,7 @@ mod tests {
                 .build_blocking()
                 .unwrap(),
             download_handles: None,
+            progress: None,
         };
 
         Python::attach(|py| {
@@ -257,6 +271,7 @@ mod tests {
                 .build_blocking()
                 .unwrap(),
             download_handles: None,
+            progress: None,
         };
 
         Python::attach(|py| {

--- a/hf_xet/src/py_file_download_group.rs
+++ b/hf_xet/src/py_file_download_group.rs
@@ -194,7 +194,7 @@ impl PyXetFileDownloadGroup {
         let group = self.inner.clone();
         let result = blocking_call_with_signal_check(py, move || group.finish_blocking());
         if let (Some(handles), Some(progress)) = (&self.download_handles, &self.progress) {
-            // ignore any error from progress update
+            // Not propagate any error from progress update
             let progress_join_ret = if result.is_ok() {
                 progress.stop_and_emit(py, || {
                     let item_reports = item_reports_from_download_handles(handles);

--- a/hf_xet/src/py_upload_commit.rs
+++ b/hf_xet/src/py_upload_commit.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
-use std::time::Duration;
 
 use pyo3::prelude::*;
 use xet_pkg::xet_session::{
@@ -62,11 +61,22 @@ fn parse_sha256(py: Python<'_>, sha256: Option<Py<PyAny>>) -> PyResult<Sha256Pol
     }
 }
 
+use crate::background_progress::BackgroundProgress;
 use crate::headers::{build_header_map, build_headers_with_user_agent};
 use crate::py_file_upload_handle::PyXetFileUpload;
 use crate::py_stream_upload_handle::PyXetStreamUpload;
 use crate::utils::{progress_display, task_state_display, task_state_to_pystate};
 use crate::{PyXetTaskState, blocking_call_with_signal_check, convert_xet_error};
+
+#[inline]
+fn item_reports_from_upload_handles(
+    handles: &Arc<RwLock<Vec<XetFileUpload>>>,
+) -> HashMap<UniqueId, ItemProgressReport> {
+    handles
+        .read()
+        .map(|g| g.iter().filter_map(|h| h.progress().map(|p| (h.task_id(), p))).collect())
+        .unwrap_or_default()
+}
 
 // ── build_upload_commit ───────────────────────────────────────────────────────
 
@@ -106,38 +116,24 @@ pub(crate) fn build_upload_commit(
             .map_err(convert_xet_error)
     })?;
 
-    let upload_handles = if let Some(callback) = progress_callback {
+    let (upload_handles, background_progress) = if let Some(callback) = progress_callback {
         let handles: Arc<RwLock<Vec<XetFileUpload>>> = Arc::new(RwLock::new(Vec::new()));
         let inner = commit.clone();
         let handles_for_thread = handles.clone();
-        let interval = Duration::from_millis(progress_interval_ms);
-        std::thread::spawn(move || {
-            loop {
-                std::thread::sleep(interval);
-                let is_terminal = !matches!(inner.status(), Ok(XetTaskState::Running) | Ok(XetTaskState::Finalizing));
-                let group_report = inner.progress();
-                let item_reports: HashMap<UniqueId, ItemProgressReport> = handles_for_thread
-                    .read()
-                    .map(|g| g.iter().filter_map(|h| h.progress().map(|p| (h.task_id(), p))).collect())
-                    .unwrap_or_default();
-                let result = Python::attach(|py| callback.call1(py, (group_report, item_reports)));
-                if let Err(e) = result {
-                    Python::attach(|py| e.print(py));
-                    break;
-                }
-                if is_terminal {
-                    break;
-                }
-            }
+        let background_progress = BackgroundProgress::spawn(py, callback, progress_interval_ms, move || {
+            let is_terminal = !matches!(inner.status(), Ok(XetTaskState::Running) | Ok(XetTaskState::Finalizing));
+            let item_reports = item_reports_from_upload_handles(&handles_for_thread);
+            (inner.progress(), item_reports, is_terminal)
         });
-        Some(handles)
+        (Some(handles), Some(background_progress))
     } else {
-        None
+        (None, None)
     };
 
     Ok(PyXetUploadCommit {
         inner: commit,
         upload_handles,
+        background_progress,
     })
 }
 
@@ -158,6 +154,9 @@ pub struct PyXetUploadCommit {
     pub(crate) inner: XetUploadCommit,
     /// Per-file handles shared with the progress thread; None when no callback was registered.
     upload_handles: Option<Arc<RwLock<Vec<XetFileUpload>>>>,
+    /// Background thread that polls progress and invokes the Python callback; None when no
+    /// callback was registered. Stopped and joined from ``wait_to_finish`` and ``abort``.
+    background_progress: Option<BackgroundProgress>,
 }
 
 #[pymethods]
@@ -205,7 +204,7 @@ impl PyXetUploadCommit {
             self.wait_to_finish(py)?;
         } else {
             // Exception: cancel uploads.
-            if let Err(e) = self.inner.abort() {
+            if let Err(e) = self.abort() {
                 tracing::warn!("abort() failed during __exit__ exception path: {e}");
             }
         }
@@ -308,13 +307,27 @@ impl PyXetUploadCommit {
     ///
     /// Releases the GIL while waiting, polling for ``KeyboardInterrupt`` every
     /// 100 ms so that Ctrl-C is delivered promptly.
+    ///
+    /// When a progress callback was registered, it is invoked once more on the
+    /// calling thread with the final snapshot after all work completes.
     pub fn wait_to_finish(&self, py: Python<'_>) -> PyResult<XetCommitReport> {
         let inner = self.inner.clone();
-        blocking_call_with_signal_check(py, move || inner.commit_blocking())
+        let result = blocking_call_with_signal_check(py, move || inner.commit_blocking());
+        if let (Some(handles), Some(progress)) = (&self.upload_handles, &self.background_progress) {
+            // ignore any error from progress update
+            let _ = progress.stop_and_emit(py, || {
+                let item_reports = item_reports_from_upload_handles(handles);
+                (self.inner.progress(), item_reports)
+            });
+        }
+        result
     }
 
     /// Cancel all active uploads in this commit.
     pub fn abort(&self) -> PyResult<()> {
+        if let Some(progress) = &self.background_progress {
+            progress.stop_and_join()?;
+        }
         self.inner.abort().map_err(convert_xet_error)
     }
 
@@ -408,6 +421,7 @@ mod tests {
                 .build_blocking()
                 .unwrap(),
             upload_handles: None,
+            background_progress: None,
         };
 
         Python::attach(|py| {
@@ -437,6 +451,7 @@ mod tests {
                 .build_blocking()
                 .unwrap(),
             upload_handles: None,
+            background_progress: None,
         };
 
         Python::attach(|py| {

--- a/hf_xet/src/py_upload_commit.rs
+++ b/hf_xet/src/py_upload_commit.rs
@@ -116,16 +116,16 @@ pub(crate) fn build_upload_commit(
             .map_err(convert_xet_error)
     })?;
 
-    let (upload_handles, background_progress) = if let Some(callback) = progress_callback {
+    let (upload_handles, progress) = if let Some(callback) = progress_callback {
         let handles: Arc<RwLock<Vec<XetFileUpload>>> = Arc::new(RwLock::new(Vec::new()));
         let inner = commit.clone();
         let handles_for_thread = handles.clone();
-        let background_progress = BackgroundProgress::spawn(py, callback, progress_interval_ms, move || {
+        let progress = BackgroundProgress::spawn(py, callback, progress_interval_ms, move || {
             let is_terminal = !matches!(inner.status(), Ok(XetTaskState::Running) | Ok(XetTaskState::Finalizing));
             let item_reports = item_reports_from_upload_handles(&handles_for_thread);
             (inner.progress(), item_reports, is_terminal)
         });
-        (Some(handles), Some(background_progress))
+        (Some(handles), Some(progress))
     } else {
         (None, None)
     };
@@ -133,7 +133,7 @@ pub(crate) fn build_upload_commit(
     Ok(PyXetUploadCommit {
         inner: commit,
         upload_handles,
-        background_progress,
+        progress,
     })
 }
 
@@ -156,7 +156,7 @@ pub struct PyXetUploadCommit {
     upload_handles: Option<Arc<RwLock<Vec<XetFileUpload>>>>,
     /// Background thread that polls progress and invokes the Python callback; None when no
     /// callback was registered. Stopped and joined from ``wait_to_finish`` and ``abort``.
-    background_progress: Option<BackgroundProgress>,
+    progress: Option<BackgroundProgress>,
 }
 
 #[pymethods]
@@ -313,19 +313,23 @@ impl PyXetUploadCommit {
     pub fn wait_to_finish(&self, py: Python<'_>) -> PyResult<XetCommitReport> {
         let inner = self.inner.clone();
         let result = blocking_call_with_signal_check(py, move || inner.commit_blocking());
-        if let (Some(handles), Some(progress)) = (&self.upload_handles, &self.background_progress) {
+        if let (Some(handles), Some(progress)) = (&self.upload_handles, &self.progress) {
             // ignore any error from progress update
-            let _ = progress.stop_and_emit(py, || {
-                let item_reports = item_reports_from_upload_handles(handles);
-                (self.inner.progress(), item_reports)
-            });
+            let _ = if result.is_ok() {
+                progress.stop_and_emit(py, || {
+                    let item_reports = item_reports_from_upload_handles(handles);
+                    (self.inner.progress(), item_reports)
+                })
+            } else {
+                progress.stop_and_join(py)
+            };
         }
         result
     }
 
     /// Cancel all active uploads in this commit.
     pub fn abort(&self, py: Python<'_>) -> PyResult<()> {
-        if let Some(progress) = &self.background_progress {
+        if let Some(progress) = &self.progress {
             // ignore any error from progress update
             let _ = progress.stop_and_join(py);
         }
@@ -422,7 +426,7 @@ mod tests {
                 .build_blocking()
                 .unwrap(),
             upload_handles: None,
-            background_progress: None,
+            progress: None,
         };
 
         Python::attach(|py| {
@@ -452,7 +456,7 @@ mod tests {
                 .build_blocking()
                 .unwrap(),
             upload_handles: None,
-            background_progress: None,
+            progress: None,
         };
 
         Python::attach(|py| {

--- a/hf_xet/src/py_upload_commit.rs
+++ b/hf_xet/src/py_upload_commit.rs
@@ -204,7 +204,7 @@ impl PyXetUploadCommit {
             self.wait_to_finish(py)?;
         } else {
             // Exception: cancel uploads.
-            if let Err(e) = self.abort() {
+            if let Err(e) = self.abort(py) {
                 tracing::warn!("abort() failed during __exit__ exception path: {e}");
             }
         }
@@ -324,9 +324,10 @@ impl PyXetUploadCommit {
     }
 
     /// Cancel all active uploads in this commit.
-    pub fn abort(&self) -> PyResult<()> {
+    pub fn abort(&self, py: Python<'_>) -> PyResult<()> {
         if let Some(progress) = &self.background_progress {
-            progress.stop_and_join()?;
+            // ignore any error from progress update
+            let _ = progress.stop_and_join(py);
         }
         self.inner.abort().map_err(convert_xet_error)
     }
@@ -455,7 +456,7 @@ mod tests {
         };
 
         Python::attach(|py| {
-            commit.abort().unwrap();
+            commit.abort(py).unwrap();
             assert!(commit.wait_to_finish(py).is_err());
         });
     }

--- a/hf_xet/src/py_upload_commit.rs
+++ b/hf_xet/src/py_upload_commit.rs
@@ -314,7 +314,7 @@ impl PyXetUploadCommit {
         let inner = self.inner.clone();
         let result = blocking_call_with_signal_check(py, move || inner.commit_blocking());
         if let (Some(handles), Some(progress)) = (&self.upload_handles, &self.progress) {
-            // ignore any error from progress update
+            // Not propagate any error from progress update
             let progress_join_ret = if result.is_ok() {
                 progress.stop_and_emit(py, || {
                     let item_reports = item_reports_from_upload_handles(handles);

--- a/hf_xet/src/py_upload_commit.rs
+++ b/hf_xet/src/py_upload_commit.rs
@@ -315,7 +315,7 @@ impl PyXetUploadCommit {
         let result = blocking_call_with_signal_check(py, move || inner.commit_blocking());
         if let (Some(handles), Some(progress)) = (&self.upload_handles, &self.progress) {
             // ignore any error from progress update
-            let _ = if result.is_ok() {
+            let progress_join_ret = if result.is_ok() {
                 progress.stop_and_emit(py, || {
                     let item_reports = item_reports_from_upload_handles(handles);
                     (self.inner.progress(), item_reports)
@@ -323,6 +323,9 @@ impl PyXetUploadCommit {
             } else {
                 progress.stop_and_join(py)
             };
+            if let Err(e) = progress_join_ret {
+                tracing::warn!(id = self.inner.id().0, error = ?e, "PyXetUploadCommit progress thread join failed");
+            }
         }
         result
     }


### PR DESCRIPTION
## Problems addressed

1. **Missing final progress update** — Progress was only emitted on a fixed poll interval, so the last snapshot could be skipped when upload/download finished between ticks (e.g. UI stuck below 100%).
2. **Panic on shutdown** — The background progress thread used `Python::attach` while the interpreter was tearing down, which can panic when the GIL is no longer available. Resolves https://github.com/huggingface/huggingface_hub/pull/4116#discussion_r3272527522

## Approach

- Introduce `BackgroundProgress` (`hf_xet/src/background_progress.rs`): a shared poller for upload commits and download groups.
- Poll loop uses `Condvar::wait_timeout_while` so shutdown returns immediately when the flag is already set.
- `stop_and_join(py)` sets the shutdown flag, notifies, then `join` the background thread.
- After `wait_to_finish` / `commit_blocking` completes, `stop_and_emit` runs one final callback on the caller thread with the latest snapshot.
- Use `Python::try_attach` in the poller loop so shutdown does not crash if the interpreter is gone.

## Test plan

- [x] `cargo test` in `hf_xet` — unit test spawns a poller with a 60s interval and calls `stop_and_join` immediately (no sleep); asserts join finishes in under 2s (covers pre-set shutdown + `wait_timeout_while`, not only condvar wake while blocked).
- [x] Manual: upload/download with a progress callback and confirm final 100% (or terminal state) is reported
- [x] Manual: run `hf upload/download` cli so Python interpreter shuts down immediately after `wait_to_finish` returns, confirm no panics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes background-thread and GIL interaction for progress callbacks and makes abort(py) required on two pyclasses; mistakes could cause missed updates, deadlocks, or shutdown panics, but scope is limited to optional progress reporting.
> 
> **Overview**
> Replaces ad-hoc progress polling threads on **`XetUploadCommit`** and **`XetFileDownloadGroup`** with a shared **`BackgroundProgress`** helper that polls Rust progress atomics and calls the Python callback via **`Python::try_attach`** (avoids panics during interpreter shutdown).
> 
> The poller waits on a **condvar** with a timeout so **`stop_and_join`** returns immediately instead of sleeping the full interval; joining releases the **GIL** via **`py.detach`** to avoid deadlocks. On successful **`wait_to_finish`**, **`stop_and_emit`** runs **one final** callback on the caller thread so UIs can reach 100%; **`abort`** only stops the poller (no extra callback). **`abort`** now takes **`py`** so the background thread is joined cleanly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79b00ae33b0c8027e2426b1f77db1e8a204a264f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->