### PR TITLE
fix(simulation): remove dirty-range extension from simulation CAS client

### DIFF
--- a/xet_client/src/cas_client/chunk_window_builder.rs
+++ b/xet_client/src/cas_client/chunk_window_builder.rs
@@ -4,7 +4,6 @@
 
 use xet_core_structures::merklehash::{MerkleHash, MerkleHashSubtree};
 use xet_core_structures::metadata_shard::file_structs::MDBFileInfo;
-use xet_core_structures::xorb_object::constants::next_stable_chunk_boundary;
 
 use crate::cas_types::{ChunkWindow, FileChunkHashesResponse, FileRange};
 use crate::error::{ClientError, Result};
@@ -19,44 +18,6 @@ pub struct ChunkWindowBuilder<'a> {
     gap_chunks: Vec<(MerkleHash, u64)>,
     windows: Vec<FileRange>,
     hash_ranges: Vec<Option<MerkleHashSubtree>>,
-}
-
-fn next_stable_end_for_range(range_end: u64, file_size: u64, chunk_boundaries: &[usize]) -> u64 {
-    if range_end >= file_size {
-        return file_size;
-    }
-    let Ok(starting_position) = usize::try_from(range_end) else {
-        return file_size;
-    };
-    next_stable_chunk_boundary(starting_position, chunk_boundaries)
-        .and_then(|boundary| u64::try_from(boundary).ok())
-        .map(|boundary| boundary.min(file_size))
-        .unwrap_or(file_size)
-}
-
-fn extend_dirty_ranges_to_stable_windows(
-    mut dirty_ranges: Vec<FileRange>,
-    file_size: u64,
-    chunk_boundaries: &[usize],
-) -> Vec<FileRange> {
-    for range in &mut dirty_ranges {
-        if range.end < file_size {
-            range.end = next_stable_end_for_range(range.end, file_size, chunk_boundaries);
-        }
-    }
-
-    dirty_ranges.sort_by_key(|range| range.start);
-    let mut coalesced: Vec<FileRange> = Vec::with_capacity(dirty_ranges.len());
-    for range in dirty_ranges {
-        if let Some(last) = coalesced.last_mut()
-            && range.start <= last.end
-        {
-            last.end = last.end.max(range.end);
-            continue;
-        }
-        coalesced.push(range);
-    }
-    coalesced
 }
 
 impl<'a> ChunkWindowBuilder<'a> {
@@ -193,26 +154,6 @@ pub fn build_file_chunk_hashes_response(
     }
 
     let chunks: Vec<(MerkleHash, u64)> = chunks.into_iter().collect();
-    let mut chunk_boundaries: Vec<usize> = Vec::with_capacity(chunks.len());
-    let mut stable_ranges_supported = true;
-    {
-        let mut boundary_cursor: u64 = 0;
-        for (_, size) in &chunks {
-            boundary_cursor += *size;
-            let Ok(boundary) = usize::try_from(boundary_cursor) else {
-                stable_ranges_supported = false;
-                break;
-            };
-            chunk_boundaries.push(boundary);
-        }
-    }
-
-    let dirty_ranges = if stable_ranges_supported {
-        extend_dirty_ranges_to_stable_windows(dirty_ranges, file_size, &chunk_boundaries)
-    } else {
-        dirty_ranges
-    };
-
     let total_chunks = chunks.len() as u64;
     let mut builder = ChunkWindowBuilder::new(&dirty_ranges);
     let mut cumulative_bytes: u64 = 0;
@@ -279,19 +220,8 @@ pub fn build_file_chunk_hashes_response(
 mod tests {
     use xet_core_structures::merklehash::MerkleHash;
     use xet_core_structures::metadata_shard::file_structs::{FileDataSequenceEntry, MDBFileInfo};
-    use xet_core_structures::xorb_object::constants::{
-        MAXIMUM_CHUNK_MULTIPLIER, MINIMUM_CHUNK_DIVISOR, TARGET_CHUNK_SIZE,
-    };
 
     use super::*;
-
-    fn stable_chunk_size() -> u64 {
-        let minimum_chunk = *TARGET_CHUNK_SIZE / *MINIMUM_CHUNK_DIVISOR;
-        let maximum_chunk = *TARGET_CHUNK_SIZE * *MAXIMUM_CHUNK_MULTIPLIER;
-        let size = 2 * minimum_chunk;
-        assert!(size < maximum_chunk - minimum_chunk);
-        size as u64
-    }
 
     fn build_test_file_info_and_chunks(n_chunks: usize, chunk_size: u64) -> (MDBFileInfo, Vec<(MerkleHash, u64)>) {
         let chunks: Vec<(MerkleHash, u64)> = (0..n_chunks)
@@ -312,35 +242,8 @@ mod tests {
     }
 
     #[test]
-    fn test_server_extends_dirty_window_to_next_stable_boundary() {
-        let chunk_size = stable_chunk_size();
-        let (file_info, chunks) = build_test_file_info_and_chunks(6, chunk_size);
-        let dirty_ranges = vec![FileRange::new(1, chunk_size + 1)];
-
-        let response = build_file_chunk_hashes_response(&file_info, dirty_ranges, chunks).unwrap();
-
-        assert_eq!(response.windows.len(), 1);
-        assert_eq!(response.windows[0].dirty_byte_range, [0, 4 * chunk_size]);
-    }
-
-    #[test]
-    fn test_server_coalesces_ranges_after_stable_extension() {
-        let chunk_size = stable_chunk_size();
-        let (file_info, chunks) = build_test_file_info_and_chunks(8, chunk_size);
-        let dirty_ranges = vec![
-            FileRange::new(1, chunk_size + 1),
-            FileRange::new(3 * chunk_size + 7, 3 * chunk_size + 42),
-        ];
-
-        let response = build_file_chunk_hashes_response(&file_info, dirty_ranges, chunks).unwrap();
-
-        assert_eq!(response.windows.len(), 1);
-        assert_eq!(response.windows[0].dirty_byte_range, [0, 6 * chunk_size]);
-    }
-
-    #[test]
-    fn test_server_no_extension_when_range_already_at_file_end() {
-        let chunk_size = stable_chunk_size();
+    fn test_window_matches_dirty_range() {
+        let chunk_size = 65536u64;
         let (file_info, chunks) = build_test_file_info_and_chunks(6, chunk_size);
         let file_size = chunk_size * 6;
         let dirty_ranges = vec![FileRange::new(4 * chunk_size, file_size)];
@@ -352,8 +255,8 @@ mod tests {
     }
 
     #[test]
-    fn test_server_separate_ranges_stay_separate_when_far_apart() {
-        let chunk_size = stable_chunk_size();
+    fn test_separate_ranges_produce_separate_windows() {
+        let chunk_size = 65536u64;
         let n_chunks = 20;
         let (file_info, chunks) = build_test_file_info_and_chunks(n_chunks, chunk_size);
         let dirty_ranges = vec![
@@ -363,31 +266,7 @@ mod tests {
 
         let response = build_file_chunk_hashes_response(&file_info, dirty_ranges, chunks).unwrap();
 
-        assert!(
-            response.windows.len() >= 2,
-            "far-apart ranges should remain separate, got {} window(s)",
-            response.windows.len()
-        );
-        assert_eq!(response.hash_ranges.len(), response.windows.len() + 1);
-    }
-
-    #[test]
-    fn test_server_extension_falls_through_to_file_end_when_no_stable_boundary() {
-        let minimum_chunk = *TARGET_CHUNK_SIZE / *MINIMUM_CHUNK_DIVISOR;
-        let maximum_chunk = *TARGET_CHUNK_SIZE * *MAXIMUM_CHUNK_MULTIPLIER;
-        let forced_size = maximum_chunk as u64;
-        let (file_info, chunks) = build_test_file_info_and_chunks(4, forced_size);
-        let file_size = forced_size * 4;
-        let dirty_ranges = vec![FileRange::new(0, forced_size)];
-
-        let response = build_file_chunk_hashes_response(&file_info, dirty_ranges, chunks).unwrap();
-
-        assert_eq!(response.windows.len(), 1);
-        let w = &response.windows[0];
-        assert_eq!(
-            w.dirty_byte_range[1], file_size,
-            "when no stable boundary exists, window should extend to file end; \
-             minimum_chunk={minimum_chunk}, maximum_chunk={maximum_chunk}"
-        );
+        assert_eq!(response.windows.len(), 2);
+        assert_eq!(response.hash_ranges.len(), 3);
     }
 }

--- a/xet_client/src/cas_client/simulation/local_client.rs
+++ b/xet_client/src/cas_client/simulation/local_client.rs
@@ -1710,11 +1710,10 @@ impl Client for LocalClient {
         let mut chunks: Vec<(MerkleHash, u64)> = Vec::new();
         for segment in &file_info.segments {
             let xorb_obj = self.xorb_footer(&segment.xorb_hash).await?;
-            chunks.extend(
-                xorb_obj
-                    .chunk_hash_sizes(segment.chunk_index_start, segment.chunk_index_end)
-                    .map_err(|err| ClientError::Other(format!("chunk_hash_sizes error: {err}")))?,
-            );
+            let seg_chunks = xorb_obj
+                .chunk_hash_sizes(segment.chunk_index_start, segment.chunk_index_end)
+                .map_err(|err| ClientError::Other(format!("chunk_hash_sizes error: {err}")))?;
+            chunks.extend(seg_chunks);
         }
 
         build_file_chunk_hashes_response(&file_info, dirty_ranges, chunks)


### PR DESCRIPTION
The simulation client's `build_file_chunk_hashes_response` was calling `extend_dirty_ranges_to_stable_windows`, which expands the dirty byte ranges to the next stable CDC chunk boundary before returning them. The real Xet server expects the ranges provided to it to already be stable chunk boundaries and thus, uses the dirty_ranges from the request as-is. This discrepancy means that the simulation produces different window boundaries than production, which impacts the ability to test new features relying on this API (get_file_chunk_hashes).

Changes:
- Removes `extend_dirty_ranges_to_stable_windows` and `next_stable_end_for_range` entirely
- Updates tests to match the corrected no-extension behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to the local simulation CAS client and its tests; production paths are unchanged and the fix reduces sim/prod divergence.
> 
> **Overview**
> The simulation path for **`get_file_chunk_hashes`** no longer **widens** caller-supplied dirty byte ranges to the next stable CDC chunk boundary before building chunk windows.
> 
> **`build_file_chunk_hashes_response`** in `chunk_window_builder.rs` drops `extend_dirty_ranges_to_stable_windows`, chunk-boundary derivation, and the `next_stable_chunk_boundary` dependency. Dirty ranges are only clamped to file size and validated; **`ChunkWindowBuilder`** then derives windows from those ranges as given—aligned with production CAS, which treats request ranges as already stable.
> 
> Tests that asserted extension/coalescing at stable boundaries are replaced with cases that expect windows to follow the **exact** dirty ranges (including two separate windows for far-apart ranges). **`local_client`** has a small refactor when assembling per-segment chunk lists (no behavior change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3c13f5252f28cc6ec79ea418924b6ef35fb6b78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->