### PR TITLE
Update to session builder API to enable context, config, or runtime sharing.

### DIFF
--- a/api_changes/update_260601_session_builder_with_context.md
+++ b/api_changes/update_260601_session_builder_with_context.md
@@ -1,0 +1,120 @@
+# API Update: `XetSessionBuilder` adopts the `with_...` pattern and gains `with_context` (2026-06-01)
+
+## Overview
+
+`XetSessionBuilder` now uses a uniform `with_...` configuration pattern. The
+`new_with_config` constructor is removed in favor of `new().with_config(...)`, and a
+new `with_context` method lets a session reuse an existing `XetContext` -- sharing its
+runtime, configuration, and cached shard-file managers so the local shard cache is not
+re-scanned and re-indexed on every new session.
+
+---
+
+## Breaking Changes
+
+### Removed `XetSessionBuilder::new_with_config`
+
+```rust
+// Before
+let session = XetSessionBuilder::new_with_config(config).build()?;
+
+// After (with_config accepts XetConfig or Arc<XetConfig>)
+let session = XetSessionBuilder::new().with_config(config).build()?;
+```
+
+`new()` now takes no configuration and all configuration flows through `with_...`
+methods.
+
+---
+
+## New capability: `with_context`
+
+Build a session on top of an existing `XetContext` (e.g. obtained from another session
+via the new `XetSession::context`). The new session shares the context's runtime,
+config, and `common` state — including the cached `ShardFileManager` — so repeated
+sessions avoid re-scanning the shard cache directory from disk.
+
+```rust
+let first = XetSessionBuilder::new().build()?;
+
+// Reuses the runtime, config, and shard-file-manager cache from `first`.
+let second = XetSessionBuilder::new()
+    .with_context(first.context().clone())
+    .build()?;
+```
+
+When a context is supplied, `with_runtime` is ignored. `with_config` takes precedence:
+its configuration replaces the context's while the runtime and shared state (`common`,
+including caches) are still reused. Since `common` is still shared, construction-time
+settings stored there, such as semaphores, are not re-applied from the replacement
+configuration.
+
+```rust
+// Reuse the runtime + caches from `a`, but with a tweaked config.
+let b = XetSessionBuilder::new()
+    .with_context(a.context())
+    .with_config(custom_cfg)
+    .build()?;
+```
+
+`XetContext` and `XetRuntime` are now re-exported from `xet::xet_session`.
+
+### Accessors for recycling
+
+`XetSession` exposes accessors so an existing session's pieces can be reused when
+building another session:
+
+```rust
+pub fn config(&self) -> Arc<XetConfig>;               // now returns an owned Arc (was &XetConfig)
+pub fn context(&self) -> XetContext;                  // new (owned; Arc-backed clone)
+pub fn runtime(&self) -> Arc<XetRuntime>;             // new
+```
+
+`config()` and `runtime()` return `Arc` clones, and `context()` returns an owned
+`XetContext` clone. `with_config` accepts `impl Into<Arc<XetConfig>>`, so it takes either
+a `XetConfig` or an `Arc<XetConfig>` (e.g. the value returned by `config()`).
+
+```rust
+// Share everything, including the shard-file-manager cache:
+let b = XetSessionBuilder::new().with_context(a.context()).build()?;
+
+// Or share just the thread pool (independent config + caches):
+let b = XetSessionBuilder::new()
+    .with_config(a.config())
+    .with_runtime(a.runtime())
+    .build()?;
+```
+
+---
+
+## Full builder chain
+
+```rust
+let session = XetSessionBuilder::new()
+    .with_config(cfg)            // overrides the context config if with_context is set
+    .with_context(ctx)           // reuse runtime + config + caches
+    .with_runtime(runtime)       // ignored if with_context is set
+    .build()?;
+```
+
+---
+
+## `XetContext` constructors accept `impl Into<Arc<XetConfig>>`
+
+`XetContext::new`, `XetContext::with_config`, and `XetContext::from_external` now take
+`impl Into<Arc<XetConfig>>` instead of `XetConfig`. This is source-compatible — existing
+callers passing an owned `XetConfig` continue to work — and lets an `Arc<XetConfig>` be
+threaded straight through without an extra clone (the context stores `Arc<XetConfig>`).
+
+A new `XetContext::with_new_config(&self, config)` returns a clone of the context with
+the configuration replaced while sharing the runtime and `common` state. This backs the
+`with_context` + `with_config` precedence in `XetSessionBuilder`.
+
+---
+
+## Affected Files
+
+- `xet_pkg/src/xet_session/session.rs` — builder fields are now `Option`; `new_with_config` removed; `with_config`/`with_context`/`with_runtime` added; `build` resolution updated; `XetSession::context()` / `runtime()` accessors added; `config()` returns `Arc<XetConfig>`
+- `xet_pkg/src/xet_session/mod.rs` — re-exports `XetContext` and `XetRuntime`
+- `xet_runtime/src/core/context.rs` — `new`/`with_config`/`from_external` accept `impl Into<Arc<XetConfig>>`; adds `with_new_config`
+- `hf_xet/src/py_xet_session.rs` — updated to `new().with_config(...)`

--- a/hf_xet/src/py_xet_session.rs
+++ b/hf_xet/src/py_xet_session.rs
@@ -50,7 +50,7 @@ impl PyXetSession {
         #[allow(clippy::unwrap_or_default)]
         // XetConfig::new starts from default() and applies HF_XET_* environment variable overrides
         let xet_config = config.map(|c| c.into_inner()).unwrap_or_else(XetConfig::new);
-        let session = XetSessionBuilder::new_with_config(xet_config).build().map_err(PyErr::from)?;
+        let session = XetSessionBuilder::new().with_config(xet_config).build().map_err(PyErr::from)?;
         Ok(Self { inner: session })
     }
 

--- a/xet_pkg/src/xet_session/download_stream_group.rs
+++ b/xet_pkg/src/xet_session/download_stream_group.rs
@@ -51,7 +51,7 @@ impl AuthGroupBuilder<XetDownloadStreamGroup> {
     /// # Errors
     ///
     /// Returns [`XetError::WrongRuntimeMode`] if the session wraps an external
-    /// tokio runtime (created via [`XetSessionBuilder::with_tokio_handle`] or
+    /// tokio runtime (supplied via [`XetSessionBuilder::with_runtime`] or
     /// auto-detected inside `#[tokio::main]`).
     ///
     /// # Panics

--- a/xet_pkg/src/xet_session/file_download_group.rs
+++ b/xet_pkg/src/xet_session/file_download_group.rs
@@ -42,7 +42,7 @@ impl AuthGroupBuilder<XetFileDownloadGroup> {
     /// # Errors
     ///
     /// Returns [`XetError::WrongRuntimeMode`] if the session wraps an external
-    /// tokio runtime (created via [`XetSessionBuilder::with_tokio_handle`] or
+    /// tokio runtime (supplied via [`XetSessionBuilder::with_runtime`] or
     /// auto-detected inside `#[tokio::main]`).
     ///
     /// # Panics

--- a/xet_pkg/src/xet_session/mod.rs
+++ b/xet_pkg/src/xet_session/mod.rs
@@ -277,4 +277,5 @@ pub use xet_data::deduplication::DeduplicationMetrics;
 pub use xet_data::processing::{Sha256Policy, XetFileInfo};
 pub use xet_data::progress_tracking::{GroupProgressReport, ItemProgressReport};
 pub use xet_runtime::config::XetConfig;
+pub use xet_runtime::core::{XetContext, XetRuntime};
 pub use xet_runtime::utils::UniqueId;

--- a/xet_pkg/src/xet_session/session.rs
+++ b/xet_pkg/src/xet_session/session.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, Mutex, Weak};
 use tracing::info;
 use uuid::Uuid;
 use xet_runtime::config::XetConfig;
-use xet_runtime::core::XetContext;
+use xet_runtime::core::{XetContext, XetRuntime};
 #[cfg(feature = "fd-track")]
 use xet_runtime::fd_diagnostics::{report_fd_count, track_fd_scope};
 use xet_runtime::utils::UniqueId;
@@ -56,9 +56,8 @@ pub struct XetSessionInner {
 ///   session wraps the caller's handle; no second thread pool is created.  Both async and blocking methods work.
 /// - **Outside any runtime** — an owned multi-thread runtime is created internally. Blocking methods (`_blocking`
 ///   suffix) work from any thread; async methods work via an internal bridge.
-/// - **Explicit handle** — call [`with_tokio_handle`](Self::with_tokio_handle) to supply a handle directly.  If it
-///   doesn't meet requirements (multi-thread, time + IO drivers), it is silently ignored and an owned runtime is
-///   created instead.
+/// - **Explicit runtime** — call [`with_runtime`](Self::with_runtime) to supply an existing [`XetRuntime`]. The new
+///   session gets fresh configuration and common state while sharing the same runtime.
 ///
 /// ## Authentication
 ///
@@ -104,11 +103,20 @@ pub struct XetSessionInner {
 /// ## `XetConfig`
 ///
 /// For most use cases, [`new`](Self::new) with the default [`XetConfig`] is
-/// sufficient.  Use [`new_with_config`](Self::new_with_config) when you need to
-/// override runtime settings such as cache directories or concurrency limits.
+/// sufficient.  Use [`with_config`](Self::with_config) when you need to override
+/// runtime settings such as cache directories or concurrency limits.
+///
+/// ## Reusing a context
+///
+/// Use [`with_context`](Self::with_context) to build a session on top of an
+/// existing [`XetContext`] (for example, one obtained from another session via
+/// [`XetSession::context`]).  This shares the runtime, configuration, and—most
+/// importantly—the cached shard-file managers, so subsequent sessions avoid
+/// re-scanning and re-indexing the local shard cache from disk.
 pub struct XetSessionBuilder {
-    config: XetConfig,
-    tokio_handle: Option<tokio::runtime::Handle>,
+    config: Option<Arc<XetConfig>>,
+    context: Option<XetContext>,
+    runtime: Option<Arc<XetRuntime>>,
 }
 
 impl Default for XetSessionBuilder {
@@ -118,65 +126,102 @@ impl Default for XetSessionBuilder {
 }
 
 impl XetSessionBuilder {
-    /// Create a builder with default [`XetConfig`].
+    /// Create an empty builder.
     pub fn new() -> Self {
         Self {
-            config: XetConfig::new(),
-            tokio_handle: None,
+            config: None,
+            context: None,
+            runtime: None,
         }
     }
 
-    /// Create a builder pre-populated with the given [`XetConfig`].
-    pub fn new_with_config(config: XetConfig) -> Self {
+    /// Set the configuration used to construct the session.
+    ///
+    /// Accepts either a [`XetConfig`] or an `Arc<XetConfig>`.
+    ///
+    /// Takes precedence over a context's configuration: when combined with
+    /// [`with_context`](Self::with_context), the context's runtime and shared
+    /// state are reused but this configuration replaces the context's. Values
+    /// already baked into shared `common` state are not recalculated.
+    pub fn with_config(self, config: impl Into<Arc<XetConfig>>) -> Self {
         Self {
-            config,
-            tokio_handle: None,
+            config: Some(config.into()),
+            ..self
         }
     }
 
-    /// Attach to an existing tokio runtime handle.
+    /// Reuse an existing [`XetContext`] instead of constructing a new one.
     ///
-    /// If the handle meets runtime requirements (multi-thread flavor, time driver, IO driver),
-    /// the session will wrap it — no second thread pool is created. Only async
-    /// methods (`new_upload_commit`, `new_file_download_group`) may be called; `_blocking` variants
-    /// return [`SessionError::WrongRuntimeMode`] from `bridge_sync` (external runtime cannot run sync bridge).
+    /// The session shares the context's runtime, configuration, and shared state
+    /// (`common`), including the cached shard-file managers. This lets a sequence
+    /// of sessions avoid repeatedly scanning and indexing the local shard cache.
     ///
-    /// If the handle does **not** meet requirements (e.g. `current_thread` flavor or missing
-    /// drivers), it is silently ignored and [`build`](Self::build) will fall back to creating
-    /// an owned thread pool instead.
-    ///
-    /// Handles can be shared by multiple sessions. Each session gets its own
-    /// [`XetContext`] (`config` + `common`), while the underlying runtime
-    /// may be shared.
-    pub fn with_tokio_handle(self, handle: tokio::runtime::Handle) -> Self {
-        let accept = XetContext::handle_meets_requirements(&handle);
-        if !accept {
-            info!("supplied tokio handle rejected (missing drivers or wrong flavor); falling back to Owned mode");
-        }
+    /// [`with_runtime`](Self::with_runtime) is ignored when a context is supplied.
+    /// [`with_config`](Self::with_config) is honored: its configuration replaces
+    /// the context's while the runtime and shared state are still reused.
+    pub fn with_context(self, context: XetContext) -> Self {
         Self {
-            tokio_handle: accept.then_some(handle),
+            context: Some(context),
+            ..self
+        }
+    }
+
+    /// Reuse an existing xet runtime.
+    ///
+    /// Each session gets its own [`XetContext`] configuration and shared state,
+    /// while the supplied runtime is kept alive by its `Arc`.
+    pub fn with_runtime(self, runtime: Arc<XetRuntime>) -> Self {
+        Self {
+            runtime: Some(runtime),
             ..self
         }
     }
 
     /// Consume the builder and create a [`XetSession`].
     ///
-    /// Threadpool selection order:
-    /// 1. Reuse the current owned runtime from thread-local storage, when present.
-    /// 2. Otherwise, use a provided tokio handle (or auto-detected current handle) if valid.
-    /// 3. Otherwise, create a new owned thread pool.
+    /// Context selection order:
+    /// 1. If a context was supplied via [`with_context`](Self::with_context), reuse its runtime and shared state
+    ///    (including the cached shard-file managers). If [`with_config`](Self::with_config) was also supplied, that
+    ///    configuration replaces the context's; otherwise the context's configuration is kept.
+    /// 2. Otherwise, if a runtime was supplied via [`with_runtime`](Self::with_runtime), wrap it in a fresh context.
+    /// 3. Otherwise, construct a fresh [`XetContext`]. Threadpool selection then follows:
+    ///    1. Reuse the current owned runtime from thread-local storage, when present.
+    ///    2. Otherwise, use the auto-detected current tokio handle if valid.
+    ///    3. Otherwise, create a new owned thread pool.
     ///
-    /// Each build creates a fresh [`XetContext`] around the selected runtime, so sessions
-    /// can share the same execution backend while keeping independent config and common state.
+    /// A freshly constructed context keeps independent config and common state, so such sessions
+    /// can share an execution backend without sharing caches.
     pub fn build(self) -> Result<XetSession, SessionError> {
         #[cfg(feature = "fd-track")]
         let _fd_scope = track_fd_scope("XetSessionBuilder::build");
 
-        let ctx = if let Some(h) = self.tokio_handle {
-            info!("XetSession using explicitly provided tokio handle");
-            XetContext::from_external(h, self.config)
+        let Self {
+            config,
+            context,
+            runtime,
+        } = self;
+
+        let ctx = if let Some(ctx) = context {
+            if runtime.is_some() {
+                info!("XetSessionBuilder: with_runtime is ignored when an explicit XetContext is provided");
+            }
+            if let Some(config) = config {
+                // with_config takes precedence: swap the config while sharing the
+                // context's runtime and common state (including its caches).
+                info!("XetSession reusing provided XetContext with overridden config");
+                ctx.with_new_config(config)
+            } else {
+                info!("XetSession reusing provided XetContext");
+                ctx
+            }
         } else {
-            XetContext::with_config(self.config)?
+            let config = config.unwrap_or_else(|| Arc::new(XetConfig::new()));
+            if let Some(runtime) = runtime {
+                info!("XetSession using explicitly provided XetRuntime");
+                XetContext::new(config, runtime)
+            } else {
+                XetContext::with_config(config)?
+            }
         };
 
         let session = XetSession::new(ctx);
@@ -372,8 +417,28 @@ impl XetSession {
         &self.inner.id
     }
 
-    pub fn config(&self) -> &XetConfig {
-        &self.inner.ctx.config
+    /// The configuration backing this session.
+    pub fn config(&self) -> Arc<XetConfig> {
+        self.inner.ctx.config.clone()
+    }
+
+    /// The underlying [`XetContext`] backing this session.
+    ///
+    /// Pass it to [`XetSessionBuilder::with_context`] to build additional
+    /// sessions that share this session's runtime, configuration, and cached
+    /// shard-file managers.  Cloning a context is cheap (it is `Arc`-backed).
+    pub fn context(&self) -> XetContext {
+        self.inner.ctx.clone()
+    }
+
+    /// The xet runtime backing this session.
+    ///
+    /// Pass it to [`XetSessionBuilder::with_runtime`] to build additional
+    /// sessions that share this session's runtime while keeping independent
+    /// configuration and shared state. To also share cached shard-file managers,
+    /// prefer [`context`](Self::context).
+    pub fn runtime(&self) -> Arc<XetRuntime> {
+        self.inner.ctx.runtime.clone()
     }
 }
 
@@ -401,6 +466,87 @@ mod tests {
         let s1 = XetSessionBuilder::new().build().unwrap();
         let s2 = XetSessionBuilder::new().build().unwrap();
         assert_ne!(s1.inner.id, s2.inner.id);
+    }
+
+    #[test]
+    // with_context reuses the runtime + shared state (common), so the shard-file-manager
+    // cache is shared. The two sessions still get distinct IDs.
+    fn test_with_context_shares_common_state() {
+        let first = XetSessionBuilder::new().build().unwrap();
+        let second = XetSessionBuilder::new().with_context(first.context()).build().unwrap();
+
+        assert!(Arc::ptr_eq(&first.inner.ctx.common, &second.inner.ctx.common));
+        assert!(Arc::ptr_eq(&first.inner.ctx.runtime, &second.inner.ctx.runtime));
+        assert!(Arc::ptr_eq(&first.inner.ctx.config, &second.inner.ctx.config));
+        assert_ne!(first.inner.id, second.inner.id);
+    }
+
+    #[test]
+    // with_config combined with with_context overrides the config while still sharing the
+    // context's runtime and common state.
+    fn test_with_context_and_with_config_replaces_config() {
+        let first = XetSessionBuilder::new().build().unwrap();
+        let overridden = XetConfig::new()
+            .with_config("data.default_cas_endpoint", "https://cas.example.com")
+            .unwrap();
+
+        let second = XetSessionBuilder::new()
+            .with_context(first.context())
+            .with_config(overridden)
+            .build()
+            .unwrap();
+
+        // Runtime and common state are still shared with the source context.
+        assert!(Arc::ptr_eq(&first.inner.ctx.common, &second.inner.ctx.common));
+        assert!(Arc::ptr_eq(&first.inner.ctx.runtime, &second.inner.ctx.runtime));
+
+        // But the config is the overriding one, not the original.
+        assert_eq!(second.config().data.default_cas_endpoint, "https://cas.example.com");
+        assert_ne!(first.config().data.default_cas_endpoint, second.config().data.default_cas_endpoint);
+    }
+
+    #[test]
+    fn test_with_config_accepts_shared_config() {
+        let first = XetSessionBuilder::new().build().unwrap();
+        let second = XetSessionBuilder::new().with_config(first.config()).build().unwrap();
+
+        assert!(Arc::ptr_eq(&first.inner.ctx.config, &second.inner.ctx.config));
+        assert!(!Arc::ptr_eq(&first.inner.ctx.common, &second.inner.ctx.common));
+    }
+
+    #[test]
+    // A freshly built session does not share common state with another fresh session.
+    fn test_fresh_sessions_do_not_share_common_state() {
+        let s1 = XetSessionBuilder::new().build().unwrap();
+        let s2 = XetSessionBuilder::new().build().unwrap();
+        assert!(!Arc::ptr_eq(&s1.inner.ctx.common, &s2.inner.ctx.common));
+    }
+
+    #[test]
+    // The runtime from a session can be reused to build another session while
+    // keeping independent common state.
+    fn test_runtime_can_be_reused() {
+        let first = XetSessionBuilder::new().build().unwrap();
+        let second = XetSessionBuilder::new().with_runtime(first.runtime()).build().unwrap();
+
+        assert!(Arc::ptr_eq(&first.inner.ctx.runtime, &second.inner.ctx.runtime));
+        assert!(!Arc::ptr_eq(&first.inner.ctx.common, &second.inner.ctx.common));
+    }
+
+    #[test]
+    // with_context takes precedence over with_runtime.
+    fn test_with_context_ignores_runtime() {
+        let context_source = XetSessionBuilder::new().build().unwrap();
+        let runtime_source = XetSessionBuilder::new().build().unwrap();
+
+        let session = XetSessionBuilder::new()
+            .with_context(context_source.context())
+            .with_runtime(runtime_source.runtime())
+            .build()
+            .unwrap();
+
+        assert!(Arc::ptr_eq(&context_source.inner.ctx.runtime, &session.inner.ctx.runtime));
+        assert!(!Arc::ptr_eq(&runtime_source.inner.ctx.runtime, &session.inner.ctx.runtime));
     }
 
     #[test]
@@ -742,36 +888,32 @@ mod tests {
         assert_eq!(collected_b, data_b);
     }
 
-    // ── Shared tokio handle behavior ──────────────────────────────────────────
+    // ── Shared runtime behavior ───────────────────────────────────────────────
 
     #[test]
-    // Building multiple sessions with the same tokio handle is allowed.
-    fn test_build_with_same_handle_stays_external() {
+    // Building multiple sessions with the same runtime is allowed.
+    fn test_build_with_same_runtime_stays_external() {
         let tokio_rt = tokio::runtime::Builder::new_multi_thread().enable_all().build().unwrap();
-        let handle = tokio_rt.handle().clone();
+        let runtime = XetRuntime::from_external(tokio_rt.handle().clone());
 
-        let first = XetSessionBuilder::new().with_tokio_handle(handle.clone()).build().unwrap();
+        let first = XetSessionBuilder::new().with_runtime(runtime.clone()).build().unwrap();
         assert_eq!(first.inner.ctx.runtime.mode(), RuntimeMode::External, "first build must use External runtime");
 
-        let second = XetSessionBuilder::new().with_tokio_handle(handle).build();
-        assert!(second.is_ok(), "second build with the same tokio handle must still succeed");
-        assert_eq!(
-            second.unwrap().inner.ctx.runtime.mode(),
-            RuntimeMode::External,
-            "second build should remain External when sharing the same tokio handle"
-        );
+        let second = XetSessionBuilder::new().with_runtime(runtime).build().unwrap();
+        assert_eq!(second.inner.ctx.runtime.mode(), RuntimeMode::External);
+        assert!(Arc::ptr_eq(&first.inner.ctx.runtime, &second.inner.ctx.runtime));
     }
 
     #[test]
-    // Dropping one session must not affect creating another session with the same handle.
-    fn test_build_with_same_handle_succeeds_after_first_is_dropped() {
+    // Dropping one session must not affect creating another session with the same runtime.
+    fn test_build_with_same_runtime_succeeds_after_first_is_dropped() {
         let tokio_rt = tokio::runtime::Builder::new_multi_thread().enable_all().build().unwrap();
-        let handle = tokio_rt.handle().clone();
+        let runtime = XetRuntime::from_external(tokio_rt.handle().clone());
 
-        let first = XetSessionBuilder::new().with_tokio_handle(handle.clone()).build().unwrap();
+        let first = XetSessionBuilder::new().with_runtime(runtime.clone()).build().unwrap();
         drop(first);
 
-        let second = XetSessionBuilder::new().with_tokio_handle(handle).build();
-        assert!(second.is_ok(), "build must succeed after the previous session holding the same handle is dropped");
+        let second = XetSessionBuilder::new().with_runtime(runtime).build();
+        assert!(second.is_ok(), "build must succeed after the previous session holding the same runtime is dropped");
     }
 }

--- a/xet_pkg/src/xet_session/upload_commit.rs
+++ b/xet_pkg/src/xet_session/upload_commit.rs
@@ -43,7 +43,7 @@ impl AuthGroupBuilder<XetUploadCommit> {
     /// # Errors
     ///
     /// Returns [`XetError::WrongRuntimeMode`] if the session wraps an external
-    /// tokio runtime (created via [`XetSessionBuilder::with_tokio_handle`] or
+    /// tokio runtime (supplied via [`XetSessionBuilder::with_runtime`] or
     /// auto-detected inside `#[tokio::main]`).
     ///
     /// # Panics

--- a/xet_pkg/tests/test_xet_session.rs
+++ b/xet_pkg/tests/test_xet_session.rs
@@ -998,7 +998,7 @@ fn deficient_tokio_no_drivers_large_file() {
 // build() inside a deficient tokio runtime auto-falls-back to Owned mode;
 // blocking API still works from a sync context afterward.
 #[test]
-fn deficient_tokio_handle_auto_fallback_blocking_roundtrip() {
+fn deficient_tokio_runtime_auto_fallback_blocking_roundtrip() {
     for (label, builder) in [
         ("deficient", build_rt_no_drivers as RuntimeBuilder),
         ("no_io", build_rt_no_io as RuntimeBuilder),
@@ -1009,7 +1009,7 @@ fn deficient_tokio_handle_auto_fallback_blocking_roundtrip() {
         let endpoint = format!("local://{}", temp.path().join("cas").display());
         let session = rt.block_on(async { XetSessionBuilder::new().build().unwrap() });
 
-        let payload = format!("{label} handle blocking roundtrip");
+        let payload = format!("{label} runtime blocking roundtrip");
         assert_roundtrip_sync(&session, &endpoint, &temp, payload.as_bytes(), &format!("{label}_blocking"));
     }
 }

--- a/xet_runtime/src/core/context.rs
+++ b/xet_runtime/src/core/context.rs
@@ -22,8 +22,10 @@ pub struct XetContext {
 
 impl XetContext {
     /// Creates a context from a pre-built thread pool and configuration.
-    pub fn new(config: XetConfig, runtime: Arc<XetRuntime>) -> Self {
-        let config = Arc::new(config);
+    ///
+    /// Accepts either a [`XetConfig`] or an `Arc<XetConfig>`.
+    pub fn new(config: impl Into<Arc<XetConfig>>, runtime: Arc<XetRuntime>) -> Self {
+        let config = config.into();
         let common = Arc::new(XetCommon::new(&config));
         Self {
             runtime,
@@ -44,9 +46,12 @@ impl XetContext {
 
     /// Creates a context with the given configuration and an auto-detected thread pool.
     ///
+    /// Accepts either a [`XetConfig`] or an `Arc<XetConfig>`.
+    ///
     /// Follows the same runtime selection as [`default`](Self::default):
     /// reuse an owned runtime if available, wrap an existing tokio handle, or create a new one.
-    pub fn with_config(config: XetConfig) -> Result<Self, RuntimeError> {
+    pub fn with_config(config: impl Into<Arc<XetConfig>>) -> Result<Self, RuntimeError> {
+        let config = config.into();
         let runtime = if let Some(runtime) = XetRuntime::current_if_exists() {
             runtime
         } else if let Ok(handle) = TokioRuntimeHandle::try_current()
@@ -63,8 +68,25 @@ impl XetContext {
     }
 
     /// Wraps a caller-provided tokio handle with the given configuration.
-    pub fn from_external(rt_handle: TokioRuntimeHandle, config: XetConfig) -> Self {
+    ///
+    /// Accepts either a [`XetConfig`] or an `Arc<XetConfig>`.
+    pub fn from_external(rt_handle: TokioRuntimeHandle, config: impl Into<Arc<XetConfig>>) -> Self {
         Self::new(config, XetRuntime::from_external(rt_handle))
+    }
+
+    /// Returns a clone of this context with the configuration replaced.
+    ///
+    /// The runtime and shared `common` state (including its caches, such as the
+    /// shard-file managers) are shared with the original context; only the
+    /// configuration is swapped.  Note that `common` was sized from the original
+    /// configuration, so config fields that only affect `common` at construction
+    /// time (e.g. concurrency-limit semaphores) are not re-applied.
+    pub fn with_new_config(&self, config: impl Into<Arc<XetConfig>>) -> Self {
+        Self {
+            runtime: self.runtime.clone(),
+            config: config.into(),
+            common: self.common.clone(),
+        }
     }
 
     /// Checks whether a tokio handle meets the requirements for use with xet.
@@ -90,5 +112,29 @@ impl std::fmt::Debug for XetContext {
             .field("config", &"...")
             .field("common", &"...")
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_with_new_config_replaces_config_only() {
+        let original_config = Arc::new(XetConfig::new());
+        let runtime = XetRuntime::new(&original_config).unwrap();
+        let context = XetContext::new(original_config.clone(), runtime);
+        let new_config = Arc::new(
+            XetConfig::new()
+                .with_config("data.default_cas_endpoint", "https://cas.example.com")
+                .unwrap(),
+        );
+
+        let updated = context.with_new_config(new_config.clone());
+
+        assert!(Arc::ptr_eq(&context.runtime, &updated.runtime));
+        assert!(Arc::ptr_eq(&context.common, &updated.common));
+        assert!(Arc::ptr_eq(&new_config, &updated.config));
+        assert!(!Arc::ptr_eq(&original_config, &updated.config));
     }
 }


### PR DESCRIPTION
The XetContext object is designed partly to enable control over shared runtime, config, and common resources between sessions, but this isn't fully reflected in the XetSessionBuilder API.  This PR simply adds this API polish to enable this. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking API removal (new_with_config, with_tokio_handle) and changed config() return type affect integrators; context/config precedence and shared common state can surprise callers tuning concurrency via config overrides.
> 
> **Overview**
> **`XetSessionBuilder`** is refactored to a consistent `with_*` API: **`new_with_config` is removed** (use `new().with_config(...)`), **`with_tokio_handle` is replaced by `with_runtime(Arc<XetRuntime>)`**, and **`with_context`** lets new sessions reuse an existing **`XetContext`** so runtime, config, and **`common`** (including shard-file manager caches) are shared instead of re-scanning the shard cache on every session.
> 
> **`XetSession`** gains **`context()`**, **`runtime()`**, and **`config()` now returns `Arc<XetConfig>`**. Build order: explicit context wins ( **`with_runtime` ignored** ); **`with_config` overrides** the context’s config via **`XetContext::with_new_config`** while keeping shared **`common`** (construction-time limits in **`common`** are not rebuilt).
> 
> **`XetContext`** constructors take **`impl Into<Arc<XetConfig>>`**; **`with_new_config`** is added. **`XetContext`** / **`XetRuntime`** are re-exported from **`xet::xet_session`**. Python **`hf_xet`** and docs/tests are updated accordingly; an **`api_changes`** note documents the migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec2cc73890b857d37af2925a28fabbaf221907b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->