### PR TITLE
fix: debug assertions for deserialized MerkleHashSubtree

### DIFF
--- a/xet_core_structures/src/merklehash/merkle_hash_subtree.rs
+++ b/xet_core_structures/src/merklehash/merkle_hash_subtree.rs
@@ -424,7 +424,9 @@ pub fn find_stable_end(nodes: &[Node]) -> Option<usize> {
 /// - `at_start`: `true` if this range begins at position 0 of the full chunk sequence (left boundary is known).
 /// - `at_end`: `true` if this range ends at the last chunk of the full sequence (right boundary is known).
 /// - `debug_chunks`: (debug builds only) the original level-0 chunks, retained to verify that `final_hash()` matches
-///   `aggregated_node_hash`.
+///   `aggregated_node_hash`. Populated by [`from_chunks`] and empty after [`deserialize`] (the chunk list is not
+///   recoverable from the hump). A merge keeps `debug_chunks` only when both operands tracked theirs; otherwise it is
+///   cleared so the partial list never drives a false-positive invariant check.
 #[derive(Clone, Debug)]
 pub struct MerkleHashSubtree {
     nodes: Vec<Node>,
@@ -644,6 +646,13 @@ impl MerkleHashSubtree {
             return Err(CoreError::InvalidArguments);
         }
 
+        // A subtree with nodes but no `debug_chunks` was deserialized rather than built
+        // via `from_chunks` (its chunk list is unrecoverable from the hump). Capture this
+        // for `self` now, before its node array is rebuilt below; see the `debug_chunks`
+        // merge block at the end of this function.
+        #[cfg(debug_assertions)]
+        let self_untracked = !self.nodes.is_empty() && self.debug_chunks.is_empty();
+
         let combined_at_start = self.at_start;
         let combined_at_end = other.at_end;
 
@@ -771,11 +780,20 @@ impl MerkleHashSubtree {
 
         #[cfg(debug_assertions)]
         {
-            self.debug_chunks.extend_from_slice(&other.debug_chunks);
+            // `debug_chunks` only reconstructs the full chunk list end-to-end when BOTH
+            // operands tracked theirs. If either side was deserialized (nodes present but
+            // no `debug_chunks`), the concatenation would be incomplete and
+            // `verify_invariants` would compare `final_hash()` (over the full merged tree)
+            // against `aggregated_node_hash` of a partial list — a guaranteed false
+            // positive. In that case, drop `debug_chunks` so the invariant disables itself.
+            let other_untracked = !other.nodes.is_empty() && other.debug_chunks.is_empty();
+            if self_untracked || other_untracked {
+                self.debug_chunks.clear();
+            } else {
+                self.debug_chunks.extend_from_slice(&other.debug_chunks);
+            }
+            self.verify_invariants();
         }
-
-        #[cfg(debug_assertions)]
-        self.verify_invariants();
 
         Ok(())
     }
@@ -1267,6 +1285,30 @@ mod tests {
             let r2 = MerkleHashSubtree::from_chunks(false, &chunks[split..], true);
             merged.merge_into(&r2).unwrap();
             assert_eq!(merged.final_hash().unwrap(), expected, "Failed split={split}");
+        }
+    }
+
+    /// Merging a `from_chunks`-built subtree with a deserialized one (whose `debug_chunks`
+    /// were stripped crossing the wire) must not trip the debug-only `verify_invariants`
+    /// check. Regression for a false positive where the invariant compared the full merged
+    /// `final_hash()` against `aggregated_node_hash` of only the tracked half.
+    #[test]
+    fn test_merge_with_deserialized_operand_no_false_positive() {
+        let mut rng = SmallRng::seed_from_u64(0xDE6B6F);
+        let chunks = random_chunks(&mut rng, 16);
+        let expected = xorb_hash(&chunks);
+
+        for split in 1..16 {
+            let left = MerkleHashSubtree::from_chunks(true, &chunks[..split], false);
+            let right = MerkleHashSubtree::from_chunks(false, &chunks[split..], true);
+
+            // Round-trip `right` through serde exactly as a CAS stable subtree does: the
+            // nodes survive, but `debug_chunks` is reset to empty on deserialize.
+            let right_wire: MerkleHashSubtree = serde_json::from_str(&serde_json::to_string(&right).unwrap()).unwrap();
+
+            let mut merged = left;
+            merged.merge_into(&right_wire).unwrap();
+            assert_eq!(merged.final_hash().unwrap(), expected, "split={split}");
         }
     }
 


### PR DESCRIPTION
Fixes a false-positive debug assertion in `MerkleHashSubtree` that panics when a
  subtree built via `from_chunks` is merged with one obtained by deserialization
  (e.g. a stable interior fetched from the Xet server over the wire).

  ## Background

  `MerkleHashSubtree` keeps a debug-only `debug_chunks` field and an end-to-end
  invariant check, `verify_invariants`, which asserts that `final_hash()` equals
  `aggregated_node_hash(debug_chunks)`. The field is populated by `from_chunks`
  but reset to empty by `deserialize`, thus the original chunk list is not recoverable
  from the compacted hump representation.

  `merge_into_impl` blindly concatenated `debug_chunks` from both operands. When
  one operand was deserialized (nodes present, `debug_chunks` empty), the merged
  `debug_chunks` held only the *tracked* half's chunks, while `final_hash()`
  correctly reflected the *full* merged tree. On the final fully-closed merge,
  `verify_invariants` then compared the correct full-tree hash against
  `aggregated_node_hash` of a partial chunk list and panicked:

      assertion `left == right` failed: MerkleHashSubtree invariant: final_hash mismatch.
      Num debug_chunks: 6, num_nodes: 1

  This surfaced in a downstream multipart-merge use case (S3 gateway) that stitches
  deserialized stable interiors from Xet server together with locally re-chunked dirty
  boundary runs. The produced hash was always correct, which was confirmed by running
  the affected integration tests in release mode (no `debug_assertions`) and validating with
  the file-hash of the full content. The panic was purely the debug-only invariant misfiring in debug builds.

  ## Fix

  `debug_chunks` reconstructs the full chunk list end-to-end only when **both**
  merge operands tracked theirs. When either side has nodes but no `debug_chunks`
  (i.e. was deserialized), the merged result drops `debug_chunks` entirely, so
  `verify_invariants` skips rather than comparing against a partial list. The
  invariant remains fully active for the all-`from_chunks` case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Debug-build-only invariant and test changes; production hashes and merge logic are unchanged.
> 
> **Overview**
> Fixes a **debug-only false panic** when merging a `from_chunks` `MerkleHashSubtree` with one that was **deserialized** (e.g. stable interior from CAS), where `debug_chunks` is empty but the hump `nodes` are intact.
> 
> `merge_into_impl` no longer always appends both operands’ `debug_chunks`. If either side has **nodes but no `debug_chunks`** (untracked / wire form), the merged result **clears** `debug_chunks` so `verify_invariants` skips instead of comparing `final_hash()` on the full tree to `aggregated_node_hash` on a **partial** chunk list. When **both** sides tracked chunks, behavior is unchanged and the invariant still runs.
> 
> Docs on `debug_chunks` describe deserialize vs merge behavior. A regression test serde-round-trips one merge operand and asserts merges still match the expected hash without tripping the invariant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d908904a5aa1295a7779ca44199277cda50ded98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->