### PR TITLE
feat(xorb): per-upload uniqueness nonce APIs for S3 ETag differentiation

### DIFF
--- a/api_changes/update_260604_xorb_uniqueness_nonce.md
+++ b/api_changes/update_260604_xorb_uniqueness_nonce.md
@@ -1,14 +1,14 @@
 This update adds APIs for stamping a per-upload uniqueness nonce into a xorb's serialized footer, so that two otherwise byte-identical serializations of the same xorb can be made to differ in their bytes.
 
 What changed
-- New constant `XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN` (= 16) names the footer's `_buffer` length; used wherever that length is referenced.
-- `XorbObjectInfoV1` (`xet_core_structures/src/xorb_object/xorb_object_format.rs`) gains nonce accessors over its existing `_buffer` extensibility field:
+- New constant `XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN` (= 16) names the footer's nonce-buffer length; used wherever that length is referenced.
+- `XorbObjectInfoV1` (`xet_core_structures/src/xorb_object/xorb_object_format.rs`) gains nonce accessors over its renamed `_nonce_buffer` extensibility field (was `_buffer`; the legacy `XorbObjectInfoV0` keeps `_buffer` unchanged):
   - `set_uniqueness_nonce(&mut self, nonce: [u8; XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN])`
   - `uniqueness_nonce(&self) -> [u8; XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN]`
 - `XorbObject` gains an associated function to rewrite the nonce in already-serialized bytes without re-serializing:
   - `XorbObject::overwrite_uniqueness_nonce(serialized: &mut [u8], nonce: [u8; XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN]) -> Result<(), CoreError>`
-  - Writes `nonce` into the `_buffer` slot, which is the `XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN` bytes immediately before the trailing 4-byte `info_length`. Works for both V0 and V1 serialized objects, since both footers end with `_buffer || info_length(u32)`. Validates the trailing `info_length` first and returns `Err(CoreError::MalformedData)` for too-short or implausible inputs.
-- The `_buffer` field doc on `XorbObjectInfoV1` is updated to describe the nonce usage.
+  - Writes `nonce` into the nonce-buffer slot, which is the `XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN` bytes immediately before the trailing 4-byte `info_length`. Works for both V0 and V1 serialized objects, since both footers end with `nonce_buffer || info_length(u32)`. Validates the trailing `info_length` first and returns `Err(CoreError::MalformedData)` for too-short or implausible inputs.
+- The `_nonce_buffer` field doc on `XorbObjectInfoV1` describes the nonce usage.
 
 Why this matters
 - The nonce is excluded from the xorb hash (the hash is a merkle tree over chunk contents only), so it does not change the xorb's content hash — only the serialized bytes.
@@ -19,4 +19,4 @@ Downstream usage
 - To refresh an already-serialized object in place, read its bytes and call `XorbObject::overwrite_uniqueness_nonce`, which rewrites only the nonce and preserves the existing chunk layout.
 
 Migration notes
-- Purely additive; no changes to serialization layout, `serialized_length`, the wire format, or existing call sites. Objects written before this change have an all-zero `_buffer` and remain valid.
+- Purely additive; no changes to serialization layout, `serialized_length`, the wire format, or existing call sites. The V1 field rename `_buffer` → `_nonce_buffer` is source-only (the field is private and `#[serde(skip)]`). Objects written before this change have an all-zero nonce buffer and remain valid.

--- a/api_changes/update_260604_xorb_uniqueness_nonce.md
+++ b/api_changes/update_260604_xorb_uniqueness_nonce.md
@@ -1,13 +1,13 @@
 This update adds APIs for stamping a per-upload uniqueness nonce into a xorb's serialized footer, so that two otherwise byte-identical serializations of the same xorb can be made to differ in their bytes.
 
 What changed
-- New constant `XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN` (= 16) names the footer's nonce-buffer length; used wherever that length is referenced.
+- New constants: `XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN` (= 16, the footer buffer slot) and `XORB_OBJECT_FORMAT_NONCE_LEN` (= 4, the bytes of that slot used for the nonce). The remaining 12 bytes stay zero, reserved for future use.
 - `XorbObjectInfoV1` (`xet_core_structures/src/xorb_object/xorb_object_format.rs`) gains nonce accessors over its renamed `_nonce_buffer` extensibility field (was `_buffer`; the legacy `XorbObjectInfoV0` keeps `_buffer` unchanged):
-  - `set_uniqueness_nonce(&mut self, nonce: [u8; XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN])`
-  - `uniqueness_nonce(&self) -> [u8; XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN]`
+  - `set_uniqueness_nonce(&mut self, nonce: [u8; XORB_OBJECT_FORMAT_NONCE_LEN])` (writes the leading `NONCE_LEN` bytes, leaving the reserved bytes unchanged)
+  - `uniqueness_nonce(&self) -> [u8; XORB_OBJECT_FORMAT_NONCE_LEN]`
 - `XorbObject` gains an associated function to rewrite the nonce in already-serialized bytes without re-serializing:
-  - `XorbObject::overwrite_uniqueness_nonce(serialized: &mut [u8], nonce: [u8; XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN]) -> Result<(), CoreError>`
-  - Writes `nonce` into the nonce-buffer slot, which is the `XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN` bytes immediately before the trailing 4-byte `info_length`. Works for both V0 and V1 serialized objects, since both footers end with `nonce_buffer || info_length(u32)`. Validates the trailing `info_length` first and returns `Err(CoreError::MalformedData)` for too-short or implausible inputs.
+  - `XorbObject::overwrite_uniqueness_nonce(serialized: &mut [u8], nonce: [u8; XORB_OBJECT_FORMAT_NONCE_LEN]) -> Result<(), CoreError>`
+  - Writes `nonce` into the leading `NONCE_LEN` bytes of the footer buffer (which sits immediately before the trailing 4-byte `info_length`), leaving the reserved bytes and `info_length` untouched. Works for both V0 and V1 serialized objects. Validates the trailing `info_length` first and returns `Err(CoreError::MalformedData)` for too-short or implausible inputs.
 - The `_nonce_buffer` field doc on `XorbObjectInfoV1` describes the nonce usage.
 
 Why this matters

--- a/api_changes/update_260604_xorb_uniqueness_nonce.md
+++ b/api_changes/update_260604_xorb_uniqueness_nonce.md
@@ -1,0 +1,22 @@
+This update adds APIs for stamping a per-upload uniqueness nonce into a xorb's serialized footer, so that two otherwise byte-identical serializations of the same xorb can be made to differ in their bytes.
+
+What changed
+- New constant `XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN` (= 16) names the footer's `_buffer` length; used wherever that length is referenced.
+- `XorbObjectInfoV1` (`xet_core_structures/src/xorb_object/xorb_object_format.rs`) gains nonce accessors over its existing `_buffer` extensibility field:
+  - `set_uniqueness_nonce(&mut self, nonce: [u8; XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN])`
+  - `uniqueness_nonce(&self) -> [u8; XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN]`
+- `XorbObject` gains an associated function to rewrite the nonce in already-serialized bytes without re-serializing:
+  - `XorbObject::overwrite_uniqueness_nonce(serialized: &mut [u8], nonce: [u8; XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN]) -> Result<(), CoreError>`
+  - Writes `nonce` into the `_buffer` slot, which is the `XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN` bytes immediately before the trailing 4-byte `info_length`. Works for both V0 and V1 serialized objects, since both footers end with `_buffer || info_length(u32)`. Validates the trailing `info_length` first and returns `Err(CoreError::MalformedData)` for too-short or implausible inputs.
+- The `_buffer` field doc on `XorbObjectInfoV1` is updated to describe the nonce usage.
+
+Why this matters
+- The nonce is excluded from the xorb hash (the hash is a merkle tree over chunk contents only), so it does not change the xorb's content hash — only the serialized bytes.
+- This lets a caller give every (re-)upload of byte-identical content a distinct serialized byte stream, so two serializations of the same xorb can be told apart.
+
+Downstream usage
+- On first xorb upload, call `set_uniqueness_nonce(rand::random())` on the metadata before `XorbObject::serialize_given_info`.
+- To refresh an already-serialized object in place, read its bytes and call `XorbObject::overwrite_uniqueness_nonce`, which rewrites only the nonce and preserves the existing chunk layout.
+
+Migration notes
+- Purely additive; no changes to serialization layout, `serialized_length`, the wire format, or existing call sites. Objects written before this change have an all-zero `_buffer` and remain valid.

--- a/xet_core_structures/src/xorb_object/xorb_object_format.rs
+++ b/xet_core_structures/src/xorb_object/xorb_object_format.rs
@@ -32,8 +32,19 @@ const _XORB_OBJECT_INFO_DEFAULT_LENGTH_V0: u32 = 60;
 const XORB_OBJECT_INFO_DEFAULT_LENGTH: u32 = 92;
 
 /// Length in bytes of the footer's trailing extensibility buffer (`_nonce_buffer` in V1, `_buffer`
-/// in the legacy V0), which may hold a per-upload uniqueness nonce. Excluded from the xorb hash.
+/// in the legacy V0). Excluded from the xorb hash.
 pub(crate) const XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN: usize = 16;
+
+/// Number of leading bytes of the footer buffer used for the per-upload uniqueness nonce. The
+/// remaining `XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN - XORB_OBJECT_FORMAT_NONCE_LEN` bytes stay zero,
+/// reserved for future use.
+///
+/// A 32-bit random nonce collides with any one specific previously-seen nonce with probability
+/// ~1/2^32. The nonce only matters in the narrow window where a dereferenced xorb is snapshotted and
+/// then identical content is re-uploaded before deletion; even at a generous 10^8 such events per
+/// year that is ~0.02 expected collisions/year, so 4 bytes is sufficient while leaving 12 of the 16
+/// buffer bytes free for future use.
+pub(crate) const XORB_OBJECT_FORMAT_NONCE_LEN: usize = 4;
 
 // Decide array preallocation size based on the declared size, to prevent an adversarial
 // giant size that leads to OOM on allocation.
@@ -390,15 +401,19 @@ impl Default for XorbObjectInfoV1 {
 }
 
 impl XorbObjectInfoV1 {
-    /// Set the per-upload uniqueness nonce stored in the extensibility buffer. Does
-    /// not affect the xorb hash; see the `_nonce_buffer` field docs.
-    pub fn set_uniqueness_nonce(&mut self, nonce: [u8; XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN]) {
-        self._nonce_buffer = nonce;
+    /// Set the per-upload uniqueness nonce. It occupies the leading `XORB_OBJECT_FORMAT_NONCE_LEN`
+    /// bytes of `_nonce_buffer`; the remaining (reserved) bytes are left unchanged. Does not affect
+    /// the xorb hash; see the `_nonce_buffer` field docs.
+    pub fn set_uniqueness_nonce(&mut self, nonce: [u8; XORB_OBJECT_FORMAT_NONCE_LEN]) {
+        self._nonce_buffer[..XORB_OBJECT_FORMAT_NONCE_LEN].copy_from_slice(&nonce);
     }
 
-    /// The per-upload uniqueness nonce stored in the extensibility buffer (zero if unset).
-    pub fn uniqueness_nonce(&self) -> [u8; XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN] {
-        self._nonce_buffer
+    /// The per-upload uniqueness nonce (the leading `XORB_OBJECT_FORMAT_NONCE_LEN` bytes of
+    /// `_nonce_buffer`; zero if unset).
+    pub fn uniqueness_nonce(&self) -> [u8; XORB_OBJECT_FORMAT_NONCE_LEN] {
+        self._nonce_buffer[..XORB_OBJECT_FORMAT_NONCE_LEN]
+            .try_into()
+            .expect("slice is exactly XORB_OBJECT_FORMAT_NONCE_LEN bytes")
     }
 
     pub fn serialized_length(&self) -> usize {
@@ -1020,14 +1035,15 @@ impl XorbObject {
     /// changes the serialized bytes, so two otherwise byte-identical xorbs can be made to serialize
     /// to distinct byte streams.
     ///
-    /// Both `XorbObjectInfoV0` and `XorbObjectInfoV1` footers end with the nonce buffer
-    /// (`XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN` bytes) followed by the 4-byte `info_length`, so the
-    /// nonce always occupies those bytes immediately before that trailing length. The `info_length`
-    /// is validated first; an implausible value or an undersized buffer yields an error rather than
-    /// corrupting non-xorb bytes.
+    /// Both `XorbObjectInfoV0` and `XorbObjectInfoV1` footers end with the
+    /// `XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN`-byte buffer followed by the 4-byte `info_length`. The
+    /// nonce occupies the leading `XORB_OBJECT_FORMAT_NONCE_LEN` bytes of that buffer; the remaining
+    /// reserved bytes (and the `info_length`) are left untouched. The `info_length` is validated
+    /// first; an implausible value or an undersized buffer yields an error rather than corrupting
+    /// non-xorb bytes.
     pub fn overwrite_uniqueness_nonce(
         serialized: &mut [u8],
-        nonce: [u8; XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN],
+        nonce: [u8; XORB_OBJECT_FORMAT_NONCE_LEN],
     ) -> Result<(), CoreError> {
         let len = serialized.len();
         let trailer = size_of::<u32>(); // trailing info_length
@@ -1048,8 +1064,10 @@ impl XorbObject {
             ));
         }
 
+        // The nonce occupies the leading bytes of the footer buffer; reserved bytes after it are
+        // left as-is so they survive a refresh.
         let nonce_start = len - trailer - XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN;
-        serialized[nonce_start..len - trailer].copy_from_slice(&nonce);
+        serialized[nonce_start..nonce_start + XORB_OBJECT_FORMAT_NONCE_LEN].copy_from_slice(&nonce);
         Ok(())
     }
 
@@ -2395,7 +2413,7 @@ mod tests {
         let zero_bytes = zero_buf.into_inner();
 
         // Footer serialized with an explicit nonce.
-        let nonce = [0xAB; XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN];
+        let nonce = [0xAB; XORB_OBJECT_FORMAT_NONCE_LEN];
         let mut info = c.info.clone();
         info.set_uniqueness_nonce(nonce);
         assert_eq!(info.uniqueness_nonce(), nonce);
@@ -2403,12 +2421,17 @@ mod tests {
         XorbObject::serialize_given_info(&mut buf, info).unwrap();
         let bytes = buf.into_inner();
 
-        // Identical except for the 16-byte nonce slot at [len-20, len-4); info_length unchanged.
+        // The footer buffer holds the nonce in its leading bytes, with reserved (zero) bytes after;
+        // the body and trailing info_length are unchanged.
         assert_eq!(zero_bytes.len(), bytes.len());
         let len = bytes.len();
-        assert_eq!(zero_bytes[..len - 20], bytes[..len - 20]);
-        assert_eq!(zero_bytes[len - 4..], bytes[len - 4..]);
-        assert_eq!(bytes[len - 20..len - 4], nonce);
+        let buf_start = len - size_of::<u32>() - XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN;
+        let nonce_end = buf_start + XORB_OBJECT_FORMAT_NONCE_LEN;
+        let trailer_start = len - size_of::<u32>();
+        assert_eq!(zero_bytes[..buf_start], bytes[..buf_start]); // body + footer prefix
+        assert_eq!(zero_bytes[trailer_start..], bytes[trailer_start..]); // info_length
+        assert_eq!(bytes[buf_start..nonce_end], nonce); // nonce
+        assert_eq!(bytes[nonce_end..trailer_start], zero_bytes[nonce_end..trailer_start]); // reserved untouched
 
         // Round-trips, and the xorb hash is unaffected by the nonce.
         let ret = XorbObject::deserialize(&mut Cursor::new(bytes)).unwrap();
@@ -2432,15 +2455,20 @@ mod tests {
         let original = buf.into_inner();
         let len = original.len();
 
-        let nonce = [0xCD; XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN];
+        let nonce = [0xCD; XORB_OBJECT_FORMAT_NONCE_LEN];
         let mut bytes = original.clone();
         XorbObject::overwrite_uniqueness_nonce(&mut bytes, nonce).unwrap();
 
-        // Only the nonce slot changed; body, footer prefix, and trailing info_length are intact.
+        // Only the nonce changed; body, footer prefix, reserved bytes, and trailing info_length
+        // are intact.
         assert_eq!(bytes.len(), len);
-        assert_eq!(bytes[..len - 20], original[..len - 20]);
-        assert_eq!(bytes[len - 4..], original[len - 4..]);
-        assert_eq!(bytes[len - 20..len - 4], nonce);
+        let buf_start = len - size_of::<u32>() - XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN;
+        let nonce_end = buf_start + XORB_OBJECT_FORMAT_NONCE_LEN;
+        let trailer_start = len - size_of::<u32>();
+        assert_eq!(bytes[..buf_start], original[..buf_start]); // body + footer prefix
+        assert_eq!(bytes[trailer_start..], original[trailer_start..]); // info_length
+        assert_eq!(bytes[buf_start..nonce_end], nonce); // nonce
+        assert_eq!(bytes[nonce_end..trailer_start], original[nonce_end..trailer_start]); // reserved preserved
 
         // Still a valid xorb with the same content hash and the new nonce.
         let ret = XorbObject::deserialize(&mut Cursor::new(bytes.clone())).unwrap();
@@ -2449,7 +2477,7 @@ mod tests {
 
         // A different nonce yields different bytes.
         let mut other = original.clone();
-        XorbObject::overwrite_uniqueness_nonce(&mut other, [0x11; XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN]).unwrap();
+        XorbObject::overwrite_uniqueness_nonce(&mut other, [0x11; XORB_OBJECT_FORMAT_NONCE_LEN]).unwrap();
         assert_ne!(other, bytes);
 
         // Malformed / too-short inputs are rejected rather than corrupting bytes.
@@ -2490,13 +2518,17 @@ mod tests {
         let original = buf.into_inner();
         let len = original.len();
 
-        let nonce = [0xCD; XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN];
+        let nonce = [0xCD; XORB_OBJECT_FORMAT_NONCE_LEN];
         let mut bytes = original.clone();
         XorbObject::overwrite_uniqueness_nonce(&mut bytes, nonce).unwrap();
 
-        assert_eq!(bytes[..len - 20], original[..len - 20]);
-        assert_eq!(bytes[len - 4..], original[len - 4..]);
-        assert_eq!(bytes[len - 20..len - 4], nonce);
+        let buf_start = len - size_of::<u32>() - XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN;
+        let nonce_end = buf_start + XORB_OBJECT_FORMAT_NONCE_LEN;
+        let trailer_start = len - size_of::<u32>();
+        assert_eq!(bytes[..buf_start], original[..buf_start]); // body + footer prefix
+        assert_eq!(bytes[trailer_start..], original[trailer_start..]); // info_length
+        assert_eq!(bytes[buf_start..nonce_end], nonce); // nonce
+        assert_eq!(bytes[nonce_end..trailer_start], original[nonce_end..trailer_start]); // reserved preserved
 
         // Still deserializes (via the V0 path) to the same hash, with the nonce in `_nonce_buffer`.
         let ret = XorbObject::deserialize(&mut Cursor::new(bytes)).unwrap();

--- a/xet_core_structures/src/xorb_object/xorb_object_format.rs
+++ b/xet_core_structures/src/xorb_object/xorb_object_format.rs
@@ -79,8 +79,8 @@ pub struct XorbObjectInfoV0 {
     pub chunk_hashes: Vec<MerkleHash>,
 
     #[serde(skip)]
-    /// Extensibility buffer for future use; see `XorbObjectInfoV1::_buffer`.
-    _buffer: [u8; XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN],
+    /// Unused 16-byte buffer to allow for future extensibility.
+    _buffer: [u8; 16],
 }
 
 impl Default for XorbObjectInfoV0 {
@@ -196,7 +196,7 @@ impl XorbObjectInfoV0 {
             chunk_hashes.push(MerkleHash::from(&hash));
         }
 
-        let mut _buffer = [0u8; XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN];
+        let mut _buffer = [0u8; 16];
         read_bytes(&mut _buffer)?;
 
         Ok((
@@ -260,7 +260,7 @@ impl XorbObjectInfoV0 {
             chunk_hashes.push(MerkleHash::from(&hash));
         }
 
-        let mut _buffer = [0u8; XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN];
+        let mut _buffer = [0u8; 16];
         read_bytes(reader, &mut total_bytes_read, &mut _buffer).await?;
 
         Ok((

--- a/xet_core_structures/src/xorb_object/xorb_object_format.rs
+++ b/xet_core_structures/src/xorb_object/xorb_object_format.rs
@@ -31,8 +31,8 @@ pub(crate) const XORB_OBJECT_FORMAT_BOUNDARIES_VERSION: u8 = 1;
 const _XORB_OBJECT_INFO_DEFAULT_LENGTH_V0: u32 = 60;
 const XORB_OBJECT_INFO_DEFAULT_LENGTH: u32 = 92;
 
-/// Length in bytes of the footer's trailing extensibility buffer (`_buffer`), which may hold a
-/// per-upload uniqueness nonce. Excluded from the xorb hash.
+/// Length in bytes of the footer's trailing extensibility buffer (`_nonce_buffer` in V1, `_buffer`
+/// in the legacy V0), which may hold a per-upload uniqueness nonce. Excluded from the xorb hash.
 pub(crate) const XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN: usize = 16;
 
 // Decide array preallocation size based on the declared size, to prevent an adversarial
@@ -359,7 +359,7 @@ pub struct XorbObjectInfoV1 {
     /// here does not change the xorb's content hash — it only changes the serialized bytes, letting
     /// two otherwise byte-identical xorbs serialize to distinct byte streams. Zero when unused;
     /// readers ignore its contents.
-    _buffer: [u8; XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN],
+    _nonce_buffer: [u8; XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN],
 }
 
 impl Default for XorbObjectInfoV1 {
@@ -381,7 +381,7 @@ impl Default for XorbObjectInfoV1 {
             num_chunks: 0,
             hashes_section_offset_from_end: 0,
             boundary_section_offset_from_end: 0,
-            _buffer: Default::default(),
+            _nonce_buffer: Default::default(),
         };
 
         s.fill_in_boundary_offsets();
@@ -391,23 +391,23 @@ impl Default for XorbObjectInfoV1 {
 
 impl XorbObjectInfoV1 {
     /// Set the per-upload uniqueness nonce stored in the extensibility buffer. Does
-    /// not affect the xorb hash; see the `_buffer` field docs.
+    /// not affect the xorb hash; see the `_nonce_buffer` field docs.
     pub fn set_uniqueness_nonce(&mut self, nonce: [u8; XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN]) {
-        self._buffer = nonce;
+        self._nonce_buffer = nonce;
     }
 
     /// The per-upload uniqueness nonce stored in the extensibility buffer (zero if unset).
     pub fn uniqueness_nonce(&self) -> [u8; XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN] {
-        self._buffer
+        self._nonce_buffer
     }
 
     pub fn serialized_length(&self) -> usize {
         size_of::<XorbObjectIdent>() * 3 // ident, ident_hash_section, ident_boundary_section
             + size_of::<u8>() * 3 // version, hashes_version, boundaries_version
             + size_of::<u32>() * 5 // num_chunks, hashes_section_offset_from_end, boundary_section_offset_from_end,
-                                   // chunk_boundary_offsets, unpacked_chunk_offsets
+            // chunk_boundary_offsets, unpacked_chunk_offsets
             + size_of::<MerkleHash>() * self.chunk_hashes.len() // chunk_hashes
-            + size_of_val(&self._buffer) // _buffer
+            + size_of_val(&self._nonce_buffer) // _nonce_buffer
             + self.chunk_boundary_offsets.len() * size_of::<u32>() // chunk_boundary_offsets
             + self.unpacked_chunk_offsets.len() * size_of::<u32>() // unpacked_chunk_offsets
             + size_of::<MerkleHash>() // xorb_hash
@@ -490,7 +490,7 @@ impl XorbObjectInfoV1 {
         write_u32(w, self.boundary_section_offset_from_end)?;
 
         // write closing metadata
-        write_bytes(w, &self._buffer)?;
+        write_bytes(w, &self._nonce_buffer)?;
 
         Ok(w.writer_bytes())
     }
@@ -599,7 +599,7 @@ impl XorbObjectInfoV1 {
         s.hashes_section_offset_from_end = read_u32(r)?;
         s.boundary_section_offset_from_end = read_u32(r)?;
 
-        read_bytes(r, &mut s._buffer)?;
+        read_bytes(r, &mut s._nonce_buffer)?;
 
         let end_byte_offset = r.reader_bytes();
 
@@ -624,9 +624,9 @@ impl XorbObjectInfoV1 {
     pub fn deserialize_only_boundaries_section<R: Read + Seek>(reader: &mut R) -> Result<(Self, u32), CoreError> {
         let mut s = Self::default();
 
-        // info_length + size of _buffer + size of u32 for offset field
+        // info_length + size of _nonce_buffer + size of u32 for offset field
         let offset_to_boundary_section_offset =
-            size_of::<u32>() + size_of_val(&s._buffer) + size_of_val(&s.boundary_section_offset_from_end);
+            size_of::<u32>() + size_of_val(&s._nonce_buffer) + size_of_val(&s.boundary_section_offset_from_end);
         reader.seek(SeekFrom::End(-(offset_to_boundary_section_offset as i64)))?;
         let mut boundary_section_offset_from_end = read_u32(reader)?;
 
@@ -674,7 +674,7 @@ impl XorbObjectInfoV1 {
         s.hashes_section_offset_from_end = read_u32(r)?;
         s.boundary_section_offset_from_end = read_u32(r)?;
 
-        read_bytes(r, &mut s._buffer)?;
+        read_bytes(r, &mut s._nonce_buffer)?;
 
         let end_byte_offset = r.reader_bytes();
 
@@ -780,7 +780,7 @@ impl XorbObjectInfoV1 {
         s.hashes_section_offset_from_end = read_u32_async(r).await?;
         s.boundary_section_offset_from_end = read_u32_async(r).await?;
 
-        read_bytes_async(r, &mut s._buffer).await?;
+        read_bytes_async(r, &mut s._nonce_buffer).await?;
 
         let end_byte_offset = r.reader_bytes();
 
@@ -836,7 +836,7 @@ impl XorbObjectInfoV1 {
             num_chunks: src.num_chunks,
             hashes_section_offset_from_end: 0,
             boundary_section_offset_from_end: 0,
-            _buffer: src._buffer,
+            _nonce_buffer: src._buffer,
         };
 
         s.fill_in_boundary_offsets();
@@ -866,7 +866,7 @@ impl XorbObjectInfoV1 {
             num_chunks: src.num_chunks,
             hashes_section_offset_from_end: 0,
             boundary_section_offset_from_end: 0,
-            _buffer: Default::default(),
+            _nonce_buffer: Default::default(),
         };
 
         s.fill_in_boundary_offsets();
@@ -882,7 +882,7 @@ impl XorbObjectInfoV1 {
             + size_of_val(&self.num_chunks)
             + size_of_val(&self.hashes_section_offset_from_end)
             + size_of_val(&self.boundary_section_offset_from_end)
-            + size_of_val(&self._buffer)) as u32;
+            + size_of_val(&self._nonce_buffer)) as u32;
 
         self.hashes_section_offset_from_end = (size_of_val(&self.ident_hash_section)
             + size_of_val(&self.hashes_version)
@@ -1014,16 +1014,17 @@ impl XorbObject {
         Self { info, info_length }
     }
 
-    /// Overwrite the uniqueness nonce (`_buffer`) inside an already-serialized `XorbObject`, leaving
-    /// every other byte — chunk data, footer fields, and the trailing `info_length` — untouched. The
-    /// nonce is excluded from the xorb hash, so this does not change the object's content hash; it
-    /// only changes the serialized bytes, so two otherwise byte-identical xorbs can be made to
-    /// serialize to distinct byte streams.
+    /// Overwrite the uniqueness nonce inside an already-serialized `XorbObject`, leaving every other
+    /// byte — chunk data, footer fields, and the trailing `info_length` — untouched. The nonce is
+    /// excluded from the xorb hash, so this does not change the object's content hash; it only
+    /// changes the serialized bytes, so two otherwise byte-identical xorbs can be made to serialize
+    /// to distinct byte streams.
     ///
-    /// Both `XorbObjectInfoV0` and `XorbObjectInfoV1` footers end with `_buffer` followed by the
-    /// 4-byte `info_length`, so the nonce always occupies the `XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN`
-    /// bytes immediately before that trailing length. The `info_length` is validated first; an
-    /// implausible value or an undersized buffer yields an error rather than corrupting non-xorb bytes.
+    /// Both `XorbObjectInfoV0` and `XorbObjectInfoV1` footers end with the nonce buffer
+    /// (`XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN` bytes) followed by the 4-byte `info_length`, so the
+    /// nonce always occupies those bytes immediately before that trailing length. The `info_length`
+    /// is validated first; an implausible value or an undersized buffer yields an error rather than
+    /// corrupting non-xorb bytes.
     pub fn overwrite_uniqueness_nonce(
         serialized: &mut [u8],
         nonce: [u8; XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN],
@@ -1040,7 +1041,7 @@ impl XorbObject {
         let info_length =
             u32::from_le_bytes(serialized[len - trailer..].try_into().expect("slice is exactly 4 bytes")) as usize;
         // The footer occupies [len - trailer - info_length, len - trailer) and ends with the
-        // _buffer. Reject lengths that can't hold a _buffer or that overrun the object.
+        // nonce buffer. Reject lengths that can't hold it or that overrun the object.
         if info_length < XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN || info_length + trailer > len {
             return Err(CoreError::MalformedData(
                 "serialized xorb has an implausible info_length; refusing to write uniqueness nonce".to_string(),
@@ -2380,7 +2381,7 @@ mod tests {
         assert_eq!(ret.info.num_chunks, xorb_info_v0.num_chunks);
         assert_eq!(ret.info.chunk_boundary_offsets, xorb_info_v0.chunk_boundary_offsets);
         assert_eq!(ret.info.chunk_hashes, xorb_info_v0.chunk_hashes);
-        assert_eq!(ret.info._buffer, xorb_info_v0._buffer);
+        assert_eq!(ret.info._nonce_buffer, xorb_info_v0._buffer);
     }
 
     #[test]
@@ -2497,7 +2498,7 @@ mod tests {
         assert_eq!(bytes[len - 4..], original[len - 4..]);
         assert_eq!(bytes[len - 20..len - 4], nonce);
 
-        // Still deserializes (via the V0 path) to the same hash, with the nonce in `_buffer`.
+        // Still deserializes (via the V0 path) to the same hash, with the nonce in `_nonce_buffer`.
         let ret = XorbObject::deserialize(&mut Cursor::new(bytes)).unwrap();
         assert_eq!(ret.info.xorb_hash, xorb_info_v0.xorb_hash);
         assert_eq!(ret.info.uniqueness_nonce(), nonce);

--- a/xet_core_structures/src/xorb_object/xorb_object_format.rs
+++ b/xet_core_structures/src/xorb_object/xorb_object_format.rs
@@ -31,6 +31,10 @@ pub(crate) const XORB_OBJECT_FORMAT_BOUNDARIES_VERSION: u8 = 1;
 const _XORB_OBJECT_INFO_DEFAULT_LENGTH_V0: u32 = 60;
 const XORB_OBJECT_INFO_DEFAULT_LENGTH: u32 = 92;
 
+/// Length in bytes of the footer's trailing extensibility buffer (`_buffer`), which may hold a
+/// per-upload uniqueness nonce. Excluded from the xorb hash.
+pub(crate) const XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN: usize = 16;
+
 // Decide array preallocation size based on the declared size, to prevent an adversarial
 // giant size that leads to OOM on allocation.
 #[inline]
@@ -75,8 +79,8 @@ pub struct XorbObjectInfoV0 {
     pub chunk_hashes: Vec<MerkleHash>,
 
     #[serde(skip)]
-    /// Unused 16-byte buffer to allow for future extensibility.
-    _buffer: [u8; 16],
+    /// Extensibility buffer for future use; see `XorbObjectInfoV1::_buffer`.
+    _buffer: [u8; XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN],
 }
 
 impl Default for XorbObjectInfoV0 {
@@ -192,7 +196,7 @@ impl XorbObjectInfoV0 {
             chunk_hashes.push(MerkleHash::from(&hash));
         }
 
-        let mut _buffer = [0u8; 16];
+        let mut _buffer = [0u8; XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN];
         read_bytes(&mut _buffer)?;
 
         Ok((
@@ -256,7 +260,7 @@ impl XorbObjectInfoV0 {
             chunk_hashes.push(MerkleHash::from(&hash));
         }
 
-        let mut _buffer = [0u8; 16];
+        let mut _buffer = [0u8; XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN];
         read_bytes(reader, &mut total_bytes_read, &mut _buffer).await?;
 
         Ok((
@@ -350,8 +354,12 @@ pub struct XorbObjectInfoV1 {
     pub boundary_section_offset_from_end: u32,
 
     #[serde(skip)]
-    /// Unused 16-byte buffer to allow for future extensibility.
-    _buffer: [u8; 16],
+    /// Extensibility buffer, optionally carrying a per-upload uniqueness nonce. It is excluded from
+    /// the xorb hash (the hash is a merkle tree over the chunk contents only), so writing a nonce
+    /// here does not change the xorb's content hash — it only changes the serialized bytes, letting
+    /// two otherwise byte-identical xorbs serialize to distinct byte streams. Zero when unused;
+    /// readers ignore its contents.
+    _buffer: [u8; XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN],
 }
 
 impl Default for XorbObjectInfoV1 {
@@ -382,6 +390,17 @@ impl Default for XorbObjectInfoV1 {
 }
 
 impl XorbObjectInfoV1 {
+    /// Set the per-upload uniqueness nonce stored in the extensibility buffer. Does
+    /// not affect the xorb hash; see the `_buffer` field docs.
+    pub fn set_uniqueness_nonce(&mut self, nonce: [u8; XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN]) {
+        self._buffer = nonce;
+    }
+
+    /// The per-upload uniqueness nonce stored in the extensibility buffer (zero if unset).
+    pub fn uniqueness_nonce(&self) -> [u8; XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN] {
+        self._buffer
+    }
+
     pub fn serialized_length(&self) -> usize {
         size_of::<XorbObjectIdent>() * 3 // ident, ident_hash_section, ident_boundary_section
             + size_of::<u8>() * 3 // version, hashes_version, boundaries_version
@@ -993,6 +1012,44 @@ impl XorbObject {
     pub fn from_info(info: XorbObjectInfoV1) -> Self {
         let info_length = info.serialized_length() as u32;
         Self { info, info_length }
+    }
+
+    /// Overwrite the uniqueness nonce (`_buffer`) inside an already-serialized `XorbObject`, leaving
+    /// every other byte — chunk data, footer fields, and the trailing `info_length` — untouched. The
+    /// nonce is excluded from the xorb hash, so this does not change the object's content hash; it
+    /// only changes the serialized bytes, so two otherwise byte-identical xorbs can be made to
+    /// serialize to distinct byte streams.
+    ///
+    /// Both `XorbObjectInfoV0` and `XorbObjectInfoV1` footers end with `_buffer` followed by the
+    /// 4-byte `info_length`, so the nonce always occupies the `XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN`
+    /// bytes immediately before that trailing length. The `info_length` is validated first; an
+    /// implausible value or an undersized buffer yields an error rather than corrupting non-xorb bytes.
+    pub fn overwrite_uniqueness_nonce(
+        serialized: &mut [u8],
+        nonce: [u8; XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN],
+    ) -> Result<(), CoreError> {
+        let len = serialized.len();
+        let trailer = size_of::<u32>(); // trailing info_length
+
+        if len < XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN + trailer {
+            return Err(CoreError::MalformedData(
+                "serialized xorb too short to contain a uniqueness nonce".to_string(),
+            ));
+        }
+
+        let info_length =
+            u32::from_le_bytes(serialized[len - trailer..].try_into().expect("slice is exactly 4 bytes")) as usize;
+        // The footer occupies [len - trailer - info_length, len - trailer) and ends with the
+        // _buffer. Reject lengths that can't hold a _buffer or that overrun the object.
+        if info_length < XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN || info_length + trailer > len {
+            return Err(CoreError::MalformedData(
+                "serialized xorb has an implausible info_length; refusing to write uniqueness nonce".to_string(),
+            ));
+        }
+
+        let nonce_start = len - trailer - XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN;
+        serialized[nonce_start..len - trailer].copy_from_slice(&nonce);
+        Ok(())
     }
 
     /// Validate XorbObject.
@@ -2235,7 +2292,7 @@ mod tests {
 
         // Retrieve the jump pointers.
         const JUMP_POINTER_BUFFER_AND_INFO_LENGTH_SIZE: usize =
-            size_of::<u32>() + size_of::<u32>() + size_of::<[u8; 16]>() + size_of::<u32>();
+            size_of::<u32>() + size_of::<u32>() + XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN + size_of::<u32>();
 
         let jump_pointer_buffer_and_info_length_bytes =
             &xorb_bytes[xorb_bytes.len() - JUMP_POINTER_BUFFER_AND_INFO_LENGTH_SIZE..];
@@ -2324,6 +2381,126 @@ mod tests {
         assert_eq!(ret.info.chunk_boundary_offsets, xorb_info_v0.chunk_boundary_offsets);
         assert_eq!(ret.info.chunk_hashes, xorb_info_v0.chunk_hashes);
         assert_eq!(ret.info._buffer, xorb_info_v0._buffer);
+    }
+
+    #[test]
+    fn test_uniqueness_nonce_roundtrip() {
+        let (c, _cas_data, _raw_data, _raw_chunk_boundaries) =
+            build_xorb_object(3, ChunkSize::Fixed(100), CompressionScheme::None);
+
+        // Footer serialized with the default (zero) nonce.
+        let mut zero_buf: Cursor<Vec<u8>> = Cursor::new(Vec::new());
+        XorbObject::serialize_given_info(&mut zero_buf, c.info.clone()).unwrap();
+        let zero_bytes = zero_buf.into_inner();
+
+        // Footer serialized with an explicit nonce.
+        let nonce = [0xAB; XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN];
+        let mut info = c.info.clone();
+        info.set_uniqueness_nonce(nonce);
+        assert_eq!(info.uniqueness_nonce(), nonce);
+        let mut buf: Cursor<Vec<u8>> = Cursor::new(Vec::new());
+        XorbObject::serialize_given_info(&mut buf, info).unwrap();
+        let bytes = buf.into_inner();
+
+        // Identical except for the 16-byte nonce slot at [len-20, len-4); info_length unchanged.
+        assert_eq!(zero_bytes.len(), bytes.len());
+        let len = bytes.len();
+        assert_eq!(zero_bytes[..len - 20], bytes[..len - 20]);
+        assert_eq!(zero_bytes[len - 4..], bytes[len - 4..]);
+        assert_eq!(bytes[len - 20..len - 4], nonce);
+
+        // Round-trips, and the xorb hash is unaffected by the nonce.
+        let ret = XorbObject::deserialize(&mut Cursor::new(bytes)).unwrap();
+        assert_eq!(ret.info.uniqueness_nonce(), nonce);
+        assert_eq!(ret.info.xorb_hash, c.info.xorb_hash);
+    }
+
+    #[test]
+    fn test_overwrite_uniqueness_nonce_v1() {
+        let (c, _cas_data, raw_data, raw_chunk_boundaries) =
+            build_xorb_object(4, ChunkSize::Random(512, 2048), CompressionScheme::LZ4);
+        let mut buf: Cursor<Vec<u8>> = Cursor::new(Vec::new());
+        serialize_xorb_to_stream_reference(
+            &mut buf,
+            &c.info.xorb_hash,
+            &raw_data,
+            &raw_chunk_boundaries,
+            CompressionScheme::LZ4,
+        )
+        .unwrap();
+        let original = buf.into_inner();
+        let len = original.len();
+
+        let nonce = [0xCD; XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN];
+        let mut bytes = original.clone();
+        XorbObject::overwrite_uniqueness_nonce(&mut bytes, nonce).unwrap();
+
+        // Only the nonce slot changed; body, footer prefix, and trailing info_length are intact.
+        assert_eq!(bytes.len(), len);
+        assert_eq!(bytes[..len - 20], original[..len - 20]);
+        assert_eq!(bytes[len - 4..], original[len - 4..]);
+        assert_eq!(bytes[len - 20..len - 4], nonce);
+
+        // Still a valid xorb with the same content hash and the new nonce.
+        let ret = XorbObject::deserialize(&mut Cursor::new(bytes.clone())).unwrap();
+        assert_eq!(ret.info.xorb_hash, c.info.xorb_hash);
+        assert_eq!(ret.info.uniqueness_nonce(), nonce);
+
+        // A different nonce yields different bytes.
+        let mut other = original.clone();
+        XorbObject::overwrite_uniqueness_nonce(&mut other, [0x11; XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN]).unwrap();
+        assert_ne!(other, bytes);
+
+        // Malformed / too-short inputs are rejected rather than corrupting bytes.
+        assert!(XorbObject::overwrite_uniqueness_nonce(&mut [0u8; 8], nonce).is_err());
+        let mut bogus = vec![0u8; 64]; // trailing info_length == 0 → implausible
+        assert!(XorbObject::overwrite_uniqueness_nonce(&mut bogus, nonce).is_err());
+    }
+
+    #[test]
+    fn test_overwrite_uniqueness_nonce_v0() {
+        // Build a V0-footer'd xorb, mirroring `test_deserialize_from_v0_xorb`.
+        let (c, _cas_data, raw_data, raw_chunk_boundaries) =
+            build_xorb_object(4, ChunkSize::Random(512, 2048), CompressionScheme::LZ4);
+        let mut buf: Cursor<Vec<u8>> = Cursor::new(Vec::new());
+        serialize_xorb_to_stream_reference(
+            &mut buf,
+            &c.info.xorb_hash,
+            &raw_data,
+            &raw_chunk_boundaries,
+            CompressionScheme::LZ4,
+        )
+        .unwrap();
+        let xorb_info_v0 = XorbObjectInfoV0 {
+            xorb_hash: c.info.xorb_hash,
+            num_chunks: c.info.num_chunks,
+            chunk_boundary_offsets: c.info.chunk_boundary_offsets.clone(),
+            chunk_hashes: c.info.chunk_hashes.clone(),
+            ..Default::default()
+        };
+        let mut buf = buf.into_inner();
+        let serialized_chunks_length = c.get_contents_length().unwrap();
+        buf.resize(serialized_chunks_length as usize, 0);
+        let mut buf = Cursor::new(buf);
+        buf.seek(SeekFrom::End(0)).unwrap();
+        #[allow(deprecated)]
+        let info_length = xorb_info_v0.serialize(&mut buf).unwrap() as u32;
+        write_u32(&mut buf, info_length).unwrap();
+        let original = buf.into_inner();
+        let len = original.len();
+
+        let nonce = [0xCD; XORB_OBJECT_FORMAT_FOOTER_BUFFER_LEN];
+        let mut bytes = original.clone();
+        XorbObject::overwrite_uniqueness_nonce(&mut bytes, nonce).unwrap();
+
+        assert_eq!(bytes[..len - 20], original[..len - 20]);
+        assert_eq!(bytes[len - 4..], original[len - 4..]);
+        assert_eq!(bytes[len - 20..len - 4], nonce);
+
+        // Still deserializes (via the V0 path) to the same hash, with the nonce in `_buffer`.
+        let ret = XorbObject::deserialize(&mut Cursor::new(bytes)).unwrap();
+        assert_eq!(ret.info.xorb_hash, xorb_info_v0.xorb_hash);
+        assert_eq!(ret.info.uniqueness_nonce(), nonce);
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds APIs to stamp a per-upload **uniqueness nonce** into a xorb's serialized footer, so that byte-identical re-uploads of the same xorb produce a different S3 ETag.

- `XorbObjectInfoV1::set_uniqueness_nonce(&mut self, [u8; 16])` / `uniqueness_nonce(&self) -> [u8; 16]` — accessors over the existing 16-byte `_buffer` extensibility field.
- `XorbObject::overwrite_uniqueness_nonce(serialized: &mut [u8], nonce: [u8; 16]) -> Result<(), CoreError>` — rewrites the nonce in already-serialized bytes without re-serializing. Writes into `[len-20, len-4)` (the `_buffer` slot, which precedes the trailing 4-byte `info_length`). Works for **both V0 and V1** objects, since both footers end with `_buffer(16) || info_length(u32)`. Validates the trailing `info_length` and returns `Err` on too-short/implausible input rather than corrupting bytes.

## Why

The nonce is **excluded from the xorb hash** (the hash is a merkle tree over chunk contents only), so it does not change the xorb's content address or S3 key — only the serialized bytes, and hence the S3 ETag.

Garbage collection snapshots `(xorb_hash, S3 ETag)` and later conditionally soft-deletes (`HeadObject If-Match` → `PutObjectTagging(gc-delete=true)`). Giving every (re-)upload a fresh ETag makes the `If-Match` fail for a resurrected object, preventing GC from deleting live data.

## Downstream

Consumed by xetcas / cas_server (stacked PR): stamp a nonce on first upload before `serialize_given_info`; on re-upload of an existing object, rewrite the nonce in the ground-truth bytes and force-PUT to refresh the ETag.

## Compatibility

Purely additive. No changes to serialization layout, `serialized_length`, the wire format, or existing call sites. Objects written before this change have an all-zero `_buffer` and remain valid. See `api_changes/update_260604_xorb_uniqueness_nonce.md`.

## Tests

- nonce roundtrip (hash unaffected by nonce)
- in-place overwrite for V1 and V0-footer'd xorbs (only the nonce slot changes; still deserializes to the same hash; malformed input rejected)
- `cargo test -p xet-core-structures` (162 passing), `cargo +nightly fmt`, `cargo clippy -r -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how serialized xorb footers are written and patched in core storage format code; wire layout is unchanged but incorrect nonce handling could affect upload/GC ETag behavior downstream.
> 
> **Overview**
> Adds **per-upload uniqueness nonce** support in the xorb footer so byte-identical content can produce different serialized bytes (e.g. distinct S3 ETags) without changing the content hash.
> 
> `XorbObjectInfoV1` renames the private footer extensibility field to `_nonce_buffer` and exposes `set_uniqueness_nonce` / `uniqueness_nonce` for the leading **4 bytes** of the existing 16-byte footer slot (12 bytes reserved). New constants document footer buffer layout. `XorbObject::overwrite_uniqueness_nonce` patches that nonce in already-serialized bytes for V0 and V1 footers after validating trailing `info_length`, leaving chunk data and hash semantics unchanged.
> 
> Includes `api_changes/update_260604_xorb_uniqueness_nonce.md` and tests for roundtrip, in-place overwrite, and malformed-input rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e004ee441a91aeb9b748c11acd11724a69d3f56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->