### PR TITLE
Update hf-xet to 1.5.1

### DIFF
--- a/hf_xet/Cargo.lock
+++ b/hf_xet/Cargo.lock
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "hf_xet"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "async-trait",
  "hf-xet",

--- a/hf_xet/Cargo.toml
+++ b/hf_xet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hf_xet"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
Bump hf-xet Python version for release.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version-only change with no behavioral or dependency updates.
> 
> **Overview**
> Bumps the **`hf_xet`** crate from **1.5.0** to **1.5.1** in `hf_xet/Cargo.toml` and refreshes the matching entry in `hf_xet/Cargo.lock`.
> 
> No source, dependency, or feature changes—release metadata only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 712f81504ab4914f081c1bc699629f43e5f1eeb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->