### PR TITLE
Try to fix sdist release due to LICENSE missing from tarball root directory

### DIFF
--- a/hf_xet/pyproject.toml
+++ b/hf_xet/pyproject.toml
@@ -52,3 +52,4 @@ Repository = "https://github.com/huggingface/xet-core.git"
 
 [tool.maturin]
 features = ["pyo3/extension-module"]
+include = [{ path = "LICENSE", format = "sdist" }]


### PR DESCRIPTION
The last hf-xet Python [release](https://github.com/huggingface/xet-core/actions/runs/27167029243/job/80199014671) failed on sdist upload step due to the below reason:

```
Uploading hf_xet-1.5.1rc0.tar.gz
INFO     Response from https://upload.pypi.org/legacy/:                         
         400 Bad Request                                                        
INFO     <html>                                                                 
          <head>                                                                
           <title>400 License-File LICENSE does not exist in distribution file  
         hf_xet-1.5.1rc0.tar.gz at hf_xet-1.5.1rc0/LICENSE</title>              
          </head>                                                               
          <body>                                                                
           <h1>400 License-File LICENSE does not exist in distribution file     
         hf_xet-1.5.1rc0.tar.gz at hf_xet-1.5.1rc0/LICENSE</h1>                 
           The server could not comply with the request since it is either      
         malformed or otherwise incorrect.<br/><br/>                            
         License-File LICENSE does not exist in distribution file               
         hf_xet-1.5.1rc0.tar.gz at hf_xet-1.5.1rc0/LICENSE 
```

As suggested by Cursor, adding this line will add a LICENSE to the root.

- [x] Tested locally with `maturin sdist` to confirm there's a LICENSE under the root.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 650b9fc0efc8d6916e293360c525ab92507ecc7f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->