### PR TITLE
Demote per-request error log from warn to info

### DIFF
--- a/xet_client/src/common/http_client.rs
+++ b/xet_client/src/common/http_client.rs
@@ -288,7 +288,7 @@ impl Middleware for LoggingMiddleware {
                 info!(request_id, status_code, "Received CAS response");
             })
             .inspect_err(|err| {
-                warn!(?err, "Request error");
+                info!(?err, "Request error");
             })
     }
 }


### PR DESCRIPTION
## What

Changes the `Request error` log in `LoggingMiddleware` (`xet_client/src/common/http_client.rs`) from `warn!` to `info!`.

## Why

This line logs every request-level error from the HTTP middleware, including requests aborted or timed out by adaptive concurrency adjusting in-flight limits — an expected, frequent occurrence during normal operation. These errors are retried by the retry middleware, and genuine failures surface through the caller's error path, so a per-attempt `warn` is noise. `info` keeps the signal visible for troubleshooting without alarming users at default log levels.

History: introduced as an unconditional `warn!` in #603 (previously it only warned on transient retryable errors).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change in HTTP client logging; no request, retry, or error-handling behavior is modified.
> 
> **Overview**
> **LoggingMiddleware** now records per-request HTTP failures at **`info!`** instead of **`warn!`** when `next.run` returns an error (timeouts, aborted requests, etc.).
> 
> That lowers default log noise for expected cases such as adaptive concurrency trimming in-flight requests, while still emitting the same `"Request error"` message with the error details for troubleshooting. Retries and caller-visible failures are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d33a5b132222f2c6e77ee97deae43d70503f2186. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->