### PR TITLE
Clarification of unclear comment on MerkleSubTree implementation

### DIFF
--- a/xet_core_structures/src/merklehash/merkle_hash_subtree.rs
+++ b/xet_core_structures/src/merklehash/merkle_hash_subtree.rs
@@ -368,12 +368,14 @@ pub fn find_stable_start(nodes: &[Node]) -> Option<usize> {
 /// Returns `c1 + 1` as the stable end point; everything from `c1 + 1`
 /// onward is the unstable suffix that cannot yet be merged.
 ///
-/// The reasoning mirrors `find_stable_start`: because `next_merge_cut`
-/// scans forward with bounded lookahead, `c1` is always within the scan
-/// window of any group that reaches `c0`, and `c2` guarantees `c1`
-/// terminates its group.  Appending nodes after the slice can only affect
-/// groups that include the last node -- groups ending before `c1 + 1` are
-/// unaffected.
+/// The reason that the logic there is a bit more complicated is that
+/// we don't actually know whether or not that last cut point was due
+/// to the end of the sequence, i.e. the end of the file.  In the
+/// chunking case, we know this contextually, but here if we append to
+/// a file, we load the last chunk hashes as a MerkleSubTree where the
+/// end is not fixed, but it turns out the last chunk cut point is
+/// actually only there cause it was the end in that case and we don't
+/// know that here.
 pub fn find_stable_end(nodes: &[Node]) -> Option<usize> {
     if nodes.len() < MIN_GROUP_SIZE + 1 {
         return None;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Comment-only change with no runtime or algorithm behavior impact.
> 
> **Overview**
> Updates the doc comment on **`find_stable_end`** in `merkle_hash_subtree.rs` to explain why right-edge stability is trickier than the left-edge case.
> 
> The old text mirrored **`find_stable_start`** (forward scan / bounded lookahead). The new text states that a trailing natural cut may exist only because the slice ended at a file boundary, which chunking knows but a **`MerkleHashSubtree`** loaded for append does not—so **`find_stable_end`** cannot assume the same “append can’t affect earlier groups” story without that context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df970b976fe211cb2427d7cc942fa62cbe52efae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->