### PR TITLE
feat(client): share adaptive concurrency controllers per (session, endpoint)

### DIFF
--- a/xet_client/src/cas_client/adaptive_concurrency/cache.rs
+++ b/xet_client/src/cas_client/adaptive_concurrency/cache.rs
@@ -1,0 +1,77 @@
+//! Runtime-scoped cache of adaptive concurrency controllers, keyed by endpoint.
+//!
+//! All `RemoteClient`s created from the same `XetContext` (i.e. the same
+//! `XetSession`) and pointing at the same endpoint share one upload and one
+//! download controller, so the adaptive model state and the concurrency limit
+//! are session-wide rather than per-client.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use xet_runtime::core::XetContext;
+
+use super::AdaptiveConcurrencyController;
+
+const CACHE_KEY: &str = "cas_client::concurrency_controllers";
+
+#[derive(Default)]
+struct ConcurrencyControllerCache {
+    upload: Mutex<HashMap<String, Arc<AdaptiveConcurrencyController>>>,
+    download: Mutex<HashMap<String, Arc<AdaptiveConcurrencyController>>>,
+}
+
+/// Returns the shared upload concurrency controller for this (ctx, endpoint) pair,
+/// creating it on first use.
+pub fn upload_controller(ctx: &XetContext, endpoint: &str) -> Arc<AdaptiveConcurrencyController> {
+    let cache: Arc<ConcurrencyControllerCache> = ctx.common.cache_get_or_create(CACHE_KEY, Default::default);
+    let mut map = cache.upload.lock().unwrap();
+    map.entry(endpoint.to_string())
+        .or_insert_with(|| AdaptiveConcurrencyController::new_upload(ctx.clone(), "upload"))
+        .clone()
+}
+
+/// Returns the shared download concurrency controller for this (ctx, endpoint) pair,
+/// creating it on first use.
+pub fn download_controller(ctx: &XetContext, endpoint: &str) -> Arc<AdaptiveConcurrencyController> {
+    let cache: Arc<ConcurrencyControllerCache> = ctx.common.cache_get_or_create(CACHE_KEY, Default::default);
+    let mut map = cache.download.lock().unwrap();
+    map.entry(endpoint.to_string())
+        .or_insert_with(|| AdaptiveConcurrencyController::new_download(ctx.clone(), "download"))
+        .clone()
+}
+
+#[cfg(test)]
+#[cfg(not(target_family = "wasm"))]
+mod tests {
+    use super::*;
+
+    const EP_A: &str = "https://cas-a.example.com";
+    const EP_B: &str = "https://cas-b.example.com";
+
+    #[test]
+    fn test_same_ctx_same_endpoint_shares_controller() {
+        let ctx = XetContext::default().unwrap();
+        assert!(Arc::ptr_eq(&upload_controller(&ctx, EP_A), &upload_controller(&ctx, EP_A)));
+        assert!(Arc::ptr_eq(&download_controller(&ctx, EP_A), &download_controller(&ctx, EP_A)));
+    }
+
+    #[test]
+    fn test_same_ctx_different_endpoint_distinct_controllers() {
+        let ctx = XetContext::default().unwrap();
+        assert!(!Arc::ptr_eq(&upload_controller(&ctx, EP_A), &upload_controller(&ctx, EP_B)));
+        assert!(!Arc::ptr_eq(&download_controller(&ctx, EP_A), &download_controller(&ctx, EP_B)));
+    }
+
+    #[test]
+    fn test_different_ctx_distinct_controllers() {
+        let ctx1 = XetContext::default().unwrap();
+        let ctx2 = XetContext::default().unwrap();
+        assert!(!Arc::ptr_eq(&upload_controller(&ctx1, EP_A), &upload_controller(&ctx2, EP_A)));
+    }
+
+    #[test]
+    fn test_upload_and_download_controllers_distinct() {
+        let ctx = XetContext::default().unwrap();
+        assert!(!Arc::ptr_eq(&upload_controller(&ctx, EP_A), &download_controller(&ctx, EP_A)));
+    }
+}

--- a/xet_client/src/cas_client/adaptive_concurrency/cache.rs
+++ b/xet_client/src/cas_client/adaptive_concurrency/cache.rs
@@ -74,4 +74,16 @@ mod tests {
         let ctx = XetContext::default().unwrap();
         assert!(!Arc::ptr_eq(&upload_controller(&ctx, EP_A), &download_controller(&ctx, EP_A)));
     }
+
+    #[test]
+    // The cache lives inside XetCommon, so cached controllers must not hold anything that
+    // points back at XetCommon — that Arc cycle would keep the runtime state alive forever.
+    fn test_cached_controllers_do_not_keep_runtime_common_alive() {
+        let ctx = XetContext::default().unwrap();
+        let weak_common = Arc::downgrade(&ctx.common);
+        let _upload = upload_controller(&ctx, EP_A);
+        let _download = download_controller(&ctx, EP_A);
+        drop(ctx);
+        assert!(weak_common.upgrade().is_none());
+    }
 }

--- a/xet_client/src/cas_client/adaptive_concurrency/controller.rs
+++ b/xet_client/src/cas_client/adaptive_concurrency/controller.rs
@@ -11,6 +11,7 @@ use tracing::info;
 #[cfg(target_family = "wasm")]
 use web_time::Instant;
 use xet_core_structures::ExpWeightedMovingAvg;
+use xet_runtime::config::XetConfig;
 use xet_runtime::core::XetContext;
 use xet_runtime::utils::adjustable_semaphore::{AdjustableSemaphore, AdjustableSemaphorePermit};
 
@@ -42,7 +43,7 @@ pub struct CCLatencyModelState {
 
 /// The internal state of the concurrency controller.
 struct ConcurrencyControllerState {
-    ctx: XetContext,
+    config: Arc<XetConfig>,
     /// A running model of the current bandwidth.  Uses an exponentially weighted average to predict the
     rtt_predictor: RTTPredictor,
 
@@ -74,13 +75,12 @@ struct ConcurrencyControllerState {
 }
 
 impl ConcurrencyControllerState {
-    fn new(ctx: XetContext) -> Self {
-        let config = &ctx.config;
+    fn new(config: Arc<XetConfig>) -> Self {
         let rtt_half_life_count = config.client.ac_latency_rtt_half_life;
         let success_half_life_count = config.client.ac_success_tracking_half_life;
 
         Self {
-            ctx,
+            config,
             rtt_predictor: RTTPredictor::new(rtt_half_life_count),
             success_ratio_tracking: ExpWeightedMovingAvg::new_count_decay(success_half_life_count),
             last_adjustment_time: Instant::now(),
@@ -94,7 +94,7 @@ impl ConcurrencyControllerState {
     }
 
     fn success_ratio_thresholds(&self) -> (f64, f64) {
-        let config = &self.ctx.config;
+        let config = &self.config;
         let increase_threshold = config.client.ac_healthy_success_ratio_threshold;
         let decrease_threshold = config.client.ac_unhealthy_success_ratio_threshold;
         (increase_threshold, decrease_threshold)
@@ -132,7 +132,7 @@ impl ConcurrencyControllerState {
 
     #[inline]
     fn latency_model_state(&self, current_concurrency: f64) -> CCLatencyModelState {
-        let config = &self.ctx.config;
+        let config = &self.config;
         let (predicted_max_rtt, prediction_max_rtt_standard_error) = self
             .rtt_predictor
             .predict(*config.client.ac_max_reference_transmission_size, current_concurrency);
@@ -161,7 +161,7 @@ impl ConcurrencyControllerState {
 
         let quantile_95 = (mu + REFERENCE_SIZE_QUANTILE_Z * sigma).exp();
 
-        let config = &self.ctx.config;
+        let config = &self.config;
         let min_size = *config.client.ac_min_reference_transmission_size;
         let max_size = *config.client.ac_max_reference_transmission_size;
 
@@ -259,7 +259,10 @@ impl ConcurrencyControllerState {
 ///
 /// The controller uses these reports to update its models and adjust concurrency accordingly.
 pub struct AdaptiveConcurrencyController {
-    ctx: XetContext,
+    // Holds only the config, never a full `XetContext`: controllers are cached inside
+    // `XetCommon` (see cache.rs), so holding a `XetContext` (which owns an `Arc<XetCommon>`)
+    // would create a reference cycle that keeps the runtime state alive forever.
+    config: Arc<XetConfig>,
     // The current state, including tracking information and when previous adjustments were made.
     // Also holds related constants
     state: Mutex<ConcurrencyControllerState>,
@@ -302,10 +305,9 @@ impl AdaptiveConcurrencyController {
             "Initializing Adaptive Concurrency Controller for {logging_tag} with starting concurrency = {current_concurrency}; min = {min_concurrency}, max = {max_concurrency}, min_bytes_for_adjustment = {min_bytes_required_for_adjustment}, min_completed_transmissions_for_adjustment = {min_completed_transmissions_required_for_adjustment}"
         );
 
-        let config = &ctx.config;
+        let config = ctx.config.clone();
         Arc::new(Self {
-            ctx: ctx.clone(),
-            state: Mutex::new(ConcurrencyControllerState::new(ctx.clone())),
+            state: Mutex::new(ConcurrencyControllerState::new(config.clone())),
             concurrency_semaphore: AdjustableSemaphore::new(
                 current_concurrency as u64,
                 (min_concurrency as u64, max_concurrency as u64),
@@ -317,6 +319,7 @@ impl AdaptiveConcurrencyController {
             logging_tag,
             min_bytes_required_for_adjustment,
             min_completed_transmissions_required_for_adjustment,
+            config,
         })
     }
 
@@ -325,8 +328,8 @@ impl AdaptiveConcurrencyController {
         info!("Fixing maximum concurrency for {logging_tag} at {concurrency}; adaptive concurrency disabled.");
 
         Arc::new(Self {
-            ctx: ctx.clone(),
-            state: Mutex::new(ConcurrencyControllerState::new(ctx)),
+            config: ctx.config.clone(),
+            state: Mutex::new(ConcurrencyControllerState::new(ctx.config)),
             concurrency_semaphore: AdjustableSemaphore::new(
                 concurrency as u64,
                 (concurrency as u64, concurrency as u64),
@@ -453,7 +456,7 @@ impl AdaptiveConcurrencyController {
         let t_actual = elapsed_time.as_secs_f64().max(1e-4);
 
         // Track if the transfer completed within a healthy time.
-        let config = &self.ctx.config;
+        let config = &self.config;
         let completed_in_time = elapsed_time < config.client.ac_max_healthy_rtt;
 
         let mut state_lg = self.state.lock().await;
@@ -749,11 +752,11 @@ mod test_constants {
 
 #[cfg(test)]
 impl ConcurrencyControllerState {
-    fn new_testing(ctx: XetContext) -> Self {
+    fn new_testing(config: Arc<XetConfig>) -> Self {
         use self::test_constants::TR_HALF_LIFE_COUNT;
 
         Self {
-            ctx,
+            config,
             rtt_predictor: RTTPredictor::new(TR_HALF_LIFE_COUNT),
             success_ratio_tracking: ExpWeightedMovingAvg::new_count_decay(TR_HALF_LIFE_COUNT),
             last_adjustment_time: Instant::now(),
@@ -770,10 +773,10 @@ impl ConcurrencyControllerState {
 #[cfg(test)]
 impl AdaptiveConcurrencyController {
     pub fn new_testing(concurrency: usize, concurrency_bounds: (usize, usize)) -> Arc<Self> {
-        let ctx = XetContext::default().expect("test runtime");
+        let config = Arc::new(XetConfig::new());
         Arc::new(Self {
-            ctx: ctx.clone(),
-            state: Mutex::new(ConcurrencyControllerState::new_testing(ctx)),
+            config: config.clone(),
+            state: Mutex::new(ConcurrencyControllerState::new_testing(config)),
             concurrency_semaphore: AdjustableSemaphore::new(
                 concurrency as u64,
                 (concurrency_bounds.0 as u64, concurrency_bounds.1 as u64),
@@ -993,15 +996,15 @@ mod tests {
 
     #[test]
     fn test_reference_size_returns_none_with_insufficient_data() {
-        let ctx = XetContext::default().expect("test runtime");
-        let state = ConcurrencyControllerState::new_testing(ctx);
+        let config = Arc::new(XetConfig::new());
+        let state = ConcurrencyControllerState::new_testing(config);
         assert!(state.estimated_reference_transmission_size().is_none());
     }
 
     #[test]
     fn test_reference_size_with_uniform_sizes() {
-        let ctx = XetContext::default().expect("test runtime");
-        let mut state = ConcurrencyControllerState::new_testing(ctx);
+        let config = Arc::new(XetConfig::new());
+        let mut state = ConcurrencyControllerState::new_testing(config);
 
         let size: u64 = 10 * 1024 * 1024; // 10 MB
         for _ in 0..10 {
@@ -1019,8 +1022,8 @@ mod tests {
 
     #[test]
     fn test_reference_size_bounded_by_minimum() {
-        let ctx = XetContext::default().expect("test runtime");
-        let mut state = ConcurrencyControllerState::new_testing(ctx);
+        let config = Arc::new(XetConfig::new());
+        let mut state = ConcurrencyControllerState::new_testing(config);
 
         let size: u64 = 1024; // 1 KB
         for _ in 0..10 {
@@ -1034,8 +1037,8 @@ mod tests {
 
     #[test]
     fn test_reference_size_bounded_by_config_maximum() {
-        let ctx = XetContext::default().expect("test runtime");
-        let mut state = ConcurrencyControllerState::new_testing(ctx);
+        let config = Arc::new(XetConfig::new());
+        let mut state = ConcurrencyControllerState::new_testing(config);
 
         let size: u64 = 200 * 1024 * 1024; // 200 MB (above the 64MB config default)
         for _ in 0..10 {
@@ -1049,8 +1052,8 @@ mod tests {
 
     #[test]
     fn test_reference_size_skips_zero_byte_transfers() {
-        let ctx = XetContext::default().expect("test runtime");
-        let mut state = ConcurrencyControllerState::new_testing(ctx);
+        let config = Arc::new(XetConfig::new());
+        let mut state = ConcurrencyControllerState::new_testing(config);
 
         for _ in 0..10 {
             state.update_size_tracking(0);
@@ -1062,17 +1065,14 @@ mod tests {
 
     #[test]
     fn test_reference_size_with_mixed_sizes() {
-        let config = XetConfig::new();
-
-        let ctx_small = XetContext::default().expect("test runtime");
-        let mut small_only_state = ConcurrencyControllerState::new_testing(ctx_small);
+        let mut small_only_state = ConcurrencyControllerState::new_testing(Arc::new(XetConfig::new()));
         for _ in 0..10 {
             small_only_state.update_size_tracking(512 * 1024); // 512 KB
         }
         let small_only_ref_size = small_only_state.estimated_reference_transmission_size().unwrap();
 
-        let ctx = XetContext::default().expect("test runtime");
-        let mut state = ConcurrencyControllerState::new_testing(ctx);
+        let config = Arc::new(XetConfig::new());
+        let mut state = ConcurrencyControllerState::new_testing(config.clone());
 
         // Mix of small and large transfers
         for _ in 0..5 {

--- a/xet_client/src/cas_client/adaptive_concurrency/mod.rs
+++ b/xet_client/src/cas_client/adaptive_concurrency/mod.rs
@@ -1,5 +1,7 @@
+mod cache;
 mod controller;
 mod exp_weighted_olr;
 mod rtt_prediction;
 
+pub use cache::{download_controller, upload_controller};
 pub use controller::{AdaptiveConcurrencyController, CCLatencyModelState, CCSuccessModelState, ConnectionPermit};

--- a/xet_client/src/cas_client/remote_client.rs
+++ b/xet_client/src/cas_client/remote_client.rs
@@ -14,7 +14,9 @@ use xet_core_structures::metadata_shard::file_structs::{FileDataSequenceEntry, F
 use xet_core_structures::xorb_object::SerializedXorbObject;
 use xet_runtime::core::XetContext;
 
-use super::adaptive_concurrency::{AdaptiveConcurrencyController, ConnectionPermit};
+use super::adaptive_concurrency::{
+    AdaptiveConcurrencyController, ConnectionPermit, download_controller, upload_controller,
+};
 use super::auth::AuthConfig;
 use super::interface::URLProvider;
 use super::progress_tracked_streams::{
@@ -96,8 +98,8 @@ impl RemoteClient {
                 )
                 .unwrap(),
             ),
-            upload_concurrency_controller: AdaptiveConcurrencyController::new_upload(ctx.clone(), "upload"),
-            download_concurrency_controller: AdaptiveConcurrencyController::new_download(ctx.clone(), "download"),
+            upload_concurrency_controller: upload_controller(&ctx, endpoint),
+            download_concurrency_controller: download_controller(&ctx, endpoint),
             detected_reconstruction_api_version: AtomicU32::new(0),
         })
     }
@@ -803,6 +805,30 @@ mod tests {
     };
 
     use super::*;
+
+    #[test]
+    fn test_clients_share_controllers_per_ctx_and_endpoint() {
+        let ctx = XetContext::default().unwrap();
+        let c1 = RemoteClient::new(ctx.clone(), "https://cas-a.example.com", &None, "", false, None);
+        let c2 = RemoteClient::new(ctx.clone(), "https://cas-a.example.com", &None, "", false, None);
+
+        // Same ctx + same endpoint: shared upload and download controllers.
+        assert!(Arc::ptr_eq(&c1.upload_concurrency_controller, &c2.upload_concurrency_controller));
+        assert!(Arc::ptr_eq(&c1.download_concurrency_controller, &c2.download_concurrency_controller));
+
+        // Same ctx, different endpoint: independent controllers.
+        let c3 = RemoteClient::new(ctx.clone(), "https://cas-b.example.com", &None, "", false, None);
+        assert!(!Arc::ptr_eq(&c1.upload_concurrency_controller, &c3.upload_concurrency_controller));
+
+        // Creating a second endpoint must not evict the first: re-fetching cas-a still shares with c1.
+        let c5 = RemoteClient::new(ctx.clone(), "https://cas-a.example.com", &None, "", false, None);
+        assert!(Arc::ptr_eq(&c1.upload_concurrency_controller, &c5.upload_concurrency_controller));
+
+        // Different ctx (different session), same endpoint: independent controllers.
+        let ctx2 = XetContext::default().unwrap();
+        let c4 = RemoteClient::new(ctx2, "https://cas-a.example.com", &None, "", false, None);
+        assert!(!Arc::ptr_eq(&c1.upload_concurrency_controller, &c4.upload_concurrency_controller));
+    }
 
     #[ignore = "requires a running CAS server"]
     #[traced_test]


### PR DESCRIPTION
## Human Summary:

Having all downloads and all uploads share the same concurrency controller within the same XetSession (all download groups and all upload commit builders under the same session)

2 download groups or 2 upload commits concurrently share the same semaphores for concurrently downloading segments/uploading objects. more importantly they cannot interfere with each other.

when 1 group/upload finishes, if another one starts, then next will have the previous adaptive concurrency state as the baseline so no need for a "ramp back up" (or down).

uses the dynamic cache system to allocate the adaptors. adaptor is "per endpoint" in the very rare chance we end up hitting 2 separate endpoints.

minor refactor required, the adaptive concurrency held a XetContext Arc which under the new additions would cause a circular Arc dependency (memory leak guaranteed). Only the XetConfig was used so we add the xet config instead of XetContext.


## Summary

- Adds a runtime-scoped, endpoint-keyed cache of `AdaptiveConcurrencyController`s (`xet_client/src/cas_client/adaptive_concurrency/cache.rs`), stored via the existing `XetCommon::cache_get_or_create` mechanism.
- `RemoteClient::new_with_socket` now fetches its upload/download controllers from this cache instead of constructing fresh ones, so all upload commits, file download groups, and download stream groups created from one `XetSession` and targeting the same CAS endpoint share one adaptive concurrency model and one concurrency limit (uploads and downloads remain independent).
- `AdaptiveConcurrencyController` now stores `Arc<XetConfig>` instead of a full `XetContext`. Since the cache lives inside `XetCommon`, a controller holding `XetContext` (which owns `Arc<XetCommon>`) would form a strong reference cycle that keeps each session's `XetCommon` alive for the process lifetime. The controller only ever read `ctx.config`, so this drops the over-broad dependency; a regression test pins the property (drop the context, assert `Weak<XetCommon>` no longer upgrades).

### Behavior change

Previously each `XetUploadCommit` / download group builder ramped its own controller independently, so a session's effective connection ceiling was `N builders × ac_max_*_concurrency` with the controllers competing blindly. Now `ac_max_upload_concurrency` / `ac_max_download_concurrency` bound the **total** in-flight requests per (session, endpoint), and later builders warm-start from the already-learned concurrency level instead of cold-starting.

Notes:
- File-level limits (`max_concurrent_file_ingestion` / `max_concurrent_file_downloads`) were already session-shared via `XetCommon` and are untouched.
- `LocalClient` / `MemoryClient` intentionally keep per-instance controllers.
- The simulation `local_server` test path creates two `RemoteClient`s on one ctx+endpoint and now shares controllers between them; audited — no test asserts independent ramping.

## Test Plan

- [x] New unit tests for the cache: same ctx+endpoint shares (`Arc::ptr_eq`), different endpoint distinct, different ctx distinct, upload vs download distinct
- [x] New regression test that cached controllers don't keep `XetCommon` alive (no `Arc` cycle)
- [x] New `RemoteClient` test covering the sharing matrix end-to-end through the constructor, including non-eviction when a second endpoint is added
- [x] `cargo test -p xet-client`: 138 passed, 0 failed (4 network tests ignored as usual)
- [x] `cargo check -p xet-data -p hf-xet` clean; `cargo +nightly fmt` + `cargo clippy -p xet-client --all-targets` show no warnings in changed files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how concurrent uploads/downloads compete within a session (global semaphore per direction/endpoint instead of per `RemoteClient`), which can alter throughput and ramp-up behavior for multi-group workloads.
> 
> **Overview**
> **Session-wide adaptive concurrency** for `RemoteClient`: upload and download `AdaptiveConcurrencyController` instances are now looked up from a new endpoint-keyed cache on `XetCommon` (`cache.rs`) instead of being created per client. All clients in the same `XetSession` and CAS endpoint share one upload and one download controller (separate maps), so `ac_max_*_concurrency` caps **total** in-flight CAS requests and later work reuses the learned limit instead of cold-starting per upload commit or download group.
> 
> **Refactor to avoid leaks:** `AdaptiveConcurrencyController` stores `Arc<XetConfig>` instead of `XetContext`, because caching controllers inside `XetCommon` would otherwise create an `Arc` cycle (`XetContext` → `XetCommon` → controller → `XetContext`). Tests assert sharing by ctx/endpoint, non-eviction when adding a second endpoint, and that dropping the context releases `XetCommon`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22b55fe42d5a60ff3804c478ea81ced105f5ea86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->