### PR TITLE
build: bump pyo3 0.26 → 0.29 (fix RUSTSEC-2026-0176/0177)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2414,15 +2414,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "inout"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2765,15 +2756,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "mime"
@@ -3531,36 +3513,33 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "indoc",
  "inventory",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -3568,9 +3547,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -3580,13 +3559,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]
@@ -5261,12 +5239,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "universal-hash"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1798,17 +1798,15 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.20.4"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe 0.1.6",
  "openssl-sys",
- "url",
 ]
 
 [[package]]
@@ -2620,13 +2618,12 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.3+1.9.2"
+version = "0.18.5+1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
 dependencies = [
  "cc",
  "libc",
- "libssh2-sys",
  "libz-sys",
  "openssl-sys",
  "pkg-config",
@@ -2645,20 +2642,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -2856,7 +2839,7 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "openssl-sys",
  "schannel",
  "security-framework",
@@ -3025,12 +3008,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-probe"
@@ -4064,7 +4041,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "rustls-pki-types",
  "schannel",
  "security-framework",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ gearhash = "0.1"
 getrandom = { version = "0.4", features = ["wasm_js"] }
 git-url-parse = "0.4"
 git-version = "0.3"
-git2 = "0.20"
+git2 = "0.21"
 half = "2.7"
 heapify = "0.2"
 redb = "3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ mockall = "0.14"
 more-asserts = "0.3"
 oneshot = "0.1"
 pin-project = "1"
-pyo3 = { version = "0.26", features = ["abi3-py37", "multiple-pymethods"] }
+pyo3 = { version = "0.29", features = ["abi3-py38", "multiple-pymethods"] }
 rand = "0.10"
 rand_chacha = "0.10"
 regex = "1"

--- a/git_xet/src/git_repo.rs
+++ b/git_xet/src/git_repo.rs
@@ -46,6 +46,7 @@ impl GitRepo {
             if head_ref.is_branch() {
                 head_ref
                     .name()
+                    .ok()
                     .and_then(|refs_heads_branch| refs_heads_branch.strip_prefix("refs/heads/"))
                     .map(|branch| branch.to_owned())
             } else {
@@ -81,7 +82,7 @@ impl GitRepo {
         // use only remote if there is only 1
         let remotes = repo.remotes()?;
         if remotes.len() == 1
-            && let Some(remote) = remotes.get(0)
+            && let Ok(Some(remote)) = remotes.get(0)
         {
             return Ok(remote.to_string());
         }
@@ -98,7 +99,9 @@ impl GitRepo {
         let url: GitUrl = repo
             .find_remote(remote)?
             .url()
+            .ok()
             .map(|s| s.to_string())
+            .filter(|s| !s.is_empty())
             .ok_or_else(|| GitXetError::config_error(format!("no url for remote \"{remote}\"")))?
             .parse()?;
 

--- a/hf_xet/Cargo.lock
+++ b/hf_xet/Cargo.lock
@@ -1396,15 +1396,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "inferno"
 version = "0.11.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1678,15 +1669,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -2132,36 +2114,33 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "indoc",
  "inventory",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2169,9 +2148,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2181,13 +2160,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]
@@ -3327,12 +3305,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "untrusted"

--- a/hf_xet/Cargo.toml
+++ b/hf_xet/Cargo.toml
@@ -19,8 +19,8 @@ pprof = { version = "0.14", features = [
     "prost",
     "protobuf-codec",
 ], optional = true }
-pyo3 = { version = "0.26", features = [
-    "abi3-py37",
+pyo3 = { version = "0.29", features = [
+    "abi3-py38",
     "auto-initialize",
 ] }
 async-trait = "0.1"

--- a/hf_xet/src/config.rs
+++ b/hf_xet/src/config.rs
@@ -2,7 +2,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use xet_runtime::config::XetConfig;
 
-#[pyclass(name = "XetConfig")]
+#[pyclass(name = "XetConfig", from_py_object)]
 #[derive(Clone)]
 pub struct PyXetConfig {
     inner: XetConfig,
@@ -43,7 +43,7 @@ impl PyXetConfig {
     fn py_with_config(&self, name_or_dict: &Bound<'_, PyAny>, value: Option<&Bound<'_, PyAny>>) -> PyResult<Self> {
         let mut new_inner = self.inner.clone();
 
-        if let Ok(dict) = name_or_dict.downcast::<PyDict>() {
+        if let Ok(dict) = name_or_dict.cast::<PyDict>() {
             if value.is_some() {
                 return Err(pyo3::exceptions::PyTypeError::new_err(
                     "with_config(dict) does not accept a second argument",

--- a/hf_xet/src/legacy/types.rs
+++ b/hf_xet/src/legacy/types.rs
@@ -6,7 +6,7 @@ use xet_pkg::legacy::XetFileInfo;
 // ── PyXetDownloadInfo ─────────────────────────────────────────────────────────
 
 // TODO: we won't need to subclass this in the next major version update.
-#[pyclass(subclass)]
+#[pyclass(subclass, from_py_object)]
 #[derive(Clone, Debug)]
 pub struct PyXetDownloadInfo {
     #[pyo3(get, set)]
@@ -42,7 +42,7 @@ impl PyXetDownloadInfo {
 // ── PyXetUploadInfo ───────────────────────────────────────────────────────────
 
 /// Result returned by the legacy ``upload_bytes`` / ``upload_files`` / ``hash_files`` functions.
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone, Debug)]
 pub struct PyXetUploadInfo {
     #[pyo3(get)]
@@ -95,15 +95,15 @@ impl From<XetFileInfo> for PyXetUploadInfo {
 ///
 /// Kept for backward compatibility with old versions of ``huggingface_hub``.
 // TODO: remove during the next major version update.
-#[pyclass(extends=PyXetDownloadInfo)]
+#[pyclass(extends=PyXetDownloadInfo, from_py_object)]
 #[derive(Clone, Debug)]
 pub struct PyPointerFile {}
 
 #[pymethods]
 impl PyPointerFile {
     #[new]
-    pub fn new(path: String, hash: String, filesize: u64) -> (Self, PyXetDownloadInfo) {
-        (PyPointerFile {}, PyXetDownloadInfo::new(path, hash, Some(filesize)))
+    pub fn new(path: String, hash: String, filesize: u64) -> PyClassInitializer<Self> {
+        PyClassInitializer::from(PyXetDownloadInfo::new(path, hash, Some(filesize))).add_subclass(PyPointerFile {})
     }
 
     fn __str__(&self) -> String {

--- a/hf_xet/src/lib.rs
+++ b/hf_xet/src/lib.rs
@@ -44,7 +44,7 @@ pub(crate) mod profiling;
 /// annotated with `#[pyclass]` as-is.  Rather than restructuring the internal
 /// enum, we expose this four-variant unit-only wrapper.  The `Error` case is
 /// surfaced as a raised Python exception by `task_state_to_pystate` instead.
-#[pyclass(eq, name = "XetTaskState")]
+#[pyclass(eq, name = "XetTaskState", from_py_object)]
 #[derive(Clone, Debug, PartialEq)]
 pub enum PyXetTaskState {
     Running,

--- a/hf_xet/src/py_download_stream_group.rs
+++ b/hf_xet/src/py_download_stream_group.rs
@@ -55,7 +55,7 @@ pub(crate) fn build_download_stream_group(
 /// concurrently from the same group.
 ///
 /// Cloning is cheap — all clones share the same underlying state.
-#[pyclass(name = "XetDownloadStreamGroup")]
+#[pyclass(name = "XetDownloadStreamGroup", from_py_object)]
 #[derive(Clone)]
 pub struct PyXetDownloadStreamGroup {
     pub(crate) inner: XetDownloadStreamGroup,

--- a/hf_xet/src/py_stream_upload_handle.rs
+++ b/hf_xet/src/py_stream_upload_handle.rs
@@ -23,7 +23,7 @@ use crate::{PyXetTaskState, convert_xet_error};
 ///         stream.write(chunk)
 /// # finish() was called automatically
 /// ```
-#[pyclass(name = "XetStreamUpload")]
+#[pyclass(name = "XetStreamUpload", from_py_object)]
 #[derive(Clone)]
 pub struct PyXetStreamUpload {
     pub(crate) inner: XetStreamUpload,

--- a/hf_xet/src/py_xet_session.rs
+++ b/hf_xet/src/py_xet_session.rs
@@ -15,7 +15,7 @@ use crate::{PyXetTaskState, convert_xet_error};
 /// Manages a Xet runtime context and connection pool.
 ///
 /// Session objects are cheap to clone — all clones share the same underlying state.
-#[pyclass(name = "XetSession")]
+#[pyclass(name = "XetSession", from_py_object)]
 #[derive(Clone)]
 pub struct PyXetSession {
     pub(crate) inner: XetSession,

--- a/xet_data/Cargo.toml
+++ b/xet_data/Cargo.toml
@@ -40,7 +40,7 @@ tracing = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true, features = ["v7"] }
 walkdir = { workspace = true }
-pyo3 = { version = "0.26", features = ["abi3-py37"], optional = true }
+pyo3 = { version = "0.29", features = ["abi3-py38"], optional = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 tokio = { workspace = true, features = [

--- a/xet_data/Cargo.toml
+++ b/xet_data/Cargo.toml
@@ -40,7 +40,7 @@ tracing = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true, features = ["v7"] }
 walkdir = { workspace = true }
-pyo3 = { version = "0.29", features = ["abi3-py38"], optional = true }
+pyo3 = { workspace = true, optional = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 tokio = { workspace = true, features = [

--- a/xet_data/src/deduplication/dedup_metrics.rs
+++ b/xet_data/src/deduplication/dedup_metrics.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Default, Debug, Clone, Copy, Serialize, Deserialize)]
-#[cfg_attr(feature = "python", pyo3::pyclass(get_all))]
+#[cfg_attr(feature = "python", pyo3::pyclass(get_all, from_py_object))]
 pub struct DeduplicationMetrics {
     pub total_bytes: u64,
     pub deduped_bytes: u64,

--- a/xet_data/src/processing/xet_file.rs
+++ b/xet_data/src/processing/xet_file.rs
@@ -4,7 +4,7 @@ use xet_runtime::error_printer::ErrorPrinter;
 
 /// A struct that wraps a the Xet file information.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
-#[cfg_attr(feature = "python", pyo3::pyclass(get_all))]
+#[cfg_attr(feature = "python", pyo3::pyclass(get_all, from_py_object))]
 pub struct XetFileInfo {
     /// The Merkle hash of the file
     pub hash: String,

--- a/xet_data/src/progress_tracking/progress_types.rs
+++ b/xet_data/src/progress_tracking/progress_types.rs
@@ -364,7 +364,7 @@ impl std::fmt::Debug for ItemProgressUpdater {
 // === Snapshot report structs ===
 
 #[derive(Clone, Debug, Default)]
-#[cfg_attr(feature = "python", pyo3::pyclass(get_all))]
+#[cfg_attr(feature = "python", pyo3::pyclass(get_all, from_py_object))]
 pub struct GroupProgressReport {
     pub total_bytes: u64,
     pub total_bytes_completed: u64,
@@ -375,7 +375,7 @@ pub struct GroupProgressReport {
 }
 
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "python", pyo3::pyclass(get_all))]
+#[cfg_attr(feature = "python", pyo3::pyclass(get_all, from_py_object))]
 pub struct ItemProgressReport {
     pub item_name: String,
     pub total_bytes: u64,

--- a/xet_pkg/src/xet_session/file_download_group.rs
+++ b/xet_pkg/src/xet_session/file_download_group.rs
@@ -68,7 +68,7 @@ impl AuthGroupBuilder<XetFileDownloadGroup> {
 /// Contains final progress and per-file results keyed by [`UniqueId`].
 /// Only created when all downloads succeed; any failure propagates as an error.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "python", pyo3::pyclass(get_all))]
+#[cfg_attr(feature = "python", pyo3::pyclass(get_all, from_py_object))]
 pub struct XetDownloadGroupReport {
     /// Final progress snapshot at the time the group finished.
     pub progress: GroupProgressReport,

--- a/xet_pkg/src/xet_session/file_download_handle.rs
+++ b/xet_pkg/src/xet_session/file_download_handle.rs
@@ -14,7 +14,7 @@ use crate::error::XetError;
 /// Per-file download result returned by
 /// [`XetFileDownloadGroup::finish`](crate::xet_session::XetFileDownloadGroup::finish).
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "python", pyo3::pyclass(get_all))]
+#[cfg_attr(feature = "python", pyo3::pyclass(get_all, from_py_object))]
 pub struct XetDownloadReport {
     /// Unique identifier for this download task.
     pub task_id: UniqueId,

--- a/xet_pkg/src/xet_session/upload_commit.rs
+++ b/xet_pkg/src/xet_session/upload_commit.rs
@@ -72,7 +72,7 @@ impl AuthGroupBuilder<XetUploadCommit> {
 /// [`XetFileMetadata`] for every file that was successfully ingested,
 /// keyed by [`UniqueId`].
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "python", pyo3::pyclass(get_all))]
+#[cfg_attr(feature = "python", pyo3::pyclass(get_all, from_py_object))]
 pub struct XetCommitReport {
     /// Aggregate deduplication metrics across all files in this commit.
     pub dedup_metrics: DeduplicationMetrics,
@@ -108,7 +108,7 @@ impl XetCommitReport {
 /// Per-file metadata returned by [`XetFileUpload::finalize_ingestion`] and
 /// [`XetStreamUpload::finish`].
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(feature = "python", pyo3::pyclass(get_all))]
+#[cfg_attr(feature = "python", pyo3::pyclass(get_all, from_py_object))]
 pub struct XetFileMetadata {
     /// Unique identifier for the task that produced this metadata.
     #[serde(skip)]

--- a/xet_runtime/src/utils/unique_id.rs
+++ b/xet_runtime/src/utils/unique_id.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 static NEXT_ID: AtomicU64 = AtomicU64::new(1);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[cfg_attr(feature = "python", pyo3::pyclass)]
+#[cfg_attr(feature = "python", pyo3::pyclass(from_py_object))]
 pub struct UniqueId(pub u64);
 
 impl UniqueId {


### PR DESCRIPTION
## Fix RUSTSEC-2026-0176 / RUSTSEC-2026-0177 by upgrading pyo3 0.26 → 0.29

`pyo3 0.26.0` is affected by two advisories (published 2026-06-11), both fixed in `>=0.29.0`:
- **RUSTSEC-2026-0176** — out-of-bounds read in `nth`/`nth_back` for `PyList`/`PyTuple` iterators
- **RUSTSEC-2026-0177** — missing `Sync` bound on `PyCFunction::new_closure` closures

`cargo audit` is currently red on `main` because of these; this bumps pyo3 to `0.29.0` across both workspaces (root + `hf_xet`) and does the required migration.

## Migration

- **`abi3-py37` → `abi3-py38`** — pyo3 0.29 drops Python 3.7 (EOL). No change to supported versions: `hf_xet/pyproject.toml` already declares `requires-python = ">=3.8"`.
- **`FromPyObject` opt-in** — 0.29 makes the auto `FromPyObject` derive for `Clone` `#[pyclass]` types opt-in. Added `from_py_object` to the affected classes to preserve current behavior (CI clippy runs `-D warnings`, so the deprecation must be cleared).
- **`PyAnyMethods::downcast` → `Bound::cast`** — one site (`config.rs`).
- **`#[new]` tuple super-class init → `PyClassInitializer`** — legacy `PyPointerFile`.

## Verification (local)

- Root workspace (`xet_runtime`/`xet_data`/`xet_pkg` with `python`) builds; tests compile.
- `hf_xet` workspace: `cargo clippy --manifest-path hf_xet/Cargo.toml -- -D warnings` clean; tests compile.
- `cargo fmt --all --check` clean (both workspaces).
- **`cargo audit -D warnings` passes** (advisories resolved).

The maturin/`hub-python-tests` runtime suite runs on CI — opening as draft until that's green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Python FFI surface and minimum ABI (3.8+); security-motivated pyo3 bump is low runtime risk if CI/Python tests pass, but dependency and binding changes warrant normal release verification.
> 
> **Overview**
> Upgrades **pyo3** to **0.29** (root + `hf_xet` workspaces) to clear **RUSTSEC-2026-0176/0177**, and bumps **git2** to **0.21** with lockfile churn (e.g. dropped `libssh2-sys`, unified `openssl-probe`).
> 
> **Python extension:** `abi3-py37` → **`abi3-py38`**; **`from_py_object`** on exposed `#[pyclass]` types; **`downcast` → `cast`** in `hf_xet` config; legacy **`PyPointerFile`** `#[new]` uses **`PyClassInitializer`**; `xet_data` optional pyo3 now uses the workspace crate.
> 
> **git_xet:** Small **git2 0.21** API fixes in `git_repo.rs` (optional ref names/URLs, `remotes.get` `Result`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f4bef5e05fa8c80958d1973d39a2af21b56abed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->