### PR TITLE
Drop hf-xet Python release for Python 3.13t

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ on:
         description: 'Semantic version for PyPI release (tag will share the same name)'
         required: true
         default: 'v0.1.0'
-  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ on:
         description: 'Semantic version for PyPI release (tag will share the same name)'
         required: true
         default: 'v0.1.0'
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,6 @@ jobs:
             manylinux: manylinux_2_28
         python-version:
           - 3.14
-          - 3.13t
           - 3.14t
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -130,7 +129,6 @@ jobs:
             target: aarch64
         python-version:
           - 3.14
-          - 3.13t
           - 3.14t
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -220,7 +218,6 @@ jobs:
             rust_target: aarch64-pc-windows-msvc
         python-version:
           - 3.14
-          - 3.13t
           - 3.14t
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -279,7 +276,6 @@ jobs:
             rust_target: aarch64-apple-darwin
         python-version:
           - 3.14
-          - 3.13t
           - 3.14t
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2


### PR DESCRIPTION
`pyo3` (so `maturin`) has [dropped](https://github.com/PyO3/pyo3/releases/tag/v0.29.0) support for Python `3.13t`, so our hf-xet Python release CI is failing. This PR drops releases for Python `3.13t`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI matrix-only change; narrows published wheel variants with no runtime or application code changes.
> 
> **Overview**
> Stops building and publishing **hf-xet** wheels for **Python 3.13t** because PyO3/maturin no longer supports that interpreter.
> 
> The change removes `3.13t` from the `python-version` matrix in the **linux**, **musllinux**, **windows**, and **macos** jobs in `.github/workflows/release.yml`. Releases continue for **3.14** and **3.14t** on the same platform targets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e6f0add69f8a24f7365b1b7b6b8ba50e98192c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->