### PR TITLE
fix(client): call versioned /v1/shards endpoint for shard uploads

### DIFF
--- a/xet_client/src/cas_client/remote_client.rs
+++ b/xet_client/src/cas_client/remote_client.rs
@@ -581,7 +581,7 @@ impl Client for RemoteClient {
         event!(INFORMATION_LOG_LEVEL, call_id, size = n_upload_bytes, "Starting upload_shard API call",);
 
         let api_tag = "cas::upload_shard";
-        let url = Url::parse(&format!("{}/shards", self.endpoint))?;
+        let url = Url::parse(&format!("{}/v1/shards", self.endpoint))?;
 
         // Use the no-read-timeout client for shard uploads. reqwest's per-request timeout()
         // does NOT override the client-level read_timeout(), so we use a separate client

--- a/xet_client/src/cas_client/simulation/local_server/server.rs
+++ b/xet_client/src/cas_client/simulation/local_server/server.rs
@@ -179,6 +179,7 @@ impl LocalServer {
                     .route("/reconstructions/{file_id}", get(handlers::get_reconstruction))
                     .route("/chunks/{prefix}/{hash}", get(handlers::get_dedup_info_by_chunk))
                     .route("/xorbs/{prefix}/{hash}", head(handlers::head_xorb).post(handlers::post_xorb))
+                    .route("/shards", post(handlers::post_shard))
                     .route("/files/{file_id}", head(handlers::head_file))
                     .route("/get_xorb/{prefix}/{hash}/", get(handlers::get_file_term_data))
                     .route("/fetch_term", get(handlers::fetch_term)),
@@ -193,7 +194,6 @@ impl LocalServer {
             )
             // Routes used by RemoteClient without /v1/ prefix
             .route("/reconstructions", get(handlers::batch_get_reconstruction))
-            .route("/shards", post(handlers::post_shard))
             .layer(CorsLayer::very_permissive())
             .with_state(handlers::ServerState {
                 client: self.client.clone(),


### PR DESCRIPTION
The shard-upload client was still calling the old unversioned `/shards` path while every other CAS endpoint (chunks, reconstructions, xorbs, file-chunk-hashes) already uses a version prefix. This switches `upload_shard` to the canonical `/v1/shards` and registers that route on the simulation mock server.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small URL change only; risk is limited to environments that still expose only unversioned `/shards` without `/v1/shards`.
> 
> **Overview**
> Shard uploads from `RemoteClient::upload_shard` now POST to **`/v1/shards`** instead of the legacy unversioned **`/shards`**, matching other versioned CAS routes (`/v1/chunks`, `/v1/xorbs`, etc.).
> 
> The simulation **local server** registers **`POST /v1/shards`** under the `/v1` router and drops the root-level **`/shards`** alias so local/integration tests hit the same path the client uses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a4ba3aa75e0236611315169364e5d1087cb9f2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->