### PR TITLE
feat(file-reconstruction): add read_timeout to bound stalled download streams

### DIFF
--- a/xet_data/src/file_reconstruction/data_writer/download_stream.rs
+++ b/xet_data/src/file_reconstruction/data_writer/download_stream.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use bytes::Bytes;
 use tokio::sync::Notify;
@@ -39,6 +40,10 @@ pub struct DownloadStream {
     /// Signal to unblock the spawned reconstruction task. `Some` means
     /// `start()` has not yet been called; the spawned task is waiting.
     start_signal: Option<Arc<Notify>>,
+    /// Optional inactivity timeout: when set, a [`next`](Self::next) that waits
+    /// longer than this for the next chunk fails with
+    /// [`FileReconstructionError::ReadTimeout`] and cancels the reconstruction.
+    read_timeout: Option<Duration>,
 }
 
 impl DownloadStream {
@@ -49,7 +54,11 @@ impl DownloadStream {
     /// # Panics
     ///
     /// Panics if called outside a tokio runtime context.
-    pub(crate) fn new(reconstructor: FileReconstructor, run_state: Arc<RunState>) -> Self {
+    pub(crate) fn new(
+        reconstructor: FileReconstructor,
+        run_state: Arc<RunState>,
+        read_timeout: Option<Duration>,
+    ) -> Self {
         let (data_writer, receiver) = SequentialWriter::new_streaming(run_state.clone());
         let start_signal = Arc::new(Notify::new());
 
@@ -66,6 +75,7 @@ impl DownloadStream {
             finished: false,
             run_state,
             start_signal: Some(start_signal),
+            read_timeout,
         }
     }
 
@@ -149,12 +159,33 @@ impl DownloadStream {
     /// Returns the next chunk of downloaded data asynchronously.
     ///
     /// Returns `Ok(None)` when the download is complete or cancelled.
+    ///
+    /// If a `read_timeout` was configured on the [`FileReconstructor`], a call
+    /// that waits longer than that for the next chunk fails with
+    /// [`FileReconstructionError::ReadTimeout`] and cancels the reconstruction
+    /// (aborting the in-flight fetch).
     pub async fn next(&mut self) -> Result<Option<Bytes>> {
         if self.finished {
             return Ok(None);
         }
         self.ensure_started();
 
+        match self.read_timeout {
+            Some(timeout) => match tokio::time::timeout(timeout, self.next_inner()).await {
+                Ok(result) => result,
+                Err(_elapsed) => {
+                    // Stalled with no data: abort the reconstruction so the
+                    // in-flight fetch is cancelled, then surface the timeout.
+                    self.cancel_reconstruction();
+                    self.finished = true;
+                    Err(FileReconstructionError::ReadTimeout(timeout))
+                },
+            },
+            None => self.next_inner().await,
+        }
+    }
+
+    async fn next_inner(&mut self) -> Result<Option<Bytes>> {
         let item = if let Ok(item) = self.receiver.try_recv() {
             Some(item)
         } else {

--- a/xet_data/src/file_reconstruction/error.rs
+++ b/xet_data/src/file_reconstruction/error.rs
@@ -27,6 +27,9 @@ pub enum FileReconstructionError {
     #[error("Internal Error: {0}")]
     InternalError(String),
 
+    #[error("Read timed out after {0:?} with no data from CAS/CDN")]
+    ReadTimeout(std::time::Duration),
+
     #[error("Task Join Error: {0}")]
     TaskJoinError(Arc<tokio::task::JoinError>),
 

--- a/xet_data/src/file_reconstruction/file_reconstructor.rs
+++ b/xet_data/src/file_reconstruction/file_reconstructor.rs
@@ -7,6 +7,7 @@ use std::io::{Seek, SeekFrom};
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
+use std::time::Duration;
 
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info};
@@ -46,6 +47,13 @@ pub struct FileReconstructor {
     /// When cancelled, reconstruction stops at its next check point. Long waits
     /// (such as semaphore acquisition) use `tokio::select!` so they abort promptly.
     cancellation_token: CancellationToken,
+
+    /// Optional inactivity timeout for the streaming path. When set, each
+    /// [`DownloadStream::next`] that waits longer than this for the next chunk
+    /// fails with [`FileReconstructionError::ReadTimeout`] and cancels the
+    /// reconstruction. Guards against a stalled CAS/CDN connection wedging a
+    /// consumer indefinitely. `None` (default) preserves the unbounded behavior.
+    read_timeout: Option<Duration>,
 }
 
 impl FileReconstructor {
@@ -60,6 +68,7 @@ impl FileReconstructor {
             chunk_cache: None,
             custom_buffer_semaphore: None,
             cancellation_token: CancellationToken::new(),
+            read_timeout: None,
         }
     }
 
@@ -80,6 +89,18 @@ impl FileReconstructor {
     pub fn with_chunk_cache(self, cache: Arc<dyn ChunkCache>) -> Self {
         Self {
             chunk_cache: Some(cache),
+            ..self
+        }
+    }
+
+    /// Sets an inactivity timeout for the streaming path ([`reconstruct_to_stream`](Self::reconstruct_to_stream)).
+    /// When set, each [`DownloadStream::next`] that waits longer than `timeout`
+    /// for the next chunk fails with [`FileReconstructionError::ReadTimeout`] and
+    /// cancels the reconstruction (aborting the in-flight fetch). Has no effect on
+    /// the non-streaming paths.
+    pub fn with_read_timeout(self, timeout: Duration) -> Self {
+        Self {
+            read_timeout: Some(timeout),
             ..self
         }
     }
@@ -209,8 +230,9 @@ impl FileReconstructor {
     /// uses [`tokio::spawn`]).
     pub fn reconstruct_to_stream(self) -> DownloadStream {
         let run_state = RunState::new(self.cancellation_token.clone(), self.file_hash, self.progress_updater.clone());
+        let read_timeout = self.read_timeout;
 
-        DownloadStream::new(self, run_state)
+        DownloadStream::new(self, run_state, read_timeout)
     }
 
     /// Reconstructs the file as an unordered stream, returning an
@@ -673,6 +695,60 @@ mod tests {
                     .expect("reconstruct_to_file_at_offset_zero should succeed");
             assert_eq!(file_offset_result, expected, "file_at_offset failed (vectored={use_vectored})");
         }
+    }
+
+    // ==================== Read Timeout Tests ====================
+
+    /// A stalled reconstruction must surface `ReadTimeout` from `next()` instead
+    /// of hanging forever. A 0-permit custom buffer semaphore (which is never
+    /// seeded, since the dynamic scaling only runs for the global limiter) blocks
+    /// the reconstruction at the buffer acquisition before any data is produced,
+    /// standing in for a stalled CAS/CDN connection.
+    #[tokio::test]
+    async fn read_timeout_fires_when_reconstruction_stalls() {
+        let (client, file_contents) = setup_test_file(&[(1, (0, 3))]).await;
+
+        let stalled_semaphore = AdjustableSemaphore::new(0, (0, 10_000));
+
+        let mut stream = FileReconstructor::new(
+            &XetContext::default().unwrap(),
+            &(client.clone() as Arc<dyn Client>),
+            file_contents.file_hash,
+        )
+        .with_config(&test_config())
+        .with_buffer_semaphore(stalled_semaphore)
+        .with_read_timeout(Duration::from_millis(100))
+        .reconstruct_to_stream();
+
+        let result = stream.next().await;
+        assert!(
+            matches!(result, Err(FileReconstructionError::ReadTimeout(_))),
+            "expected ReadTimeout on a stalled reconstruction, got {result:?}"
+        );
+
+        // After a timeout the stream is finished and cancelled.
+        assert!(matches!(stream.next().await, Ok(None)));
+    }
+
+    /// With no `read_timeout` set, a healthy reconstruction streams normally
+    /// (guards against the timeout path regressing the default behavior).
+    #[tokio::test]
+    async fn no_read_timeout_streams_normally() {
+        let (client, file_contents) = setup_test_file(&[(1, (0, 3))]).await;
+
+        let mut stream = FileReconstructor::new(
+            &XetContext::default().unwrap(),
+            &(client.clone() as Arc<dyn Client>),
+            file_contents.file_hash,
+        )
+        .with_config(&test_config())
+        .reconstruct_to_stream();
+
+        let mut out = Vec::new();
+        while let Some(chunk) = stream.next().await.unwrap() {
+            out.extend_from_slice(&chunk);
+        }
+        assert_eq!(out, file_contents.data);
     }
 
     // ==================== Full File Reconstruction Tests ====================


### PR DESCRIPTION
## Problem

`DownloadStream::next()` awaits the next reconstructed chunk with **no upper bound**. If the underlying CAS/CDN connection stalls (delivers no data and no error), `next()` never returns.

Consumers that block a thread on `next()` are then parked indefinitely. A concrete case: a FUSE filesystem (e.g. mountpoint-style mounts, or `hf-mount`) does `block_on(stream.next())` on a bounded pool of worker threads — a single stalled stream pins a worker forever, and once enough stalled reads accumulate, every worker is stuck and the whole mount silently wedges (cold reads hang while metadata ops still work). The only recourse today is to cancel the entire stream.

## Change

Add an optional **inactivity timeout** to the streaming reconstruction path:

- `FileReconstructor::with_read_timeout(Duration)` — opt-in, stored as `Option<Duration>` (default `None`).
- `DownloadStream::next()` — when a timeout is set, a call that waits longer than `timeout` for the next chunk returns the new `FileReconstructionError::ReadTimeout(Duration)` and **cancels the reconstruction** (via the existing `RunState`), so the in-flight fetch is aborted rather than left running detached.

`None` preserves the current unbounded behavior, so this is fully backwards compatible.

The point is to put the stall bound **in the client library**, where every consumer benefits, instead of each one wrapping `next()` in its own `tokio::time::timeout` (which leaves the underlying fetch running).

## Scope

Applies to the ordered streaming path (`reconstruct_to_stream` → `DownloadStream::next`). Left unchanged, as candidates for the same treatment later:
- `DownloadStream::blocking_next()` (sync path; `blocking_recv` has no timeout variant),
- `UnorderedDownloadStream`,
- the file/writer reconstruction paths (`reconstruct_to_file` / `reconstruct_to_writer`), which have no consumer-side `next()` to bound — they'd need the timeout inside the reconstruction loop itself.

## Tests

- `read_timeout_fires_when_reconstruction_stalls`: a 0-permit custom buffer semaphore (never seeded, since dynamic scaling only runs for the global limiter) stalls the reconstruction at buffer acquisition before any data is produced — standing in for a stalled CAS/CDN connection. `next()` returns `ReadTimeout`, and the next call returns `Ok(None)` (stream finished/cancelled).
- `no_read_timeout_streams_normally`: with no timeout set, a healthy reconstruction streams to completion unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core streaming download behavior and cancellation on timeout; default is opt-in `None`, but misconfigured timeouts could abort slow-but-valid reads.
> 
> **Overview**
> Adds an **opt-in inactivity timeout** on the ordered streaming path so consumers are not blocked forever when CAS/CDN stops delivering chunks.
> 
> **`FileReconstructor::with_read_timeout(Duration)`** stores an optional timeout (default **`None`** keeps unbounded waits). **`reconstruct_to_stream`** passes it into **`DownloadStream`**, which wraps async **`next()`** with **`tokio::time::timeout`**. If a wait exceeds the limit, the stream returns **`FileReconstructionError::ReadTimeout`**, marks the stream finished, and **cancels reconstruction** via existing **`RunState`** so the background fetch is torn down—not left running after an outer timeout.
> 
> A new **`next_inner`** holds the prior receive logic; **`blocking_next`**, unordered streams, and file/writer paths are unchanged. Tests cover a stalled reconstruction (0-permit buffer semaphore) surfacing **`ReadTimeout`** and the default path still streaming to completion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba891f33ee0f3eb8b710b28b4799bc3dbe1c79f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->