### PR TITLE
feat: add lifecycle-tag deletion mode to simulation clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"
@@ -1098,9 +1098,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a0d26b245348befa0c121944541476763dcc46ede886c88f9d12e1697d27c3"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
 dependencies = [
  "cpubits",
  "ctutils",
@@ -2155,9 +2155,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "ctutils",
  "subtle",
@@ -3571,9 +3571,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -4765,7 +4765,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -5216,9 +5216,9 @@ checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "typewit"

--- a/xet_client/src/cas_client/simulation/local_client.rs
+++ b/xet_client/src/cas_client/simulation/local_client.rs
@@ -4,7 +4,7 @@ use std::io::{BufReader, Cursor, Read, Seek, SeekFrom, Write};
 use std::mem::size_of;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU16, AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, Weak};
 
 use anyhow::anyhow;
@@ -259,6 +259,13 @@ pub struct LocalClient {
     max_ranges_per_fetch: AtomicUsize,
     /// HTTP status code to return when V2 is disabled (0 = enabled).
     v2_disabled_status: AtomicU16,
+    /// When true, deletes rename the on-disk object to `<canonical>.gctag`
+    /// instead of removing it, mirroring production's S3 lifecycle-tag
+    /// deletion. Reads of the canonical path then fail as
+    /// if the object were gone, while a subsequent upload of the same hash
+    /// clears the `.gctag` file (matching S3 PutObject overwriting a tagged
+    /// object). Off by default; opt in via [`Self::set_lifecycle_tag_deletion`].
+    lifecycle_tag_deletion: AtomicBool,
     _tmp_dir: Option<TempDir>,
 }
 
@@ -334,6 +341,7 @@ impl LocalClient {
             random_ms_delay_window: (AtomicU64::new(0), AtomicU64::new(0)),
             max_ranges_per_fetch: AtomicUsize::new(usize::MAX),
             v2_disabled_status: AtomicU16::new(0),
+            lifecycle_tag_deletion: AtomicBool::new(false),
             _tmp_dir: tmp_dir,
         })
     }
@@ -345,6 +353,33 @@ impl LocalClient {
     /// Internal function to get the path for a given hash entry
     fn get_path_for_entry(&self, hash: &MerkleHash) -> PathBuf {
         self.xorb_dir.join(format!("default.{hash:?}"))
+    }
+
+    /// Toggle lifecycle-tag deletion mode (see [`Self::lifecycle_tag_deletion`]).
+    pub fn set_lifecycle_tag_deletion(&self, on: bool) {
+        self.lifecycle_tag_deletion.store(on, Ordering::Relaxed);
+    }
+
+    fn lifecycle_tag_deletion_enabled(&self) -> bool {
+        self.lifecycle_tag_deletion.load(Ordering::Relaxed)
+    }
+
+    /// Path used to park a tagged-for-deletion xorb: `<canonical>.gctag`.
+    /// Bytes are retained on disk until an upload of the same hash clears
+    /// the tag (matching S3 PutObject overwriting a tagged object).
+    fn gctag_xorb_path(&self, hash: &MerkleHash) -> PathBuf {
+        let canonical = self.get_path_for_entry(hash);
+        let mut name = canonical.into_os_string();
+        name.push(".gctag");
+        PathBuf::from(name)
+    }
+
+    /// Path used to park a tagged-for-deletion shard: `<hex>.mdb.gctag`.
+    fn gctag_shard_path(&self, hash: &MerkleHash) -> PathBuf {
+        let canonical = self.shard_dir.join(shard_file_name(hash));
+        let mut name = canonical.into_os_string();
+        name.push(".gctag");
+        PathBuf::from(name)
     }
 
     #[cfg(test)]
@@ -364,6 +399,9 @@ impl LocalClient {
         for entry in std::fs::read_dir(&self.shard_dir).map_err(ClientError::internal)? {
             let entry = entry.map_err(ClientError::internal)?;
             let path = entry.path();
+            if path.file_name().and_then(|n| n.to_str()).is_some_and(|n| n.ends_with(".gctag")) {
+                continue;
+            }
             if let Some(hash) = parse_shard_filename(&path)
                 && path.is_file()
             {
@@ -597,6 +635,9 @@ impl DirectAccessClient for LocalClient {
             .filter_map(|x| x.ok())
             .filter_map(|x| x.file_name().into_string().ok())
             .for_each(|x| {
+                if x.ends_with(".gctag") {
+                    return;
+                }
                 if let Some(pos) = x.rfind('.') {
                     let hash = &x[(pos + 1)..];
                     if let Ok(hash) = MerkleHash::from_hex(hash) {
@@ -857,7 +898,12 @@ impl super::DeletionControlableClient for LocalClient {
     async fn delete_shard_entry(&self, hash: &MerkleHash) -> Result<()> {
         let path = self.shard_path_for_hash(hash)?;
         self.remove_file_entries_for_shard(hash)?;
-        std::fs::remove_file(&path)?;
+        if self.lifecycle_tag_deletion_enabled() {
+            let gctag = self.gctag_shard_path(hash);
+            std::fs::rename(&path, &gctag)?;
+        } else {
+            std::fs::remove_file(&path)?;
+        }
         Ok(())
     }
 
@@ -939,7 +985,14 @@ impl super::DeletionControlableClient for LocalClient {
         #[cfg(windows)]
         Self::clear_readonly(&file_path);
 
-        let _ = std::fs::remove_file(file_path);
+        if self.lifecycle_tag_deletion_enabled() {
+            let gctag = self.gctag_xorb_path(hash);
+            #[cfg(windows)]
+            Self::clear_readonly(&gctag);
+            let _ = std::fs::rename(&file_path, &gctag);
+        } else {
+            let _ = std::fs::remove_file(file_path);
+        }
     }
 
     async fn list_xorbs_and_tags(&self) -> Result<Vec<(MerkleHash, ObjectTag)>> {
@@ -988,7 +1041,14 @@ impl super::DeletionControlableClient for LocalClient {
         #[cfg(windows)]
         Self::clear_readonly(&tmp_path);
 
-        std::fs::remove_file(&tmp_path)?;
+        if self.lifecycle_tag_deletion_enabled() {
+            let gctag = self.gctag_xorb_path(hash);
+            #[cfg(windows)]
+            Self::clear_readonly(&gctag);
+            std::fs::rename(&tmp_path, &gctag)?;
+        } else {
+            std::fs::remove_file(&tmp_path)?;
+        }
         Ok(true)
     }
 
@@ -1026,7 +1086,12 @@ impl super::DeletionControlableClient for LocalClient {
             Self::restore_from_tmp(&tmp_path, &path);
             return Err(e);
         }
-        std::fs::remove_file(&tmp_path)?;
+        if self.lifecycle_tag_deletion_enabled() {
+            let gctag = self.gctag_shard_path(hash);
+            std::fs::rename(&tmp_path, &gctag)?;
+        } else {
+            std::fs::remove_file(&tmp_path)?;
+        }
         Ok(true)
     }
 
@@ -1510,6 +1575,11 @@ impl Client for LocalClient {
         }
         write_txn.commit().map_err(map_redb_db_error)?;
 
+        // A re-upload of the same shard hash supersedes any prior
+        // lifecycle-tagged copy: clear the `.gctag` file so the shard is
+        // readable again. Mirrors S3 PutObject overwriting a tagged object.
+        let _ = std::fs::remove_file(self.gctag_shard_path(&shard_hash));
+
         Ok(true)
     }
 
@@ -1578,6 +1648,11 @@ impl Client for LocalClient {
             permissions.set_readonly(true);
             let _ = std::fs::set_permissions(&file_path, permissions);
         }
+
+        // A re-upload of the same xorb hash supersedes any prior
+        // lifecycle-tagged copy: clear the `.gctag` file so the xorb is
+        // readable again. Mirrors S3 PutObject overwriting a tagged object.
+        let _ = std::fs::remove_file(self.gctag_xorb_path(&hash));
 
         info!("{file_path:?} successfully written with {bytes_written} bytes.");
 
@@ -2217,5 +2292,129 @@ mod tests {
         let (_, tag2) = tags2.iter().find(|(h, _)| *h == xorb_hash2).unwrap();
 
         assert_ne!(tag1, tag2, "Tags should differ after re-creation with timestamp delay");
+    }
+
+    // ── Lifecycle-tag deletion mode tests ───────────────────────────────
+
+    #[tokio::test]
+    async fn test_lifecycle_tag_xorb_delete_renames_to_gctag() {
+        let client = LocalClient::temporary(test_context()).await.unwrap();
+        client.set_lifecycle_tag_deletion(true);
+
+        let file = client.upload_random_file(&[(1, (0, 2))], 2048).await.unwrap();
+        let xorb_hash = file.terms[0].xorb_hash;
+        assert!(client.xorb_exists(&xorb_hash).await.unwrap());
+
+        client.delete_xorb(&xorb_hash).await;
+
+        // Canonical path is gone — reads fail.
+        assert!(!client.xorb_exists(&xorb_hash).await.unwrap());
+        assert!(client.get_full_xorb(&xorb_hash).await.is_err());
+        // .gctag file retains the bytes.
+        let gctag = client.gctag_xorb_path(&xorb_hash);
+        assert!(gctag.exists(), "gctag file should exist after tag-delete");
+        // list_xorbs excludes the tagged xorb.
+        let listed = client.list_xorbs().await.unwrap();
+        assert!(!listed.contains(&xorb_hash));
+    }
+
+    #[tokio::test]
+    async fn test_lifecycle_tag_xorb_upload_clears_tag() {
+        let client = LocalClient::temporary(test_context()).await.unwrap();
+        client.set_lifecycle_tag_deletion(true);
+
+        let file = client.upload_random_file(&[(1, (0, 2))], 2048).await.unwrap();
+        let xorb_hash = file.terms[0].xorb_hash;
+
+        client.delete_xorb(&xorb_hash).await;
+        let gctag = client.gctag_xorb_path(&xorb_hash);
+        assert!(gctag.exists());
+
+        // Re-upload the same xorb (same content seed) — tag is cleared.
+        let file2 = client.upload_random_file(&[(1, (0, 2))], 2048).await.unwrap();
+        let xorb_hash2 = file2.terms[0].xorb_hash;
+        assert_eq!(xorb_hash, xorb_hash2, "same seed should produce same xorb hash");
+
+        assert!(!gctag.exists(), "gctag file should be removed after re-upload");
+        assert!(client.xorb_exists(&xorb_hash).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_lifecycle_tag_shard_delete_renames_to_gctag() {
+        let client = LocalClient::temporary(test_context()).await.unwrap();
+        client.set_lifecycle_tag_deletion(true);
+
+        let file = client.upload_random_file(&[(1, (0, 2))], 2048).await.unwrap();
+        let shard_hash = client.list_shard_entries().await.unwrap().pop().unwrap();
+
+        // Remove the file entry first (as the harness does on user delete).
+        client.delete_file_entry(&file.file_hash).await.unwrap();
+        // Now GC deletes the shard.
+        client.delete_shard_entry(&shard_hash).await.unwrap();
+
+        // Canonical shard path is gone.
+        assert!(client.get_shard_bytes(&shard_hash).await.is_err());
+        // .gctag file retains the bytes.
+        let gctag = client.gctag_shard_path(&shard_hash);
+        assert!(gctag.exists(), "gctag shard file should exist after tag-delete");
+        // list_shard_entries excludes the tagged shard.
+        let listed = client.list_shard_entries().await.unwrap();
+        assert!(!listed.contains(&shard_hash));
+    }
+
+    #[tokio::test]
+    async fn test_lifecycle_tag_mode_off_hard_deletes() {
+        let client = LocalClient::temporary(test_context()).await.unwrap();
+        // Mode is off by default.
+        assert!(!client.lifecycle_tag_deletion_enabled());
+
+        let file = client.upload_random_file(&[(1, (0, 2))], 2048).await.unwrap();
+        let xorb_hash = file.terms[0].xorb_hash;
+
+        client.delete_xorb(&xorb_hash).await;
+
+        let gctag = client.gctag_xorb_path(&xorb_hash);
+        assert!(!gctag.exists(), "gctag file should NOT exist when mode is off");
+        let canonical = client.get_path_for_entry(&xorb_hash);
+        assert!(!canonical.exists(), "canonical file should be hard-deleted");
+    }
+
+    #[tokio::test]
+    async fn test_lifecycle_tag_verify_integrity_flags_tagged_xorb() {
+        let client = LocalClient::temporary(test_context()).await.unwrap();
+        client.set_lifecycle_tag_deletion(true);
+
+        // Upload a file, then tag its xorb WITHOUT removing the file entry
+        // (simulates a GC bug: tagging an xorb still referenced by an active file).
+        let file = client.upload_random_file(&[(1, (0, 2))], 2048).await.unwrap();
+        let xorb_hash = file.terms[0].xorb_hash;
+
+        client.delete_xorb(&xorb_hash).await;
+
+        // verify_integrity should fail: the file entry references a tagged xorb
+        // whose canonical path no longer exists.
+        assert!(client.verify_integrity().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_lifecycle_tag_verify_all_reachable_ignores_tagged() {
+        let client = LocalClient::temporary(test_context()).await.unwrap();
+        client.set_lifecycle_tag_deletion(true);
+
+        let file = client.upload_random_file(&[(1, (0, 2))], 2048).await.unwrap();
+        let xorb_hash = file.terms[0].xorb_hash;
+        let shard_hash = client.list_shard_entries().await.unwrap().pop().unwrap();
+
+        // Properly delete: remove file entry, then tag shard + xorb.
+        client.delete_file_entry(&file.file_hash).await.unwrap();
+        client.delete_shard_entry(&shard_hash).await.unwrap();
+        client.delete_xorb(&xorb_hash).await;
+
+        // verify_all_reachable should pass: tagged objects are treated as
+        // already collected, not as orphaned on-disk data.
+        client
+            .verify_all_reachable()
+            .await
+            .expect("tagged objects should be ignored by reachability");
     }
 }

--- a/xet_client/src/cas_client/simulation/memory_client.rs
+++ b/xet_client/src/cas_client/simulation/memory_client.rs
@@ -488,6 +488,7 @@ impl DirectAccessClient for MemoryClient {
         // Treat the shard as gone only when the *current* shard hash matches
         // the tagged one — delete_file_entry mutates the shard hash, so a
         // stale `gc_tagged_shard` must not block files of the new shard.
+        #[cfg(not(target_family = "wasm"))]
         if let Some((shard_hash, _)) = Self::current_shard_hash_and_bytes(&shard)?
             && self.shard_is_tagged(&shard_hash).await
         {
@@ -503,6 +504,7 @@ impl DirectAccessClient for MemoryClient {
         // Refuse reads while the *current* shard hash matches the tagged
         // shard hash — a stale tag must not block files of a new shard
         // after delete_file_entry rewrites the shard.
+        #[cfg(not(target_family = "wasm"))]
         {
             let shard = self.shard.read().await;
             if let Some((shard_hash, _)) = Self::current_shard_hash_and_bytes(&shard)?

--- a/xet_client/src/cas_client/simulation/memory_client.rs
+++ b/xet_client/src/cas_client/simulation/memory_client.rs
@@ -484,10 +484,15 @@ impl DirectAccessClient for MemoryClient {
     }
 
     async fn get_file_size(&self, hash: &MerkleHash) -> Result<u64> {
-        if self.gc_tagged_shard.read().await.is_some() {
+        let shard = self.shard.read().await;
+        // Treat the shard as gone only when the *current* shard hash matches
+        // the tagged one — delete_file_entry mutates the shard hash, so a
+        // stale `gc_tagged_shard` must not block files of the new shard.
+        if let Some((shard_hash, _)) = Self::current_shard_hash_and_bytes(&shard)?
+            && self.shard_is_tagged(&shard_hash).await
+        {
             return Err(ClientError::FileNotFound(*hash));
         }
-        let shard = self.shard.read().await;
         let file_info = shard
             .get_file_reconstruction_info(hash)
             .ok_or(ClientError::FileNotFound(*hash))?;
@@ -495,8 +500,16 @@ impl DirectAccessClient for MemoryClient {
     }
 
     async fn get_file_data(&self, hash: &MerkleHash, byte_range: Option<FileRange>) -> Result<Bytes> {
-        if self.gc_tagged_shard.read().await.is_some() {
-            return Err(ClientError::FileNotFound(*hash));
+        // Refuse reads while the *current* shard hash matches the tagged
+        // shard hash — a stale tag must not block files of a new shard
+        // after delete_file_entry rewrites the shard.
+        {
+            let shard = self.shard.read().await;
+            if let Some((shard_hash, _)) = Self::current_shard_hash_and_bytes(&shard)?
+                && self.shard_is_tagged(&shard_hash).await
+            {
+                return Err(ClientError::FileNotFound(*hash));
+            }
         }
         let file_info = {
             let shard = self.shard.read().await;
@@ -606,6 +619,13 @@ impl DirectAccessClient for MemoryClient {
             return Err(ClientError::InvalidArguments);
         }
 
+        // A lifecycle-tagged xorb is "gone" from the namespace; mirror the
+        // get_full_xorb behavior so reconstruction paths cannot resurrect
+        // tagged data.
+        if self.xorb_is_tagged(&xorb_hash).await {
+            return Err(ClientError::XORBNotFound(xorb_hash));
+        }
+
         let xorbs = self.xorbs.read().await;
         let storage = xorbs.get(&xorb_hash).ok_or_else(|| {
             error!("Unable to find xorb in memory CAS {:?}", hash);
@@ -661,8 +681,15 @@ impl MemoryClient {
             }
         };
 
+        // Snapshot the tagged set so the sync closure can refuse tagged xorbs
+        // without an async lock acquire — a lifecycle-tagged xorb must appear
+        // "gone" to reconstruction, matching get_full_xorb.
+        let tagged = self.gc_tagged_xorbs.read().await.clone();
         let xorbs = self.xorbs.read().await;
         xorb_utils::compute_reconstruction_ranges(&file_info, bytes_range, &mut |hash| {
+            if tagged.contains(hash) {
+                return Err(ClientError::XORBNotFound(*hash));
+            }
             let storage = xorbs.get(hash).ok_or_else(|| {
                 error!("Unable to find xorb in memory CAS {:?}", hash);
                 ClientError::XORBNotFound(*hash)
@@ -983,6 +1010,12 @@ impl Client for MemoryClient {
             return Err(ClientError::PresignedUrlExpirationError);
         }
 
+        // A lifecycle-tagged xorb is "gone" from the namespace; refuse to
+        // serve its bytes via the term-data path, matching get_full_xorb.
+        if self.xorb_is_tagged(&xorb_hash).await {
+            return Err(ClientError::XORBNotFound(xorb_hash));
+        }
+
         let xorbs = self.xorbs.read().await;
         let storage = xorbs.get(&xorb_hash).ok_or(ClientError::XORBNotFound(xorb_hash))?;
 
@@ -1045,9 +1078,15 @@ impl Client for MemoryClient {
                 .ok_or(ClientError::FileNotFound(*file_id))?
         };
 
+        // Snapshot tagged xorbs so a lifecycle-tagged xorb appears "gone" and
+        // is surfaced as XORBNotFound, matching get_xorb_ranges.
+        let tagged = self.gc_tagged_xorbs.read().await.clone();
         let xorbs = self.xorbs.read().await;
         let mut chunks: Vec<(MerkleHash, u64)> = Vec::new();
         for segment in &file_info.segments {
+            if tagged.contains(&segment.xorb_hash) {
+                return Err(ClientError::XORBNotFound(segment.xorb_hash));
+            }
             let storage = xorbs
                 .get(&segment.xorb_hash)
                 .ok_or(ClientError::XORBNotFound(segment.xorb_hash))?;
@@ -1224,10 +1263,21 @@ impl super::DeletionControlableClient for MemoryClient {
         let tagged = self.gc_tagged_xorbs.read().await;
         let xorbs = self.xorbs.read().await;
         let shard = self.shard.read().await;
-        for file_info in shard.file_content.values() {
-            for segment in &file_info.segments {
-                if !xorbs.contains_key(&segment.xorb_hash) || tagged.contains(&segment.xorb_hash) {
-                    return Err(ClientError::XORBNotFound(segment.xorb_hash));
+        // Files living in a lifecycle-tagged shard are "gone" from the
+        // namespace (list APIs hide them too), so do not walk their
+        // segments — `delete_shard_entry` retains `file_content` for
+        // re-upload semantics, but those entries must not be treated as
+        // active for integrity verification.
+        let shard_tagged = match Self::current_shard_hash_and_bytes(&shard)? {
+            Some((shard_hash, _)) => self.gc_tagged_shard.read().await.is_some_and(|h| h == shard_hash),
+            None => false,
+        };
+        if !shard_tagged {
+            for file_info in shard.file_content.values() {
+                for segment in &file_info.segments {
+                    if !xorbs.contains_key(&segment.xorb_hash) || tagged.contains(&segment.xorb_hash) {
+                        return Err(ClientError::XORBNotFound(segment.xorb_hash));
+                    }
                 }
             }
         }

--- a/xet_client/src/cas_client/simulation/memory_client.rs
+++ b/xet_client/src/cas_client/simulation/memory_client.rs
@@ -1,8 +1,8 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::{BufReader, Cursor};
 use std::ops::Range;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU16, AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU64, AtomicUsize, Ordering};
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -75,6 +75,19 @@ pub struct MemoryClient {
     max_ranges_per_fetch: AtomicUsize,
     /// HTTP status code to return when V2 is disabled (0 = enabled).
     v2_disabled_status: AtomicU16,
+    /// When true, deletes move the object's identity into the tagged sets
+    /// below instead of dropping its data, mirroring production's S3
+    /// lifecycle-tag deletion. Reads of a tagged object
+    /// then fail as if it were gone, while a subsequent upload of the same
+    /// hash clears the tag (matching S3 PutObject overwriting a tagged
+    /// object). Off by default; opt in via [`Self::set_lifecycle_tag_deletion`].
+    lifecycle_tag_deletion: AtomicBool,
+    /// XORB hashes currently tagged for lifecycle deletion. Data is retained
+    /// in `xorbs` so a re-upload can clear the tag.
+    gc_tagged_xorbs: RwLock<HashSet<MerkleHash>>,
+    /// Shard hash currently tagged for lifecycle deletion. Shard data is
+    /// retained in `shard` so a re-upload can clear the tag.
+    gc_tagged_shard: RwLock<Option<MerkleHash>>,
 }
 
 impl MemoryClient {
@@ -91,7 +104,27 @@ impl MemoryClient {
             random_ms_delay_window: (AtomicU64::new(0), AtomicU64::new(0)),
             max_ranges_per_fetch: AtomicUsize::new(usize::MAX),
             v2_disabled_status: AtomicU16::new(0),
+            lifecycle_tag_deletion: AtomicBool::new(false),
+            gc_tagged_xorbs: RwLock::new(HashSet::new()),
+            gc_tagged_shard: RwLock::new(None),
         })
+    }
+
+    /// Toggle lifecycle-tag deletion mode (see [`Self::lifecycle_tag_deletion`]).
+    pub fn set_lifecycle_tag_deletion(&self, on: bool) {
+        self.lifecycle_tag_deletion.store(on, Ordering::Relaxed);
+    }
+
+    fn lifecycle_tag_deletion_enabled(&self) -> bool {
+        self.lifecycle_tag_deletion.load(Ordering::Relaxed)
+    }
+
+    async fn xorb_is_tagged(&self, hash: &MerkleHash) -> bool {
+        self.gc_tagged_xorbs.read().await.contains(hash)
+    }
+
+    async fn shard_is_tagged(&self, hash: &MerkleHash) -> bool {
+        self.gc_tagged_shard.read().await.is_some_and(|h| &h == hash)
     }
 
     /// Inserts a RandomXorb into the client's storage and registers it in the shard
@@ -340,10 +373,21 @@ impl DirectAccessClient for MemoryClient {
     }
 
     async fn list_xorbs(&self) -> Result<Vec<MerkleHash>> {
-        Ok(self.xorbs.read().await.keys().copied().collect())
+        let tagged = self.gc_tagged_xorbs.read().await;
+        Ok(self
+            .xorbs
+            .read()
+            .await
+            .keys()
+            .copied()
+            .filter(|h| !tagged.contains(h))
+            .collect())
     }
 
     async fn get_full_xorb(&self, hash: &MerkleHash) -> Result<Bytes> {
+        if self.xorb_is_tagged(hash).await {
+            return Err(ClientError::XORBNotFound(*hash));
+        }
         let xorbs = self.xorbs.read().await;
         let storage = xorbs.get(hash).ok_or_else(|| {
             error!("Unable to find xorb in memory CAS {:?}", hash);
@@ -364,6 +408,9 @@ impl DirectAccessClient for MemoryClient {
     }
 
     async fn get_xorb_ranges(&self, hash: &MerkleHash, chunk_ranges: Vec<(u32, u32)>) -> Result<Vec<Bytes>> {
+        if self.xorb_is_tagged(hash).await {
+            return Err(ClientError::XORBNotFound(*hash));
+        }
         if chunk_ranges.is_empty() {
             return Ok(vec![Bytes::new()]);
         }
@@ -406,15 +453,24 @@ impl DirectAccessClient for MemoryClient {
     }
 
     async fn xorb_length(&self, hash: &MerkleHash) -> Result<u32> {
+        if self.xorb_is_tagged(hash).await {
+            return Err(ClientError::XORBNotFound(*hash));
+        }
         let data = self.get_full_xorb(hash).await?;
         Ok(data.len() as u32)
     }
 
     async fn xorb_exists(&self, hash: &MerkleHash) -> Result<bool> {
+        if self.xorb_is_tagged(hash).await {
+            return Ok(false);
+        }
         Ok(self.xorbs.read().await.contains_key(hash))
     }
 
     async fn xorb_footer(&self, hash: &MerkleHash) -> Result<XorbObject> {
+        if self.xorb_is_tagged(hash).await {
+            return Err(ClientError::XORBNotFound(*hash));
+        }
         let xorbs = self.xorbs.read().await;
         let storage = xorbs.get(hash).ok_or_else(|| {
             error!("Unable to find xorb in memory CAS {:?}", hash);
@@ -428,6 +484,9 @@ impl DirectAccessClient for MemoryClient {
     }
 
     async fn get_file_size(&self, hash: &MerkleHash) -> Result<u64> {
+        if self.gc_tagged_shard.read().await.is_some() {
+            return Err(ClientError::FileNotFound(*hash));
+        }
         let shard = self.shard.read().await;
         let file_info = shard
             .get_file_reconstruction_info(hash)
@@ -436,6 +495,9 @@ impl DirectAccessClient for MemoryClient {
     }
 
     async fn get_file_data(&self, hash: &MerkleHash, byte_range: Option<FileRange>) -> Result<Bytes> {
+        if self.gc_tagged_shard.read().await.is_some() {
+            return Err(ClientError::FileNotFound(*hash));
+        }
         let file_info = {
             let shard = self.shard.read().await;
             shard
@@ -471,6 +533,9 @@ impl DirectAccessClient for MemoryClient {
     }
 
     async fn get_xorb_raw_bytes(&self, hash: &MerkleHash, byte_range: Option<FileRange>) -> Result<Bytes> {
+        if self.xorb_is_tagged(hash).await {
+            return Err(ClientError::XORBNotFound(*hash));
+        }
         let xorbs = self.xorbs.read().await;
         let storage = xorbs.get(hash).ok_or(ClientError::XORBNotFound(*hash))?;
 
@@ -506,6 +571,9 @@ impl DirectAccessClient for MemoryClient {
     }
 
     async fn xorb_raw_length(&self, hash: &MerkleHash) -> Result<u64> {
+        if self.xorb_is_tagged(hash).await {
+            return Err(ClientError::XORBNotFound(*hash));
+        }
         let xorbs = self.xorbs.read().await;
         let storage = xorbs.get(hash).ok_or(ClientError::XORBNotFound(*hash))?;
 
@@ -782,6 +850,11 @@ impl Client for MemoryClient {
             }
         }
 
+        // A re-upload supersedes any prior lifecycle-tagged shard: clear the
+        // tag so the shard is readable again. Mirrors S3 PutObject
+        // overwriting a tagged object.
+        *self.gc_tagged_shard.write().await = None;
+
         Ok(true)
     }
 
@@ -841,6 +914,11 @@ impl Client for MemoryClient {
                 },
             );
         }
+
+        // A re-upload of the same xorb hash supersedes any prior
+        // lifecycle-tagged copy: clear the tag so the xorb is readable again.
+        // Mirrors S3 PutObject overwriting a tagged object.
+        self.gc_tagged_xorbs.write().await.remove(&hash);
 
         if let Some(ref cb) = progress_callback {
             let n = bytes_written as u64;
@@ -993,12 +1071,19 @@ impl Client for MemoryClient {
 impl super::DeletionControlableClient for MemoryClient {
     async fn list_shard_entries(&self) -> Result<Vec<MerkleHash>> {
         let shard = self.shard.read().await;
-        Ok(Self::current_shard_hash_and_bytes(&shard)?
-            .map(|(h, _)| vec![h])
-            .unwrap_or_default())
+        let Some((h, _)) = Self::current_shard_hash_and_bytes(&shard)? else {
+            return Ok(Vec::new());
+        };
+        if self.shard_is_tagged(&h).await {
+            return Ok(Vec::new());
+        }
+        Ok(vec![h])
     }
 
     async fn get_shard_bytes(&self, hash: &MerkleHash) -> Result<Bytes> {
+        if self.shard_is_tagged(hash).await {
+            return Err(ClientError::Other(format!("Shard not found: {}", hash.hex())));
+        }
         let shard = self.shard.read().await;
         let Some((current_hash, bytes)) = Self::current_shard_hash_and_bytes(&shard)? else {
             return Err(ClientError::Other(format!("Shard not found: {}", hash.hex())));
@@ -1017,7 +1102,11 @@ impl super::DeletionControlableClient for MemoryClient {
         if &current_hash != hash {
             return Err(ClientError::Other(format!("Shard not found: {}", hash.hex())));
         }
-        *shard = MDBInMemoryShard::default();
+        if self.lifecycle_tag_deletion_enabled() {
+            *self.gc_tagged_shard.write().await = Some(current_hash);
+        } else {
+            *shard = MDBInMemoryShard::default();
+        }
         Ok(())
     }
 
@@ -1026,6 +1115,9 @@ impl super::DeletionControlableClient for MemoryClient {
         let Some((shard_hash, _)) = Self::current_shard_hash_and_bytes(&shard)? else {
             return Ok(Vec::new());
         };
+        if self.shard_is_tagged(&shard_hash).await {
+            return Ok(Vec::new());
+        }
         Ok(shard
             .file_content
             .keys()
@@ -1057,26 +1149,39 @@ impl super::DeletionControlableClient for MemoryClient {
     }
 
     async fn delete_xorb(&self, hash: &MerkleHash) {
-        self.xorbs.write().await.remove(hash);
+        if self.lifecycle_tag_deletion_enabled() {
+            self.gc_tagged_xorbs.write().await.insert(*hash);
+        } else {
+            self.xorbs.write().await.remove(hash);
+        }
     }
 
     async fn list_xorbs_and_tags(&self) -> Result<Vec<(MerkleHash, ObjectTag)>> {
+        let tagged = self.gc_tagged_xorbs.read().await;
         let xorbs = self.xorbs.read().await;
         Ok(xorbs
             .iter()
+            .filter(|(hash, _)| !tagged.contains(hash))
             .map(|(hash, storage)| (*hash, Self::xorb_tag(hash, storage)))
             .collect())
     }
 
     async fn delete_xorb_if_tag_matches(&self, hash: &MerkleHash, tag: &ObjectTag) -> Result<bool> {
-        let mut xorbs = self.xorbs.write().await;
-        let Some(storage) = xorbs.get(hash) else {
-            return Err(ClientError::XORBNotFound(*hash));
+        let current_tag = {
+            let xorbs = self.xorbs.read().await;
+            let Some(storage) = xorbs.get(hash) else {
+                return Err(ClientError::XORBNotFound(*hash));
+            };
+            Self::xorb_tag(hash, storage)
         };
-        if &Self::xorb_tag(hash, storage) != tag {
+        if &current_tag != tag {
             return Ok(false);
         }
-        xorbs.remove(hash);
+        if self.lifecycle_tag_deletion_enabled() {
+            self.gc_tagged_xorbs.write().await.insert(*hash);
+        } else {
+            self.xorbs.write().await.remove(hash);
+        }
         Ok(true)
     }
 
@@ -1085,32 +1190,43 @@ impl super::DeletionControlableClient for MemoryClient {
         let Some((shard_hash, shard_bytes)) = Self::current_shard_hash_and_bytes(&shard)? else {
             return Ok(Vec::new());
         };
+        if self.shard_is_tagged(&shard_hash).await {
+            return Ok(Vec::new());
+        }
         let tag = Self::object_tag_from_key_and_payload(b"shard", &shard_hash, shard_bytes.as_ref());
         Ok(vec![(shard_hash, tag)])
     }
 
     async fn delete_shard_if_tag_matches(&self, hash: &MerkleHash, tag: &ObjectTag) -> Result<bool> {
-        let mut shard = self.shard.write().await;
-        let Some((current_hash, shard_bytes)) = Self::current_shard_hash_and_bytes(&shard)? else {
-            return Err(ClientError::Other(format!("Shard not found: {}", hash.hex())));
+        let (current_hash, current_tag) = {
+            let shard = self.shard.read().await;
+            let Some((current_hash, shard_bytes)) = Self::current_shard_hash_and_bytes(&shard)? else {
+                return Err(ClientError::Other(format!("Shard not found: {}", hash.hex())));
+            };
+            if &current_hash != hash {
+                return Err(ClientError::Other(format!("Shard not found: {}", hash.hex())));
+            }
+            let current_tag = Self::object_tag_from_key_and_payload(b"shard", &current_hash, shard_bytes.as_ref());
+            (current_hash, current_tag)
         };
-        if &current_hash != hash {
-            return Err(ClientError::Other(format!("Shard not found: {}", hash.hex())));
-        }
-        let current_tag = Self::object_tag_from_key_and_payload(b"shard", &current_hash, shard_bytes.as_ref());
         if &current_tag != tag {
             return Ok(false);
         }
-        *shard = MDBInMemoryShard::default();
+        if self.lifecycle_tag_deletion_enabled() {
+            *self.gc_tagged_shard.write().await = Some(current_hash);
+        } else {
+            *self.shard.write().await = MDBInMemoryShard::default();
+        }
         Ok(true)
     }
 
     async fn verify_integrity(&self) -> Result<()> {
+        let tagged = self.gc_tagged_xorbs.read().await;
         let xorbs = self.xorbs.read().await;
         let shard = self.shard.read().await;
         for file_info in shard.file_content.values() {
             for segment in &file_info.segments {
-                if !xorbs.contains_key(&segment.xorb_hash) {
+                if !xorbs.contains_key(&segment.xorb_hash) || tagged.contains(&segment.xorb_hash) {
                     return Err(ClientError::XORBNotFound(segment.xorb_hash));
                 }
             }
@@ -1368,5 +1484,109 @@ mod tests {
         assert_eq!(client.list_xorbs().await.unwrap().len(), 2);
         assert!(!client.get_full_xorb(&random_hash).await.unwrap().is_empty());
         assert!(!client.get_full_xorb(&materialized_hash).await.unwrap().is_empty());
+    }
+
+    // ── Lifecycle-tag deletion mode tests ───────────────────────────────
+
+    #[tokio::test]
+    async fn test_lifecycle_tag_xorb_delete_hides_xorb() {
+        let client = new_deletion_client();
+        client.set_lifecycle_tag_deletion(true);
+
+        let file = client.upload_random_file(&[(1, (0, 2))], 2048).await.unwrap();
+        let xorb_hash = file.terms[0].xorb_hash;
+        assert!(client.xorb_exists(&xorb_hash).await.unwrap());
+
+        client.delete_xorb(&xorb_hash).await;
+
+        // Reads fail — tagged xorb is "gone" from the namespace.
+        assert!(!client.xorb_exists(&xorb_hash).await.unwrap());
+        assert!(client.get_full_xorb(&xorb_hash).await.is_err());
+        // list_xorbs excludes the tagged xorb.
+        assert!(!client.list_xorbs().await.unwrap().contains(&xorb_hash));
+    }
+
+    #[tokio::test]
+    async fn test_lifecycle_tag_xorb_upload_clears_tag() {
+        let client = new_deletion_client();
+        client.set_lifecycle_tag_deletion(true);
+
+        let file = client.upload_random_file(&[(1, (0, 2))], 2048).await.unwrap();
+        let xorb_hash = file.terms[0].xorb_hash;
+
+        client.delete_xorb(&xorb_hash).await;
+        assert!(!client.xorb_exists(&xorb_hash).await.unwrap());
+
+        // Re-upload the same xorb (same content seed) — tag is cleared.
+        let file2 = client.upload_random_file(&[(1, (0, 2))], 2048).await.unwrap();
+        let xorb_hash2 = file2.terms[0].xorb_hash;
+        assert_eq!(xorb_hash, xorb_hash2, "same seed should produce same xorb hash");
+
+        assert!(client.xorb_exists(&xorb_hash).await.unwrap(), "re-upload should clear the tag");
+    }
+
+    #[tokio::test]
+    async fn test_lifecycle_tag_shard_delete_hides_shard() {
+        let client = new_deletion_client();
+        client.set_lifecycle_tag_deletion(true);
+
+        let file = client.upload_random_file(&[(1, (0, 2))], 2048).await.unwrap();
+
+        client.delete_file_entry(&file.file_hash).await.unwrap();
+        // After removing the file entry, the shard's content (and thus hash)
+        // changes. Re-query the shard hash before GC deletes it.
+        let shard_hash = client.list_shard_entries().await.unwrap().pop().unwrap();
+        client.delete_shard_entry(&shard_hash).await.unwrap();
+
+        // Reads fail — tagged shard is "gone" from the namespace.
+        assert!(client.get_shard_bytes(&shard_hash).await.is_err());
+        assert!(client.list_shard_entries().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_lifecycle_tag_mode_off_hard_deletes() {
+        let client = new_deletion_client();
+        assert!(!client.lifecycle_tag_deletion_enabled());
+
+        let file = client.upload_random_file(&[(1, (0, 2))], 2048).await.unwrap();
+        let xorb_hash = file.terms[0].xorb_hash;
+
+        client.delete_xorb(&xorb_hash).await;
+
+        // Hard-deleted: data is gone.
+        assert!(client.xorbs.read().await.get(&xorb_hash).is_none());
+    }
+
+    #[tokio::test]
+    async fn test_lifecycle_tag_verify_integrity_flags_tagged_xorb() {
+        let client = new_deletion_client();
+        client.set_lifecycle_tag_deletion(true);
+
+        let file = client.upload_random_file(&[(1, (0, 2))], 2048).await.unwrap();
+        let xorb_hash = file.terms[0].xorb_hash;
+
+        // Tag the xorb WITHOUT removing the file entry (simulates a GC bug).
+        client.delete_xorb(&xorb_hash).await;
+
+        assert!(client.verify_integrity().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_lifecycle_tag_verify_all_reachable_ignores_tagged() {
+        let client = new_deletion_client();
+        client.set_lifecycle_tag_deletion(true);
+
+        let file = client.upload_random_file(&[(1, (0, 2))], 2048).await.unwrap();
+        let xorb_hash = file.terms[0].xorb_hash;
+
+        client.delete_file_entry(&file.file_hash).await.unwrap();
+        let shard_hash = client.list_shard_entries().await.unwrap().pop().unwrap();
+        client.delete_shard_entry(&shard_hash).await.unwrap();
+        client.delete_xorb(&xorb_hash).await;
+
+        client
+            .verify_all_reachable()
+            .await
+            .expect("tagged objects should be ignored by reachability");
     }
 }

--- a/xet_client/src/cas_client/simulation/simulation_server.rs
+++ b/xet_client/src/cas_client/simulation/simulation_server.rs
@@ -83,6 +83,7 @@ pub struct LocalTestServerBuilder {
     client: Option<Arc<dyn DirectAccessClient>>,
     server_latency_profile: Option<ServerLatencyProfile>,
     network_profile: Option<NetworkProfile>,
+    lifecycle_tag_deletion: bool,
 }
 
 #[allow(dead_code)]
@@ -98,6 +99,7 @@ impl LocalTestServerBuilder {
             client: None,
             server_latency_profile: None,
             network_profile: None,
+            lifecycle_tag_deletion: false,
         }
     }
 
@@ -170,6 +172,19 @@ impl LocalTestServerBuilder {
         self
     }
 
+    /// Enables lifecycle-tag deletion mode on the backing client.
+    ///
+    /// When enabled, `delete_xorb`/`delete_shard` tag objects (retain bytes)
+    /// instead of hard-deleting, mirroring production's S3 lifecycle-tag
+    /// deletion. Reads of tagged objects fail as if the
+    /// object were gone; a subsequent upload of the same hash clears the tag.
+    /// Only applies to `LocalClient` and `MemoryClient` backends (not
+    /// pre-supplied clients via [`Self::with_client`]).
+    pub fn with_lifecycle_tag_deletion(mut self, on: bool) -> Self {
+        self.lifecycle_tag_deletion = on;
+        self
+    }
+
     /// Builds and starts the test server.
     pub async fn start(self) -> LocalTestServer {
         let ctx = XetContext::default().expect("XetContext::new");
@@ -192,12 +207,14 @@ impl LocalTestServerBuilder {
                 (client, None)
             } else if self.in_memory {
                 let mc = MemoryClient::new(ctx.clone());
+                mc.set_lifecycle_tag_deletion(self.lifecycle_tag_deletion);
                 let dc: Arc<dyn DeletionControlableClient> = mc.clone();
                 (mc, Some(dc))
             } else if self.ephemeral_disk {
                 let lc = LocalClient::temporary(ctx.clone())
                     .await
                     .expect("Failed to create LocalClient with temporary directory");
+                lc.set_lifecycle_tag_deletion(self.lifecycle_tag_deletion);
                 let dc: Arc<dyn DeletionControlableClient> = lc.clone();
                 (lc, Some(dc))
             } else {
@@ -207,6 +224,7 @@ impl LocalTestServerBuilder {
                 let lc = LocalClient::new(ctx.clone(), &disk_path)
                     .await
                     .expect("Failed to create LocalClient");
+                lc.set_lifecycle_tag_deletion(self.lifecycle_tag_deletion);
                 let dc: Arc<dyn DeletionControlableClient> = lc.clone();
                 (lc, Some(dc))
             };


### PR DESCRIPTION
## Summary

Adds an opt-in **lifecycle-tag deletion mode** to `LocalClient` and `MemoryClient` that tags objects for deletion instead of hard-removing them, mirroring S3 lifecycle-tag deletion.

## Motivation

In production, deleted objects (xorbs, shards) are not removed immediately — they are tagged and left on S3 until a lifecycle rule transitions them to cheaper tier. The simulation clients previously hard-deleted objects, diverging from production semantics. This made it impossible to test scenarios where:

1. A tagged object is still referenced by a live file (a correctness bug)
2. A re-upload of the same content-addressed hash should resurrect a tagged object (matching S3 PutObject overwriting a tagged object)
3. Integrity checks need to detect when a referenced object has been tagged

## Changes

### `LocalClient` (disk-backed)
- New `lifecycle_tag_deletion: AtomicBool` field + `set_lifecycle_tag_deletion()` setter (default off)
- `delete_xorb` / `delete_shard_entry` / `delete_*_if_tag_matches`: rename to `<canonical>.gctag` instead of `remove_file` (DB/ShardList entries still deregistered)
- `upload_xorb` / `upload_shard`: clear any `.gctag` file on success (S3 PutObject overwrites tagged object)
- `list_xorbs` / `shard_file_paths`: explicitly skip `.gctag` entries

### `MemoryClient` (in-memory)
- New `lifecycle_tag_deletion: AtomicBool` + `gc_tagged_xorbs: RwLock<HashSet>` + `gc_tagged_shard: RwLock<Option<MerkleHash>>`
- All xorb/shard read methods return not-found for tagged objects
- `delete_*` methods insert into tagged sets instead of removing data
- `upload_*` methods clear tagged sets on success
- `verify_integrity` treats tagged xorbs as missing (flags bugs that tag live-referenced data)

### `LocalTestServerBuilder`
- New `with_lifecycle_tag_deletion(bool)` builder method (default `false`)
- Applied to `LocalClient` / `MemoryClient` in `start()` before wrapping in trait objects

## Behavior

| Operation | Tagged object behavior |
|---|---|
| Read (get/download) | Fails as if object were gone |
| List (list_xorbs/list_shards) | Excluded |
| Upload of same hash | Clears the tag — object becomes readable again |
| verify_integrity | Flags any shard referencing a tagged object as an integrity error |
| verify_all_reachable | Treated as already collected (passes) |


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to test/simulation clients behind a default-off flag; production paths are unaffected.
> 
> **Overview**
> Adds **opt-in lifecycle-tag deletion** to simulation CAS clients so tests can mirror production S3 behavior (tag-and-retain instead of immediate hard delete).
> 
> **`LocalClient`** gains `set_lifecycle_tag_deletion` and, when enabled, renames xorbs/shards to `*.gctag` on delete (list APIs skip them; reads fail on canonical paths). **Uploads** of the same hash remove the `.gctag` file. **`MemoryClient`** tracks tagged hashes in sets, hides tagged objects from reads/lists/reconstruction paths, and clears tags on re-upload; shard tagging only blocks reads when the **current** shard hash matches (avoids stale tags after `delete_file_entry`).
> 
> **`LocalTestServerBuilder::with_lifecycle_tag_deletion`** wires the flag into built clients. New unit tests cover tag/rename, re-upload resurrection, integrity vs reachability, and default hard-delete when off. **`Cargo.lock`** bumps a few transitive crate versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d59af69cee6463f3eda6a93b62bd2f446621a725. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->