### PR TITLE
fix: do not count defrag-prevented ranges as deduped in metrics

### DIFF
--- a/xet_data/src/deduplication/file_deduplication.rs
+++ b/xet_data/src/deduplication/file_deduplication.rs
@@ -197,16 +197,20 @@ impl<DataInterfaceType: DeduplicationDataInterface> FileDeduper<DataInterfaceTyp
             }
 
             if let Some((n_deduped, fse, is_external)) = dedupe_query {
-                dedup_metrics.deduped_chunks += n_deduped as u64;
-                dedup_metrics.deduped_bytes += fse.unpacked_segment_bytes as u64;
-                dedup_metrics.total_chunks += n_deduped as u64;
-                dedup_metrics.total_bytes += fse.unpacked_segment_bytes as u64;
-
                 // check the fragmentation state and if it is pretty fragmented,
                 // we skip dedupe.  However, continuing the previous is always fine.
                 if self.file_data_sequence_continues_current(&fse)
                     || self.defrag_tracker.allow_dedup_on_next_range(n_deduped)
                 {
+                    // Only count the range as deduped once it passes the defrag gate;
+                    // otherwise its chunks go through the new-data path below, which
+                    // does its own total/new accounting, and counting here as well
+                    // double-counts them in total_bytes and misreports them as deduped.
+                    dedup_metrics.deduped_chunks += n_deduped as u64;
+                    dedup_metrics.deduped_bytes += fse.unpacked_segment_bytes as u64;
+                    dedup_metrics.total_chunks += n_deduped as u64;
+                    dedup_metrics.total_bytes += fse.unpacked_segment_bytes as u64;
+
                     // Report this as a dependency
                     // The case where it's dededuped against the present xorb is handled
                     // when the xorb gets cut and we know the hash.

--- a/xet_data/src/processing/range_upload.rs
+++ b/xet_data/src/processing/range_upload.rs
@@ -2102,4 +2102,80 @@ mod tests {
             handle.await.unwrap();
         }
     }
+
+    // Regression test: when defrag prevention rejects a dedup range, the range's chunks
+    // fall through to the new-data path, which does its own total/new accounting. The
+    // metrics used to also count the rejected range as deduped+total up front, so every
+    // defrag-prevented byte was double-counted in total_bytes and misreported as deduped
+    // (and tripped the file_size == total_bytes debug_assert in SingleFileCleaner).
+    //
+    // Setup that reliably trips the defrag gate: upload content as small shuffled pieces
+    // (so its CAS layout is fragmented), then cleanly re-upload the assembled file from a
+    // client with no local shard cache. Dedup then only matches in piece-sized runs, and
+    // the CPR tracker starts rejecting ranges.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_dedup_metrics_when_defrag_prevention_triggers() {
+        use xet_client::cas_client::DirectAccessClient;
+
+        let server = LocalTestServerBuilder::new().start().await;
+        let server_endpoint = server.http_endpoint().to_string();
+        // Serve global-dedup shards in the production format (file data stripped, expiry
+        // set) instead of raw session shards, which the client-side parser rejects.
+        server.set_global_dedup_shard_expiration(Some(std::time::Duration::from_secs(3600)));
+        let base_dir = TempDir::new().unwrap();
+        let config = test_config(&server_endpoint, base_dir.path());
+
+        const SIZE: usize = 64 * 1024 * 1024;
+        const PIECE: usize = 256 * 1024;
+        let data = random_data(20260703, SIZE);
+
+        // Pass 1: upload the content as shuffled pieces so xorbs pack them in arrival
+        // order, not file order.
+        let n_pieces = SIZE / PIECE;
+        let mut order: Vec<usize> = (0..n_pieces).collect();
+        let mut lcg: u64 = 0x9e3779b97f4a7c15;
+        for i in (1..n_pieces).rev() {
+            lcg = lcg.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            order.swap(i, (lcg >> 33) as usize % (i + 1));
+        }
+        let session1 = FileUploadSession::new(config.clone()).await.unwrap();
+        for &piece_idx in &order {
+            let slice = &data[piece_idx * PIECE..(piece_idx + 1) * PIECE];
+            let (_id, mut cleaner) = session1
+                .start_clean(None, Some(slice.len() as u64), Sha256Policy::Skip)
+                .unwrap();
+            cleaner.add_data(slice).await.unwrap();
+            cleaner.finish().await.unwrap();
+        }
+        session1.finalize().await.unwrap();
+
+        // Pass 2: clean sequential upload of the assembled file from a fresh cache dir,
+        // so dedup discovery goes through the sampled global dedup queries.
+        let base_dir2 = TempDir::new().unwrap();
+        let config2 = test_config(&server_endpoint, base_dir2.path());
+        let session2 = FileUploadSession::new(config2).await.unwrap();
+        let (_id, mut cleaner) = session2
+            .start_clean(Some("copy".into()), Some(data.len() as u64), Sha256Policy::Skip)
+            .unwrap();
+        cleaner.add_data(&data).await.unwrap();
+        let (xfi, metrics) = cleaner.finish().await.unwrap();
+        session2.finalize().await.unwrap();
+
+        assert!(
+            metrics.defrag_prevented_dedup_bytes > 0,
+            "setup failed to trigger defrag prevention; the metrics accounting is not exercised"
+        );
+        assert_eq!(metrics.total_bytes, SIZE as u64, "total_bytes must equal the bytes actually cleaned");
+        assert_eq!(xfi.file_size(), Some(SIZE as u64));
+        assert_eq!(
+            metrics.deduped_bytes + metrics.new_bytes,
+            metrics.total_bytes,
+            "every byte is either deduped or new"
+        );
+        assert_eq!(
+            metrics.deduped_chunks + metrics.new_chunks,
+            metrics.total_chunks,
+            "every chunk is either deduped or new"
+        );
+    }
 }


### PR DESCRIPTION
## Problem

In `FileDeduper::process_chunks`, a matched dedup range is counted into `deduped_chunks`, `deduped_bytes`, `total_chunks` and `total_bytes` *before* the defrag-prevention gate (`allow_dedup_on_next_range`). When the gate rejects the range, its chunks fall through to the new-data path below, which does its own `total_*`/`new_*` accounting. As a result:

- every defrag-prevented byte is double-counted in `total_bytes` (measured: `total_bytes = file_size + defrag_prevented_dedup_bytes`, exactly),
- those bytes are also misreported as `deduped_bytes` even though they were re-stored,
- any **debug build** cleaning a file that trips defrag prevention panics on the `file_size == total_bytes` `debug_assert` in `SingleFileCleaner::finish`.

File reconstruction info is unaffected (the registered file size and segments are correct); this is a metrics/telemetry bug plus a debug-build crash.

## Fix

Move the four increments after the defrag gate so each chunk is counted exactly once, either as deduped (gate passed) or as new (gate rejected, new-data path). `defrag_prevented_*` counters keep their existing semantics.

## Regression test

`test_dedup_metrics_when_defrag_prevention_triggers` reproduces the scenario organically rather than by mocking the tracker: upload content as small shuffled pieces (fragmented CAS layout, as produced by out-of-order writers), then cleanly re-upload the assembled file from a client with an empty shard cache, so dedup discovery goes through the sampled global dedup queries and only matches in piece-sized runs. The CPR tracker then rejects ranges (`defrag_prevented_dedup_bytes > 0` is asserted so the test cannot pass vacuously). Before the fix the test fails on the `SingleFileCleaner` debug_assert with `total_bytes` inflated by exactly `defrag_prevented_dedup_bytes`; after the fix `deduped + new == total == file_size` holds.

Side note from the same investigation, out of scope here: on such fragmented references, defrag prevention re-stores a significant share of already-stored content (~17% in the test above, ~50% observed on production bucket files, i.e. ~2x stored bytes with heavily fragmented layouts). That looks like a design discussion worth having separately.