### PR TITLE
Fix retry strategy configuration

### DIFF
--- a/xet_client/src/cas_client/retry_wrapper.rs
+++ b/xet_client/src/cas_client/retry_wrapper.rs
@@ -28,6 +28,7 @@ struct ConnectionPermitInfo {
 pub struct RetryWrapper {
     max_attempts: usize,
     base_delay: Duration,
+    max_duration: Duration,
     no_retry_on_429: bool,
     retry_on_403: bool,
     expected_416: bool,
@@ -41,9 +42,11 @@ impl RetryWrapper {
     pub fn new(ctx: XetContext, api_tag: &'static str) -> Self {
         let max_attempts = ctx.config.client.retry_max_attempts;
         let base_delay = ctx.config.client.retry_base_delay;
+        let max_duration = ctx.config.client.retry_max_duration;
         Self {
             max_attempts,
             base_delay,
+            max_duration,
             no_retry_on_429: false,
             retry_on_403: false,
             expected_416: false,
@@ -61,6 +64,11 @@ impl RetryWrapper {
 
     pub fn with_base_delay(mut self, delay: Duration) -> Self {
         self.base_delay = delay;
+        self
+    }
+
+    pub fn with_max_duration(mut self, duration: Duration) -> Self {
+        self.max_duration = duration;
         self
     }
 
@@ -100,7 +108,26 @@ impl RetryWrapper {
         }));
         self
     }
+}
 
+impl std::fmt::Debug for RetryWrapper {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RetryWrapper")
+            .field("max_attempts", &self.max_attempts)
+            .field("base_delay", &self.base_delay)
+            .field("max_duration", &self.max_duration)
+            .field("no_retry_on_429", &self.no_retry_on_429)
+            .field("retry_on_403", &self.retry_on_403)
+            .field("expected_416", &self.expected_416)
+            .field("expected_404", &self.expected_404)
+            .field("log_errors_as_info", &self.log_errors_as_info)
+            .field("api_tag", &self.api_tag)
+            .field("has_connection_permit", &self.connection_permit.is_some())
+            .finish()
+    }
+}
+
+impl RetryWrapper {
     fn process_error_response(&self, try_idx: usize, err: reqwest_middleware::Error) -> RetryableReqwestError {
         let api = &self.api_tag;
 
@@ -242,16 +269,9 @@ impl RetryWrapper {
         ProcFn: Fn(Response) -> ProcFut + Send + 'static,
         ProcFut: Future<Output = std::result::Result<T, RetryableReqwestError>> + 'static,
     {
-        let strategy = ExponentialBackoff::from_millis(self.base_delay.as_millis().min(u64::MAX as u128) as u64)
-            .map(jitter)
-            .take(self.max_attempts);
+        let strategy = exponential_retry_delays(self.base_delay, self.max_attempts, self.max_duration).map(jitter);
 
-        info!(
-            max_attempts = self.max_attempts,
-            base_delay=?self.base_delay,
-            no_retry_on_429=self.no_retry_on_429,
-            "Retry strategy",
-        );
+        info!(retry=?self, "Retry strategy");
 
         // Move self (which is consumable) into an arc that can be passed into this.
         // This allows the code to be a bit better.
@@ -483,6 +503,26 @@ impl RetryWrapper {
     }
 }
 
+/// Build pre-jitter retry delays from `base_delay`, raising by `base_delay / 1s` each step.
+///
+/// `ExponentialBackoff::from_millis(base_delay_ms)` would use `base_delay_ms` as both the
+/// first delay and the per-step multiplier (e.g. 3000 -> 3s, 9000s, ...). Instead, the
+/// per-step multiplier is derived from `base_delay` in whole seconds and `factor` scales
+/// the first delay back to `base_delay`.
+fn exponential_retry_delays(
+    base_delay: Duration,
+    max_attempts: usize,
+    max_duration: Duration,
+) -> impl Iterator<Item = Duration> {
+    let base_delay_ms = base_delay.as_millis().min(u64::MAX as u128) as u64;
+    let multiplier = base_delay.as_secs().max(1);
+    let factor = (base_delay_ms / multiplier).max(1);
+    ExponentialBackoff::from_millis(multiplier)
+        .factor(factor)
+        .max_delay(max_duration)
+        .take(max_attempts)
+}
+
 /// Classifies a response status as retryable.
 ///
 /// Equivalent to `reqwest_retry::default_on_request_success`:
@@ -589,6 +629,58 @@ mod tests {
     use xet_runtime::core::XetContext;
 
     use super::*;
+
+    #[test]
+    fn test_exponential_retry_strategy() {
+        let base_delay = Duration::from_millis(3000);
+        let max_attempts = 5;
+
+        // Old construction: from_millis(base_delay) uses base_delay_ms as both the first
+        // delay and the per-step multiplier -> 3s, 9000s, 7500h, ...
+        let old_delays: Vec<Duration> =
+            ExponentialBackoff::from_millis(base_delay.as_millis().min(u64::MAX as u128) as u64)
+                .take(max_attempts)
+                .collect();
+        assert_eq!(
+            old_delays,
+            [
+                Duration::from_secs(3),
+                Duration::from_secs(9000),
+                Duration::from_hours(7500),
+                Duration::from_hours(22_500_000),
+                Duration::from_hours(67_500_000_000),
+            ]
+        );
+
+        // New construction: multiplier derived from base_delay -> 3s, 9s, 27s, 81s, 243s
+        let new_delays: Vec<Duration> = exponential_retry_delays(base_delay, max_attempts, Duration::MAX).collect();
+        assert_eq!(
+            new_delays,
+            [
+                Duration::from_secs(3),
+                Duration::from_secs(9),
+                Duration::from_secs(27),
+                Duration::from_secs(81),
+                Duration::from_secs(243),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_exponential_retry_strategy_caps_at_max_duration() {
+        let delays: Vec<Duration> =
+            exponential_retry_delays(Duration::from_millis(3000), 5, Duration::from_secs(60)).collect();
+        assert_eq!(
+            delays,
+            [
+                Duration::from_millis(3000),
+                Duration::from_millis(9000),
+                Duration::from_millis(27000),
+                Duration::from_secs(60),
+                Duration::from_secs(60),
+            ]
+        );
+    }
 
     fn test_context() -> XetContext {
         let config = XetConfig::new();

--- a/xet_runtime/src/config/groups/client.rs
+++ b/xet_runtime/src/config/groups/client.rs
@@ -19,8 +19,11 @@ crate::config_group!({
     /// Use the environment variable `HF_XET_CLIENT_RETRY_BASE_DELAY` to set this value.
     ref retry_base_delay : Duration = Duration::from_millis(3000);
 
-    /// After this much time has passed since the first attempt,
-    /// no more retries are attempted.
+    /// Cap each individual retry sleep at this duration.
+    ///
+    /// Applied as the per-attempt maximum backoff delay. Retries continue until
+    /// `retry_max_attempts` is exhausted; the total time spent sleeping across
+    /// retries may exceed this value.
     ///
     /// The default value is 6min.
     ///


### PR DESCRIPTION
## Summary

Fixes incorrect `ExponentialBackoff` construction in `RetryWrapper`. The old code passed `retry_base_delay` directly to `ExponentialBackoff::from_millis()`, which uses that value as **both** the first retry sleep and the per-step multiplier.

With the default config (`retry_base_delay = 3s`, `retry_max_attempts = 5`), that produced:

| Retry | Old delay |
|-------|-----------|
| 1 | 3s |
| 2 | **9000s (~2.5 hours)** |
| 3 | 7500h |
| 4 | 22_500_000h |
| 5 | 67_500_000_000h |

The intended behavior is 3s, 9s, 27s, 81s, 243s with defaults.

This PR corrects this configuration to match the intent.

See `test_exponential_retry_strategy` in `xet_client/src/cas_client/retry_wrapper.rs` for a side-by-side comparison of the old vs new delay sequences.

## Test plan

- [x] `cargo test -p xet-client --lib cas_client::retry_wrapper`
- [x] `test_exponential_retry_strategy` — documents old delays (including the 2.5h second retry) and asserts the corrected 3s/9s/27s/81s/243s sequence
- [x] `test_exponential_retry_strategy_caps_at_max_duration` — verifies `retry_max_duration` caps individual sleeps

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes retry timing for all CAS HTTP paths that use `RetryWrapper`; the fix is clearly necessary but alters real-world wait behavior and how `HF_XET_CLIENT_RETRY_MAX_DURATION` is interpreted.
> 
> **Overview**
> **Fixes broken exponential backoff** in `RetryWrapper` where `retry_base_delay` was passed straight into `ExponentialBackoff::from_millis`, so the same millisecond value acted as both the first sleep and the per-step multiplier. With defaults (3s base, 5 attempts), the second retry waited ~2.5 hours instead of 9s.
> 
> Backoff is now built via **`exponential_retry_delays`**: multiplier from `base_delay` in whole seconds, `factor` so the first delay matches `base_delay`, then jitter as before (e.g. 3s → 9s → 27s → 81s → 243s).
> 
> **`retry_max_duration`** is wired from config into `RetryWrapper` (plus `with_max_duration`) and applied as **`.max_delay()`** on each retry sleep. Config docs now describe it as a per-attempt cap, not a total retry budget.
> 
> Adds **`Debug` for `RetryWrapper`**, logs `retry=?self`, and unit tests that document the old delay sequence and assert capping at `max_duration`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c442ea8bd946d61119e0d4c1e8ce6b0cce78dab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->