### PR TITLE
xet_session: box bridged futures to cap type-layout depth

### DIFF
--- a/xet_pkg/src/xet_session/task_runtime.rs
+++ b/xet_pkg/src/xet_session/task_runtime.rs
@@ -379,9 +379,8 @@ impl TaskRuntime {
         T: 'static,
     {
         let token = self.cancellation_token.clone();
-        // Box to heap-erase the future's deep nested type; wasm has no runtime offload, so
-        // inlining it here would propagate into callers and can overflow rustc's type-layout
-        // query-depth limit.
+        // Box to heap-erase the future's deep type; wasm inlines it here (no offload), which
+        // otherwise overflows rustc's type-layout query-depth limit in callers.
         let fut = Box::pin(fut);
         async move {
             tokio::select! {

--- a/xet_pkg/src/xet_session/task_runtime.rs
+++ b/xet_pkg/src/xet_session/task_runtime.rs
@@ -379,6 +379,10 @@ impl TaskRuntime {
         T: 'static,
     {
         let token = self.cancellation_token.clone();
+        // Box to heap-erase the future's deep nested type; wasm has no runtime offload, so
+        // inlining it here would propagate into callers and can overflow rustc's type-layout
+        // query-depth limit.
+        let fut = Box::pin(fut);
         async move {
             tokio::select! {
                 _ = token.cancelled() => Err(XetError::UserCancelled(

--- a/xet_runtime/src/core/runtime/native.rs
+++ b/xet_runtime/src/core/runtime/native.rs
@@ -418,7 +418,10 @@ impl XetRuntime {
             )));
         }
         match &self.backend {
-            RuntimeBackend::External { .. } => Ok(fut.await),
+            // Box to heap-erase the future's deep nested type instead of inlining it into
+            // this state machine, which otherwise propagates into callers and can overflow
+            // rustc's type-layout query-depth limit. OwnedThreadPool already erases via `spawn`.
+            RuntimeBackend::External { .. } => Ok(Box::pin(fut).await),
             RuntimeBackend::OwnedThreadPool { .. } => self.bridge_to_owned(task_name, fut).await,
         }
     }

--- a/xet_runtime/src/core/runtime/native.rs
+++ b/xet_runtime/src/core/runtime/native.rs
@@ -418,9 +418,8 @@ impl XetRuntime {
             )));
         }
         match &self.backend {
-            // Box to heap-erase the future's deep nested type instead of inlining it into
-            // this state machine, which otherwise propagates into callers and can overflow
-            // rustc's type-layout query-depth limit. OwnedThreadPool already erases via `spawn`.
+            // Box to heap-erase the future's deep type; inlining it here overflows rustc's
+            // type-layout query-depth limit in callers. OwnedThreadPool erases via `spawn`.
             RuntimeBackend::External { .. } => Ok(Box::pin(fut).await),
             RuntimeBackend::OwnedThreadPool { .. } => self.bridge_to_owned(task_name, fut).await,
         }


### PR DESCRIPTION
## Problem

Every public `XetSession` async operation (`commit`, `upload_from_path`, `download_file_to_path`, `finish`, `finalize_ingestion`, stream writes, …) routes its work future through the bridge layer:

```
public async API
  └─ TaskRuntime::bridge_async(_finalizing)   (xet_pkg/.../task_runtime.rs)
       └─ TaskRuntime::run_inner_async
            └─ XetRuntime::bridge_async        (xet_runtime/.../native.rs)
                 ├─ External       => Ok(fut.await)          ← inlines the deep future
                 └─ OwnedThreadPool => bridge_to_owned(..)   ← spawn(), type-erased
```

On the inline-await paths — the `External` arm on native, and `run_inner_async` on wasm (no runtime offload) — the work future (`async move { inner.commit().await }`, i.e. the full `xet_client`/`xet_data` ingestion/CAS chain) is awaited inline, so its entire nested type becomes part of the bridge's state machine and propagates up through every layer into the caller.

Both match arms compile unconditionally, so the `External` arm inflates the layout even for `OwnedThreadPool` consumers. For deep operations this can push a consumer's own future past rustc's type-layout query-depth limit (`error: queries overflow the depth limit!`) at the call site — no downstream code change involved, just the depth of what it awaits.

## Fix

Box the future on the two inline paths so its deep type is heap-erased instead of embedded:

- `XetRuntime::bridge_async` (native) `External` arm → `Ok(Box::pin(fut).await)`
- `TaskRuntime::run_inner_async` (wasm) → box `fut` before the `select!`

The `OwnedThreadPool` arm already type-erases via `spawn`, so it's untouched (no extra allocation on that path). This collapses the layout depth once for all public async APIs and all consumers, so downstream crates no longer need `Box::pin` at call sites or `#![recursion_limit]` bumps.

## Testing

- `cargo build -p hf-xet -p xet-runtime` ✅
- `cargo check --target wasm32-unknown-unknown` (via `wasm/hf_xet_thin_wasm`) ✅
- `cargo clippy -p hf-xet -p xet-runtime` ✅ (clean)
- `cargo +nightly fmt` ✅

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compile-time typing change with a small extra allocation on External/wasm paths; owned-pool bridging and API semantics are unchanged.
> 
> **Overview**
> Public `XetSession` async work flows through bridge layers that used to **inline** very deep futures on certain paths, which could trigger rustc’s `queries overflow the depth limit!` at consumer call sites.
> 
> **`XetRuntime::bridge_async`** on native **External** mode now awaits `Box::pin(fut)` instead of `fut` directly. **`TaskRuntime::run_inner_async`** on **wasm** boxes the work future before the cancellation `select!`, since wasm has no runtime offload. **OwnedThreadPool** bridging is unchanged (still type-erased via `spawn`).
> 
> Behavior and cancellation semantics stay the same; the tradeoff is one heap allocation on External and wasm inline paths so downstream crates don’t need local `Box::pin` or higher recursion limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c26ee6c3dd4f455e76d9ab622ceae44ba52341c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->