### PR TITLE
Bump hf-xet to 1.5.2

### DIFF
--- a/hf_xet/Cargo.lock
+++ b/hf_xet/Cargo.lock
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "hf_xet"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "async-trait",
  "hf-xet",

--- a/hf_xet/Cargo.toml
+++ b/hf_xet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hf_xet"
-version = "1.5.1"
+version = "1.5.2"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
Update `version` in `hf_xet/Cargo.toml` then `maturin develop`.