### PR TITLE
Fix bump-crates-version workflow

### DIFF
--- a/.github/workflows/bump-crates-version.yml
+++ b/.github/workflows/bump-crates-version.yml
@@ -74,6 +74,9 @@ jobs:
 
       - uses: ./.github/actions/build-wasm
 
+      - name: Create venv
+        run: python3 -m venv .venv
+        
       - name: Build hf-xet wheel
         uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad  # v1
         with:


### PR DESCRIPTION
Fix the failure in https://github.com/huggingface/xet-core/actions/runs/29777956044/job/88471865677

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only change that mirrors an existing venv + maturin pattern; no runtime or release logic is modified.
> 
> **Overview**
> The **bump-crates-version** workflow was failing when building the `hf_xet` wheel with maturin `develop` because no local Python environment existed on the runner.
> 
> This adds a **Create venv** step (`python3 -m venv .venv`) immediately before **Build hf-xet wheel**, matching the pattern already used in `ci.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5648780d33c9f065e1576b612cb0a2e6c24a0f26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->