### PR TITLE
chore: bump crate versions to 1.5.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1916,7 +1916,7 @@ checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "hf-xet"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "anyhow",
  "async-std",
@@ -5859,7 +5859,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "xet-client"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "anyhow",
  "approx",
@@ -5907,7 +5907,7 @@ dependencies = [
 
 [[package]]
 name = "xet-core-structures"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5945,7 +5945,7 @@ dependencies = [
 
 [[package]]
 name = "xet-data"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "xet-runtime"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.5.3"
+version = "1.5.4"
 edition = "2024"
 license = "Apache-2.0"
 homepage = "https://github.com/huggingface/xet-core"

--- a/hf_xet/Cargo.lock
+++ b/hf_xet/Cargo.lock
@@ -947,7 +947,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hf-xet"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3988,7 +3988,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "xet-client"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4022,7 +4022,7 @@ dependencies = [
 
 [[package]]
 name = "xet-core-structures"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4053,7 +4053,7 @@ dependencies = [
 
 [[package]]
 name = "xet-data"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4084,7 +4084,7 @@ dependencies = [
 
 [[package]]
 name = "xet-runtime"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/wasm/hf_xet_thin_wasm/Cargo.lock
+++ b/wasm/hf_xet_thin_wasm/Cargo.lock
@@ -3023,7 +3023,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "xet-client"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "xet-core-structures"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "async-trait",
  "base64",
@@ -3088,7 +3088,7 @@ dependencies = [
 
 [[package]]
 name = "xet-data"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3118,7 +3118,7 @@ dependencies = [
 
 [[package]]
 name = "xet-runtime"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/wasm/hf_xet_wasm/Cargo.lock
+++ b/wasm/hf_xet_wasm/Cargo.lock
@@ -675,7 +675,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hf-xet"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3006,7 +3006,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xet-client"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3040,7 +3040,7 @@ dependencies = [
 
 [[package]]
 name = "xet-core-structures"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "async-trait",
  "base64",
@@ -3071,7 +3071,7 @@ dependencies = [
 
 [[package]]
 name = "xet-data"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3101,7 +3101,7 @@ dependencies = [
 
 [[package]]
 name = "xet-runtime"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/xet_client/Cargo.toml
+++ b/xet_client/Cargo.toml
@@ -15,8 +15,8 @@ name = "xet_client"
 path = "src/lib.rs"
 
 [dependencies]
-xet-runtime = { version = "1.5.3", path = "../xet_runtime" }
-xet-core-structures = { version = "1.5.3", path = "../xet_core_structures" }
+xet-runtime = { version = "1.5.4", path = "../xet_runtime" }
+xet-core-structures = { version = "1.5.4", path = "../xet_core_structures" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/xet_core_structures/Cargo.toml
+++ b/xet_core_structures/Cargo.toml
@@ -25,7 +25,7 @@ harness = false
 bench = true
 
 [dependencies]
-xet-runtime = { version = "1.5.3", path = "../xet_runtime" }
+xet-runtime = { version = "1.5.4", path = "../xet_runtime" }
 
 async-trait = { workspace = true }
 base64 = { workspace = true }

--- a/xet_data/Cargo.toml
+++ b/xet_data/Cargo.toml
@@ -16,9 +16,9 @@ path = "src/lib.rs"
 doctest = false
 
 [dependencies]
-xet-runtime = { version = "1.5.3", path = "../xet_runtime" }
-xet-core-structures = { version = "1.5.3", path = "../xet_core_structures" }
-xet-client = { version = "1.5.3", path = "../xet_client" }
+xet-runtime = { version = "1.5.4", path = "../xet_runtime" }
+xet-core-structures = { version = "1.5.4", path = "../xet_core_structures" }
+xet-client = { version = "1.5.4", path = "../xet_client" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/xet_pkg/Cargo.toml
+++ b/xet_pkg/Cargo.toml
@@ -36,10 +36,10 @@ name = "test_xtool_cli"
 required-features = ["internal-tools"]
 
 [dependencies]
-xet-runtime = { version = "1.5.3", path = "../xet_runtime" }
-xet-core-structures = { version = "1.5.3", path = "../xet_core_structures" }
-xet-client = { version = "1.5.3", path = "../xet_client" }
-xet-data = { version = "1.5.3", path = "../xet_data" }
+xet-runtime = { version = "1.5.4", path = "../xet_runtime" }
+xet-core-structures = { version = "1.5.4", path = "../xet_core_structures" }
+xet-client = { version = "1.5.4", path = "../xet_client" }
+xet-data = { version = "1.5.4", path = "../xet_data" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Release-only version and lockfile updates with no logic changes.
> 
> **Overview**
> Bumps the workspace and published crates from **1.5.3** to **1.5.4** with no application or library code changes.
> 
> The root `[workspace.package]` version is updated, and path dependency pins in `xet_client`, `xet_core_structures`, `xet_data`, and `xet_pkg` (`hf-xet`) are aligned to **1.5.4**. Lockfiles (`Cargo.lock`, `hf_xet/Cargo.lock`, and the wasm crate locks) are refreshed so `hf-xet`, `xet-client`, `xet-core-structures`, `xet-data`, and `xet-runtime` all resolve at the new version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a217a97fc2322c0623295877b50e8cdf31039396. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->