### PR TITLE
fix: stack overflow in AuthGroupBuilder::build() from unboxed futures

### DIFF
--- a/xet_pkg/src/xet_session/download_stream_group.rs
+++ b/xet_pkg/src/xet_session/download_stream_group.rs
@@ -377,6 +377,35 @@ mod tests {
             .unwrap()
     }
 
+    // Regression test: `AuthGroupBuilder<XetDownloadStreamGroup>::build()`'s
+    // compiler-generated future once measured 23,664 bytes. See
+    // `test_utils::stack_regression` for why this runs in a child process.
+    #[test]
+    #[cfg(not(target_family = "wasm"))]
+    fn build_survives_small_stack_download_stream_group() {
+        crate::xet_session::test_utils::stack_regression::run(
+            "build_survives_small_stack_download_stream_group",
+            || {
+                let temp = tempdir().unwrap();
+                let endpoint = format!("local://{}", temp.path().join("cas").display());
+                tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap()
+                    .block_on(async move {
+                        let session = XetSessionBuilder::new().build().unwrap();
+                        session
+                            .new_download_stream_group()
+                            .unwrap()
+                            .with_endpoint(&endpoint)
+                            .build()
+                            .await
+                            .unwrap();
+                    });
+            },
+        );
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     // Async streaming download round-trip: upload, stream, verify content.
     async fn test_download_stream_round_trip() {

--- a/xet_pkg/src/xet_session/download_stream_group.rs
+++ b/xet_pkg/src/xet_session/download_stream_group.rs
@@ -384,7 +384,10 @@ mod tests {
     #[cfg(not(target_family = "wasm"))]
     fn build_survives_small_stack_download_stream_group() {
         crate::xet_session::test_utils::stack_regression::run(
-            "build_survives_small_stack_download_stream_group",
+            &crate::xet_session::test_utils::stack_regression::test_path(
+                module_path!(),
+                "build_survives_small_stack_download_stream_group",
+            ),
             || {
                 let temp = tempdir().unwrap();
                 let endpoint = format!("local://{}", temp.path().join("cas").display());

--- a/xet_pkg/src/xet_session/file_download_group.rs
+++ b/xet_pkg/src/xet_session/file_download_group.rs
@@ -443,24 +443,30 @@ mod tests {
     // separate monomorphization from the one in `download_stream_group.rs`.
     #[test]
     fn build_survives_small_stack_file_download_group() {
-        crate::xet_session::test_utils::stack_regression::run("build_survives_small_stack_file_download_group", || {
-            let temp = tempdir().unwrap();
-            let endpoint = format!("local://{}", temp.path().join("cas").display());
-            tokio::runtime::Builder::new_multi_thread()
-                .enable_all()
-                .build()
-                .unwrap()
-                .block_on(async move {
-                    let session = XetSessionBuilder::new().build().unwrap();
-                    session
-                        .new_file_download_group()
-                        .unwrap()
-                        .with_endpoint(&endpoint)
-                        .build()
-                        .await
-                        .unwrap();
-                });
-        });
+        crate::xet_session::test_utils::stack_regression::run(
+            &crate::xet_session::test_utils::stack_regression::test_path(
+                module_path!(),
+                "build_survives_small_stack_file_download_group",
+            ),
+            || {
+                let temp = tempdir().unwrap();
+                let endpoint = format!("local://{}", temp.path().join("cas").display());
+                tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap()
+                    .block_on(async move {
+                        let session = XetSessionBuilder::new().build().unwrap();
+                        session
+                            .new_file_download_group()
+                            .unwrap()
+                            .with_endpoint(&endpoint)
+                            .build()
+                            .await
+                            .unwrap();
+                    });
+            },
+        );
     }
 
     // ── Mutex guard / concurrency test ───────────────────────────────────────

--- a/xet_pkg/src/xet_session/file_download_group.rs
+++ b/xet_pkg/src/xet_session/file_download_group.rs
@@ -438,6 +438,31 @@ mod tests {
         Ok(meta.xet_info)
     }
 
+    // Regression test - see `test_utils::stack_regression` for why this runs in a child
+    // process. Covers the `AuthGroupBuilder<XetFileDownloadGroup>` instantiation, a
+    // separate monomorphization from the one in `download_stream_group.rs`.
+    #[test]
+    fn build_survives_small_stack_file_download_group() {
+        crate::xet_session::test_utils::stack_regression::run("build_survives_small_stack_file_download_group", || {
+            let temp = tempdir().unwrap();
+            let endpoint = format!("local://{}", temp.path().join("cas").display());
+            tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .unwrap()
+                .block_on(async move {
+                    let session = XetSessionBuilder::new().build().unwrap();
+                    session
+                        .new_file_download_group()
+                        .unwrap()
+                        .with_endpoint(&endpoint)
+                        .build()
+                        .await
+                        .unwrap();
+                });
+        });
+    }
+
     // ── Mutex guard / concurrency test ───────────────────────────────────────
     //
     // `finish()` takes a write lock on `active_tasks` while draining. We verify

--- a/xet_pkg/src/xet_session/mod.rs
+++ b/xet_pkg/src/xet_session/mod.rs
@@ -273,6 +273,8 @@ mod file_download_group;
 mod file_download_handle;
 mod session;
 mod task_runtime;
+#[cfg(test)]
+mod test_utils;
 mod upload_commit;
 mod upload_file_handle;
 mod upload_stream_handle;

--- a/xet_pkg/src/xet_session/task_runtime.rs
+++ b/xet_pkg/src/xet_session/task_runtime.rs
@@ -1,4 +1,5 @@
 use std::future::Future;
+use std::pin::Pin;
 use std::sync::{Arc, Mutex, Weak};
 
 use tokio::task::JoinHandle;
@@ -223,45 +224,64 @@ impl TaskRuntime {
         Ok(live)
     }
 
-    // Async task bridging, shared across targets. The state-machine logic lives
-    // here once; only `run_inner_async` (XetRuntime offload on native, inline
-    // select on wasm) differs per target.
-    pub(super) async fn bridge_async<T, F>(&self, task_name: &'static str, fut: F) -> Result<T, XetError>
+    // Plain (non-async) fn: boxing `fut` before the async block is constructed keeps its
+    // captured type small, no matter how large `F` is. Boxing inside an `async fn` body
+    // instead doesn't work - the parameter's full type is still part of that fn's own
+    // generator state regardless of what the body does with it. `check_state`/
+    // `update_state_on_error` stay inside the block so they still only run on first poll.
+    pub(super) fn bridge_async<T, F>(
+        &self,
+        task_name: &'static str,
+        fut: F,
+    ) -> impl Future<Output = Result<T, XetError>> + MaybeSend + '_
     where
         F: Future<Output = Result<T, XetError>> + MaybeSend + 'static,
         T: MaybeSend + 'static,
     {
-        self.check_state(task_name)?;
-        let result = self.run_inner_async(task_name, fut).await;
-        if let Err(ref e) = result {
-            self.update_state_on_error(e)?;
+        let fut: BoxedBridgeFuture<T> = Box::pin(fut);
+        async move {
+            self.check_state(task_name)?;
+            let result = self.run_inner_async(task_name, fut).await;
+            if let Err(ref e) = result {
+                self.update_state_on_error(e)?;
+            }
+            result
         }
-        result
     }
 
-    pub(super) async fn bridge_async_finalizing<T, F>(
+    pub(super) fn bridge_async_finalizing<T, F>(
         &self,
         task_name: &'static str,
         allow_repeat: bool,
         fut: F,
-    ) -> Result<T, XetError>
+    ) -> impl Future<Output = Result<T, XetError>> + MaybeSend + '_
     where
         F: Future<Output = Result<T, XetError>> + MaybeSend + 'static,
         T: MaybeSend + 'static,
     {
-        self.transition_to_finalizing(task_name, allow_repeat)?;
+        let fut: BoxedBridgeFuture<T> = Box::pin(fut);
+        async move {
+            self.transition_to_finalizing(task_name, allow_repeat)?;
 
-        let result = self.run_inner_async(task_name, fut).await;
-        match &result {
-            Ok(_) => self.set_state(XetTaskState::Completed)?,
-            Err(XetError::UserCancelled(_)) => {
-                self.set_state(XetTaskState::UserCancelled)?;
-            },
-            Err(e) => self.set_state(XetTaskState::Error(e.to_string()))?,
+            let result = self.run_inner_async(task_name, fut).await;
+            match &result {
+                Ok(_) => self.set_state(XetTaskState::Completed)?,
+                Err(XetError::UserCancelled(_)) => {
+                    self.set_state(XetTaskState::UserCancelled)?;
+                },
+                Err(e) => self.set_state(XetTaskState::Error(e.to_string()))?,
+            }
+            result
         }
-        result
     }
 }
+
+// `MaybeSend` can't be used as an extra marker on a `dyn` trait object (it isn't an auto
+// trait), so this spells out the same native/wasm split as a concrete type instead.
+#[cfg(not(target_family = "wasm"))]
+type BoxedBridgeFuture<T> = Pin<Box<dyn Future<Output = Result<T, XetError>> + Send>>;
+#[cfg(target_family = "wasm")]
+type BoxedBridgeFuture<T> = Pin<Box<dyn Future<Output = Result<T, XetError>>>>;
 
 // `Send` on native, unconstrained on wasm: lets the shared bridge methods
 // above state one set of bounds while wasm futures stay `!Send`.
@@ -379,9 +399,6 @@ impl TaskRuntime {
         T: 'static,
     {
         let token = self.cancellation_token.clone();
-        // Box to heap-erase the future's deep type; wasm inlines it here (no offload), which
-        // otherwise overflows rustc's type-layout query-depth limit in callers.
-        let fut = Box::pin(fut);
         async move {
             tokio::select! {
                 _ = token.cancelled() => Err(XetError::UserCancelled(

--- a/xet_pkg/src/xet_session/test_utils.rs
+++ b/xet_pkg/src/xet_session/test_utils.rs
@@ -1,0 +1,64 @@
+//! Shared test-only helpers for `xet_session`'s unit tests.
+
+#[cfg(all(test, not(target_family = "wasm")))]
+pub(crate) mod stack_regression {
+    //! Regression-test helper guarding against a large, generic future crossing an
+    //! `.await`-spanning function boundary by value without indirection — the compiler
+    //! then bakes the full, un-erased type into every generator frame it passes through,
+    //! which can silently balloon a state machine's size until it overflows a thread's
+    //! default stack (small on some platforms, e.g. ~524 KiB for non-main threads on
+    //! macOS).
+    //!
+    //! A stack overflow aborts the whole process (it can't be caught with
+    //! `catch_unwind`), so [`run`] executes `build_in_small_stack` in a *child process*
+    //! with an explicitly small stack: if it regresses, only the child aborts and the
+    //! caller's `#[test]` fails cleanly, instead of taking down the entire test binary.
+
+    const MARKER_ENV: &str = "XET_STACK_REGRESSION_CHILD";
+    // 128 KiB is tight enough to actually catch the regression on macOS/Linux (verified:
+    // fails at this size without the fix, passes with it). Windows needs more baseline
+    // stack for the same tokio runtime + thread setup regardless of this bug, so it gets
+    // a separate, larger bound.
+    #[cfg(not(windows))]
+    const STACK_SIZE: usize = 128 * 1024;
+    #[cfg(windows)]
+    const STACK_SIZE: usize = 512 * 1024;
+
+    /// Call from a `#[test]` fn. `test_name` must be that test's own (unique) name —
+    /// used to re-invoke just this test in a child process. `build_in_small_stack`
+    /// performs the actual risky call and only ever runs inside the child, on a thread
+    /// with an explicit small stack.
+    pub(crate) fn run(test_name: &'static str, build_in_small_stack: impl FnOnce() + Send + 'static) {
+        if std::env::var_os(MARKER_ENV).is_some() {
+            let t = std::thread::Builder::new()
+                .stack_size(STACK_SIZE)
+                .spawn(build_in_small_stack)
+                .unwrap();
+            t.join().unwrap();
+            return;
+        }
+
+        let exe = std::env::current_exe().unwrap();
+        let output = std::process::Command::new(exe)
+            .arg(test_name)
+            .arg("--test-threads=1")
+            .env(MARKER_ENV, "1")
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            output.status.success(),
+            "child process exited abnormally ({:?}) - likely a stack overflow.\n{stdout}",
+            output.status
+        );
+        // libtest exits 0 even when a filter matches no tests, so a typo'd or renamed
+        // `test_name` would otherwise make this helper silently pass without the risky
+        // call ever running. Require exactly the one expected test to have run.
+        assert!(
+            stdout.contains("1 passed"),
+            "expected the child process to run exactly one test matching {test_name:?}, but it \
+             didn't (the test name filter may not have matched anything, or matched more than \
+             one test).\n{stdout}"
+        );
+    }
+}

--- a/xet_pkg/src/xet_session/test_utils.rs
+++ b/xet_pkg/src/xet_session/test_utils.rs
@@ -14,16 +14,25 @@ pub(crate) mod stack_regression {
     //! with an explicitly small stack: if it regresses, only the child aborts and the
     //! caller's `#[test]` fails cleanly, instead of taking down the entire test binary.
 
+    /// `module_path!()` is prefixed with the crate name, but libtest's own test paths
+    /// (and thus its `--exact` filter) are not. Call as
+    /// `test_path(module_path!(), "my_test_fn")` from within the `#[test]` fn itself.
+    pub(crate) fn test_path(module_path: &str, fn_name: &str) -> String {
+        let module_path = module_path.split_once("::").map_or(module_path, |(_, rest)| rest);
+        format!("{module_path}::{fn_name}")
+    }
+
     const MARKER_ENV: &str = "XET_STACK_REGRESSION_CHILD";
     // 128 KiB is tight enough to actually catch the regression (verified: fails at this
     // size without the fix, passes with it).
     const STACK_SIZE: usize = 128 * 1024;
 
-    /// Call from a `#[test]` fn. `test_name` must be that test's own (unique) name —
-    /// used to re-invoke just this test in a child process. `build_in_small_stack`
-    /// performs the actual risky call and only ever runs inside the child, on a thread
-    /// with an explicit small stack.
-    pub(crate) fn run(test_name: &'static str, build_in_small_stack: impl FnOnce() + Send + 'static) {
+    /// Call from a `#[test]` fn. `test_name` must be that test's own fully-qualified path
+    /// (module path, minus the leading crate name, plus `::` plus the fn name) — used to
+    /// re-invoke just this test in a child process via an exact filter match.
+    /// `build_in_small_stack` performs the actual risky call and only ever runs inside the
+    /// child, on a thread with an explicit small stack.
+    pub(crate) fn run(test_name: &str, build_in_small_stack: impl FnOnce() + Send + 'static) {
         if std::env::var_os(MARKER_ENV).is_some() {
             let t = std::thread::Builder::new()
                 .stack_size(STACK_SIZE)
@@ -36,6 +45,7 @@ pub(crate) mod stack_regression {
         let exe = std::env::current_exe().unwrap();
         let output = std::process::Command::new(exe)
             .arg(test_name)
+            .arg("--exact")
             .arg("--test-threads=1")
             .env(MARKER_ENV, "1")
             .output()
@@ -48,12 +58,11 @@ pub(crate) mod stack_regression {
         );
         // libtest exits 0 even when a filter matches no tests, so a typo'd or renamed
         // `test_name` would otherwise make this helper silently pass without the risky
-        // call ever running. Require exactly the one expected test to have run.
+        // call ever running. Require the expected test to have actually run.
         assert!(
             stdout.contains("1 passed"),
             "expected the child process to run exactly one test matching {test_name:?}, but it \
-             didn't (the test name filter may not have matched anything, or matched more than \
-             one test).\n{stdout}"
+             didn't (the test name filter may not have matched anything).\n{stdout}"
         );
     }
 }

--- a/xet_pkg/src/xet_session/test_utils.rs
+++ b/xet_pkg/src/xet_session/test_utils.rs
@@ -23,9 +23,15 @@ pub(crate) mod stack_regression {
     }
 
     const MARKER_ENV: &str = "XET_STACK_REGRESSION_CHILD";
-    // 128 KiB is tight enough to actually catch the regression (verified: fails at this
-    // size without the fix, passes with it).
+    // 128 KiB is tight enough to actually catch the regression on macOS/Linux (verified:
+    // fails at this size without the fix, passes with it). Windows needs more baseline
+    // stack for the same tokio runtime + thread setup regardless of this bug: confirmed on
+    // windows-latest CI, where all three regression tests below abort with
+    // STATUS_STACK_OVERFLOW at 128 KiB even on the fixed code.
+    #[cfg(not(windows))]
     const STACK_SIZE: usize = 128 * 1024;
+    #[cfg(windows)]
+    const STACK_SIZE: usize = 512 * 1024;
 
     /// Call from a `#[test]` fn. `test_name` must be that test's own fully-qualified path
     /// (module path, minus the leading crate name, plus `::` plus the fn name) — used to

--- a/xet_pkg/src/xet_session/test_utils.rs
+++ b/xet_pkg/src/xet_session/test_utils.rs
@@ -15,14 +15,9 @@ pub(crate) mod stack_regression {
     //! caller's `#[test]` fails cleanly, instead of taking down the entire test binary.
 
     const MARKER_ENV: &str = "XET_STACK_REGRESSION_CHILD";
-    // 128 KiB is tight enough to actually catch the regression on macOS/Linux (verified:
-    // fails at this size without the fix, passes with it). Windows needs more baseline
-    // stack for the same tokio runtime + thread setup regardless of this bug, so it gets
-    // a separate, larger bound.
-    #[cfg(not(windows))]
+    // 128 KiB is tight enough to actually catch the regression (verified: fails at this
+    // size without the fix, passes with it).
     const STACK_SIZE: usize = 128 * 1024;
-    #[cfg(windows)]
-    const STACK_SIZE: usize = 512 * 1024;
 
     /// Call from a `#[test]` fn. `test_name` must be that test's own (unique) name —
     /// used to re-invoke just this test in a child process. `build_in_small_stack`

--- a/xet_pkg/src/xet_session/upload_commit.rs
+++ b/xet_pkg/src/xet_session/upload_commit.rs
@@ -616,24 +616,30 @@ mod tests {
     // monomorphization from the one in `download_stream_group.rs`.
     #[test]
     fn build_survives_small_stack_upload_commit() {
-        crate::xet_session::test_utils::stack_regression::run("build_survives_small_stack_upload_commit", || {
-            let temp = tempdir().unwrap();
-            let endpoint = format!("local://{}", temp.path().join("cas").display());
-            tokio::runtime::Builder::new_multi_thread()
-                .enable_all()
-                .build()
-                .unwrap()
-                .block_on(async move {
-                    let session = XetSessionBuilder::new().build().unwrap();
-                    session
-                        .new_upload_commit()
-                        .unwrap()
-                        .with_endpoint(&endpoint)
-                        .build()
-                        .await
-                        .unwrap();
-                });
-        });
+        crate::xet_session::test_utils::stack_regression::run(
+            &crate::xet_session::test_utils::stack_regression::test_path(
+                module_path!(),
+                "build_survives_small_stack_upload_commit",
+            ),
+            || {
+                let temp = tempdir().unwrap();
+                let endpoint = format!("local://{}", temp.path().join("cas").display());
+                tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap()
+                    .block_on(async move {
+                        let session = XetSessionBuilder::new().build().unwrap();
+                        session
+                            .new_upload_commit()
+                            .unwrap()
+                            .with_endpoint(&endpoint)
+                            .build()
+                            .await
+                            .unwrap();
+                    });
+            },
+        );
     }
 
     // ── Mutex guard / concurrency test ───────────────────────────────────────

--- a/xet_pkg/src/xet_session/upload_commit.rs
+++ b/xet_pkg/src/xet_session/upload_commit.rs
@@ -611,6 +611,31 @@ mod tests {
     use super::super::session::XetSessionBuilder;
     use super::*;
 
+    // Regression test - see `test_utils::stack_regression` for why this runs in a child
+    // process. Covers the `AuthGroupBuilder<XetUploadCommit>` instantiation, a separate
+    // monomorphization from the one in `download_stream_group.rs`.
+    #[test]
+    fn build_survives_small_stack_upload_commit() {
+        crate::xet_session::test_utils::stack_regression::run("build_survives_small_stack_upload_commit", || {
+            let temp = tempdir().unwrap();
+            let endpoint = format!("local://{}", temp.path().join("cas").display());
+            tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .unwrap()
+                .block_on(async move {
+                    let session = XetSessionBuilder::new().build().unwrap();
+                    session
+                        .new_upload_commit()
+                        .unwrap()
+                        .with_endpoint(&endpoint)
+                        .build()
+                        .await
+                        .unwrap();
+                });
+        });
+    }
+
     // ── Mutex guard / concurrency test ───────────────────────────────────────
 
     #[test]

--- a/xet_runtime/src/core/runtime/native.rs
+++ b/xet_runtime/src/core/runtime/native.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::fmt::Display;
 use std::future::Future;
 use std::panic::AssertUnwindSafe;
-use std::pin::pin;
+use std::pin::{Pin, pin};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, LazyLock, OnceLock, Weak};
 use std::task::{Context, Waker};
@@ -404,24 +404,33 @@ impl XetRuntime {
     ///
     /// This is the primary async entry point. Session-level async methods should call
     /// `ctx.runtime.bridge_async(...)`.
-    pub async fn bridge_async<T, F>(&self, task_name: &'static str, fut: F) -> Result<T, RuntimeError>
+    // Plain (non-async) fn boxing `fut` before constructing the returned `async move` block:
+    // an `async fn` generic over `F` bakes F's full type into its own generator state
+    // regardless of what the body does with it (see `bridge_to_owned` below, which needed
+    // the same fix).
+    pub fn bridge_async<T, F>(
+        &self,
+        task_name: &'static str,
+        fut: F,
+    ) -> impl Future<Output = Result<T, RuntimeError>> + Send + '_
     where
         F: Future<Output = T> + Send + 'static,
         T: Send + 'static,
     {
-        self.check_sigint()?;
-        if std::process::id() != self.creation_pid {
-            return Err(RuntimeError::InvalidRuntime(format!(
-                "XetRuntime was created in process {} but is being used in process {}",
-                self.creation_pid,
-                std::process::id(),
-            )));
-        }
-        match &self.backend {
-            // Box to heap-erase the future's deep type; inlining it here overflows rustc's
-            // type-layout query-depth limit in callers. OwnedThreadPool erases via `spawn`.
-            RuntimeBackend::External { .. } => Ok(Box::pin(fut).await),
-            RuntimeBackend::OwnedThreadPool { .. } => self.bridge_to_owned(task_name, fut).await,
+        let fut: Pin<Box<dyn Future<Output = T> + Send>> = Box::pin(fut);
+        async move {
+            self.check_sigint()?;
+            if std::process::id() != self.creation_pid {
+                return Err(RuntimeError::InvalidRuntime(format!(
+                    "XetRuntime was created in process {} but is being used in process {}",
+                    self.creation_pid,
+                    std::process::id(),
+                )));
+            }
+            match &self.backend {
+                RuntimeBackend::External { .. } => Ok(fut.await),
+                RuntimeBackend::OwnedThreadPool { .. } => self.bridge_to_owned(task_name, fut).await,
+            }
         }
     }
 
@@ -477,9 +486,16 @@ impl XetRuntime {
     /// Returns `Err(RuntimeError::TaskPanic)` if the spawned future panics, or
     /// `Err(RuntimeError::TaskCanceled)` if the runtime shuts down before the result
     /// can be delivered.
-    async fn bridge_to_owned<T, F>(&self, task_name: &'static str, fut: F) -> Result<T, RuntimeError>
+    // Takes an already-boxed future rather than being generic over `F`: an `async fn`
+    // parameter is captured into this generator's state regardless of what the body does
+    // with it, so staying generic here would reintroduce the same bloat `bridge_async`
+    // above avoids by boxing before its own async block.
+    async fn bridge_to_owned<T>(
+        &self,
+        task_name: &'static str,
+        fut: Pin<Box<dyn Future<Output = T> + Send>>,
+    ) -> Result<T, RuntimeError>
     where
-        F: Future<Output = T> + Send + 'static,
         T: Send + 'static,
     {
         let (tx, rx) = oneshot::channel();

--- a/xet_runtime/src/core/runtime/native.rs
+++ b/xet_runtime/src/core/runtime/native.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::fmt::Display;
 use std::future::Future;
 use std::panic::AssertUnwindSafe;
-use std::pin::{Pin, pin};
+use std::pin::pin;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, LazyLock, OnceLock, Weak};
 use std::task::{Context, Waker};
@@ -404,33 +404,22 @@ impl XetRuntime {
     ///
     /// This is the primary async entry point. Session-level async methods should call
     /// `ctx.runtime.bridge_async(...)`.
-    // Plain (non-async) fn boxing `fut` before constructing the returned `async move` block:
-    // an `async fn` generic over `F` bakes F's full type into its own generator state
-    // regardless of what the body does with it (see `bridge_to_owned` below, which needed
-    // the same fix).
-    pub fn bridge_async<T, F>(
-        &self,
-        task_name: &'static str,
-        fut: F,
-    ) -> impl Future<Output = Result<T, RuntimeError>> + Send + '_
+    pub async fn bridge_async<T, F>(&self, task_name: &'static str, fut: F) -> Result<T, RuntimeError>
     where
         F: Future<Output = T> + Send + 'static,
         T: Send + 'static,
     {
-        let fut: Pin<Box<dyn Future<Output = T> + Send>> = Box::pin(fut);
-        async move {
-            self.check_sigint()?;
-            if std::process::id() != self.creation_pid {
-                return Err(RuntimeError::InvalidRuntime(format!(
-                    "XetRuntime was created in process {} but is being used in process {}",
-                    self.creation_pid,
-                    std::process::id(),
-                )));
-            }
-            match &self.backend {
-                RuntimeBackend::External { .. } => Ok(fut.await),
-                RuntimeBackend::OwnedThreadPool { .. } => self.bridge_to_owned(task_name, fut).await,
-            }
+        self.check_sigint()?;
+        if std::process::id() != self.creation_pid {
+            return Err(RuntimeError::InvalidRuntime(format!(
+                "XetRuntime was created in process {} but is being used in process {}",
+                self.creation_pid,
+                std::process::id(),
+            )));
+        }
+        match &self.backend {
+            RuntimeBackend::External { .. } => Ok(fut.await),
+            RuntimeBackend::OwnedThreadPool { .. } => self.bridge_to_owned(task_name, fut).await,
         }
     }
 
@@ -486,16 +475,9 @@ impl XetRuntime {
     /// Returns `Err(RuntimeError::TaskPanic)` if the spawned future panics, or
     /// `Err(RuntimeError::TaskCanceled)` if the runtime shuts down before the result
     /// can be delivered.
-    // Takes an already-boxed future rather than being generic over `F`: an `async fn`
-    // parameter is captured into this generator's state regardless of what the body does
-    // with it, so staying generic here would reintroduce the same bloat `bridge_async`
-    // above avoids by boxing before its own async block.
-    async fn bridge_to_owned<T>(
-        &self,
-        task_name: &'static str,
-        fut: Pin<Box<dyn Future<Output = T> + Send>>,
-    ) -> Result<T, RuntimeError>
+    async fn bridge_to_owned<T, F>(&self, task_name: &'static str, fut: F) -> Result<T, RuntimeError>
     where
+        F: Future<Output = T> + Send + 'static,
         T: Send + 'static,
     {
         let (tx, rx) = oneshot::channel();


### PR DESCRIPTION
## Summary

`AuthGroupBuilder<T>::build()`'s compiler-generated future was large enough to overflow a thread's default stack on platforms with a small default (e.g. ~524 KiB for non-main threads on macOS).

Root cause: `bridge_async`/`bridge_async_finalizing` and their downstream helpers were `async fn`s generic over `F`, so a large future crossing one of these boundaries by value got duplicated across nested generator frames instead of being shared — the same failure mode #901 partially addressed but didn't fully close.

**Fix:** box the future once, as early as possible (in `xet_session::TaskRuntime`), and pass the boxed pointer through downstream layers.

| | Before | After |
|---|---|---|
| `AuthGroupBuilder::build()` future size | 23,664 bytes | ~536–800 bytes (see below) |
| Min. viable stack (release build) | ~128–256 KiB | ~65.5–66 KiB |

One crate boundary further downstream, `xet_runtime::XetRuntime::bridge_async`/`bridge_to_owned` can either re-box or stay generic over `F` — we measured both (`-Zprint-type-sizes`, nightly, debug build):

| `AuthGroupBuilder<T>` instantiation | Re-box at `xet_runtime` boundary | Generic (current) |
|---|---:|---:|
| `download_stream_group` | 536 bytes | 808 bytes |
| `file_download_group` | 528 bytes | 800 bytes |
| `upload_commit` | 528 bytes | 800 bytes |

Both are trivially safe vs. the 23,664-byte pre-fix size. Re-boxing is ~34% smaller and makes that boundary self-defending for any caller, not just `xet_session` — we opted for the simpler single-boxing-point approach instead, accepting the larger (still tiny) future and leaving "box early" as the caller's responsibility.

## Test plan

- [x] Regression test per `AuthGroupBuilder<T>` instantiation, each running the real `build()` call on a small stack in a re-exec'd child process (verified: fails without the fix, passes with it)
- [x] Full test suites, workspace + wasm builds, `fmt`/`clippy` all clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core async bridging used by all session build/upload/download paths; behavior should be equivalent but incorrect boxing could affect cancellation or wasm Send bounds.
> 
> **Overview**
> Fixes **stack overflows** when calling `AuthGroupBuilder::build()` on threads with small default stacks (e.g. non-main threads on macOS). Generic `async fn` bridges were embedding huge caller futures (~24KB) into every nested generator frame.
> 
> **`TaskRuntime::bridge_async` / `bridge_async_finalizing`** are now plain functions that **`Box::pin` the incoming future before** building the outer `async` block, with a shared `BoxedBridgeFuture` type so only a pointer is carried through downstream awaits. Redundant boxing was removed from **`run_inner_async`** (wasm) and **`XetRuntime::bridge_async`** in External mode, since erasure happens once at the session layer.
> 
> Adds **`test_utils::stack_regression`**, which re-runs targeted tests in a **child process on a 128KiB stack** (512KiB on Windows), plus regression tests for upload commit, file download group, and download stream group `build().await`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d06e277356a5bec3238a81e333cbc6325d7646f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
