### PR TITLE
Local simulation test for v2 shards upload API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,7 +255,7 @@ version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -278,7 +278,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1ac0219111eb7bb7cb76d4cf2cb50c598e7ae549091d3616f9e95442c18486f"
 dependencies = [
  "async-lock",
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
 ]
 
 [[package]]
@@ -294,7 +294,7 @@ dependencies = [
  "async-task",
  "blocking",
  "cfg-if 1.0.4",
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "futures-lite",
  "rustix",
 ]
@@ -1414,11 +1414,10 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -1429,7 +1428,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "pin-project-lite",
 ]
 

--- a/xet_client/src/cas_client/simulation/direct_access_client.rs
+++ b/xet_client/src/cas_client/simulation/direct_access_client.rs
@@ -58,12 +58,12 @@ pub trait DirectAccessClient: Client + Send + Sync {
     /// Pass `None` to disable (default: returns full shards with no expiration).
     fn set_global_dedup_shard_expiration(&self, expiration: Option<Duration>);
 
-    /// Disables V2 reconstruction responses with the given HTTP status code.
-    /// When disabled, the V2 endpoint returns this status, forcing clients to
-    /// fall back to V1. Pass 0 to re-enable.
+    /// Disables V2 endpoints (reconstruction and shard upload) with the given HTTP status code.
+    /// When disabled, `/v2/*` handlers return this status, forcing clients to fall back to V1.
+    /// Pass 0 to re-enable.
     fn disable_v2_reconstruction(&self, status_code: u16);
 
-    /// Returns the HTTP status code the V2 endpoint should return when disabled,
+    /// Returns the HTTP status code V2 endpoints should return when disabled,
     /// or 0 if V2 is enabled.
     fn v2_disabled_status_code(&self) -> u16 {
         0

--- a/xet_client/src/cas_client/simulation/direct_access_client.rs
+++ b/xet_client/src/cas_client/simulation/direct_access_client.rs
@@ -61,7 +61,7 @@ pub trait DirectAccessClient: Client + Send + Sync {
     /// Disables V2 endpoints (reconstruction and shard upload) with the given HTTP status code.
     /// When disabled, `/v2/*` handlers return this status, forcing clients to fall back to V1.
     /// Pass 0 to re-enable.
-    fn disable_v2_reconstruction(&self, status_code: u16);
+    fn disable_v2_endpoints(&self, status_code: u16);
 
     /// Returns the HTTP status code V2 endpoints should return when disabled,
     /// or 0 if V2 is enabled.

--- a/xet_client/src/cas_client/simulation/local_client.rs
+++ b/xet_client/src/cas_client/simulation/local_client.rs
@@ -570,7 +570,7 @@ impl DirectAccessClient for LocalClient {
         self.max_ranges_per_fetch.store(max_ranges, Ordering::Relaxed);
     }
 
-    fn disable_v2_reconstruction(&self, status_code: u16) {
+    fn disable_v2_endpoints(&self, status_code: u16) {
         self.v2_disabled_status.store(status_code, Ordering::Relaxed);
     }
 

--- a/xet_client/src/cas_client/simulation/local_server/handlers.rs
+++ b/xet_client/src/cas_client/simulation/local_server/handlers.rs
@@ -31,8 +31,9 @@ use xet_core_structures::merklehash::MerkleHash;
 use super::super::super::{DeletionControlableClient, DirectAccessClient};
 use super::latency_simulation::{LatencySimulation, ServerLatencyProfile};
 use crate::cas_types::{
-    FileRange, HexKey, HexMerkleHash, QueryReconstructionResponseV2, UploadShardResponse, UploadShardResponseType,
-    UploadXorbResponse, XorbRangeDescriptor, XorbReconstructionFetchInfo,
+    CommitStage, FileRange, HexKey, HexMerkleHash, QueryReconstructionResponseV2, ShardUploadEvent,
+    UploadShardResponse, UploadShardResponseType, UploadXorbResponse, XorbRangeDescriptor,
+    XorbReconstructionFetchInfo,
 };
 use crate::error::ClientError;
 
@@ -587,6 +588,71 @@ pub async fn post_shard(State(state): State<ServerState>, body: Body) -> Respons
     }
 }
 
+/// POST /v2/shards
+///
+/// Upload a shard with an NDJSON progress stream (same event types production CAS emits).
+/// Respects [`DirectAccessClient::v2_disabled_status_code`] so clients can exercise V2→V1 fallback.
+///
+/// On success the response is `200` with `application/x-ndjson` frames ending in `result`.
+/// Backend upload failures map to HTTP errors (the stream never starts).
+pub async fn post_shard_v2(State(state): State<ServerState>, body: Body) -> Response {
+    let connection_guard = state.latency_simulation.register_connection().await;
+    if let Some(simulated_error) = connection_guard.simulate_error() {
+        return simulated_error;
+    }
+
+    // Allow testing V1 fallback by simulating V2 endpoint unavailability.
+    let disabled_status = state.client.v2_disabled_status_code();
+    if disabled_status != 0 {
+        let code = StatusCode::from_u16(disabled_status).unwrap_or(StatusCode::NOT_FOUND);
+        return (code, "V2 shard upload endpoint disabled").into_response();
+    }
+
+    let data = match collect_body(body).await {
+        Ok(d) => d,
+        Err(e) => return (StatusCode::BAD_REQUEST, e).into_response(),
+    };
+
+    let permit = match state.client.acquire_upload_permit().await {
+        Ok(p) => p,
+        Err(e) => return error_to_response(e),
+    };
+
+    match state.client.upload_shard(data, permit, None).await {
+        Ok(()) => ndjson_shard_upload_success_response(),
+        Err(e) => error_to_response(e),
+    }
+}
+
+/// Builds a minimal production-shaped NDJSON success stream for `/v2/shards`.
+fn ndjson_shard_upload_success_response() -> Response {
+    let events = [
+        ShardUploadEvent::Validating { verified: 0, total: 1 },
+        ShardUploadEvent::Validating { verified: 1, total: 1 },
+        ShardUploadEvent::Committing {
+            stage: CommitStage::Uploading,
+        },
+        ShardUploadEvent::Committing {
+            stage: CommitStage::Syncing,
+        },
+        ShardUploadEvent::Result,
+    ];
+
+    let mut body = Vec::new();
+    for event in &events {
+        // Simulation frames are always valid `ShardUploadEvent` values.
+        serde_json::to_writer(&mut body, event).expect("ShardUploadEvent serializes");
+        body.push(b'\n');
+    }
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        http::header::CONTENT_TYPE,
+        HeaderValue::from_static("application/x-ndjson"),
+    );
+    (StatusCode::OK, headers, body).into_response()
+}
+
 /// HEAD /v1/files/{file_id}
 ///
 /// Get the size of a file.
@@ -786,7 +852,7 @@ pub async fn set_config(State(state): State<ServerState>, uri: Uri, body: Body) 
         "disable_v2_reconstruction" => match value.parse::<u16>() {
             Ok(code) => {
                 state.client.disable_v2_reconstruction(code);
-                (StatusCode::OK, "V2 reconstruction config set").into_response()
+                (StatusCode::OK, "V2 endpoints (reconstruction + shard upload) config set").into_response()
             },
             Err(e) => (StatusCode::BAD_REQUEST, format!("Invalid status code: {e}")).into_response(),
         },

--- a/xet_client/src/cas_client/simulation/local_server/handlers.rs
+++ b/xet_client/src/cas_client/simulation/local_server/handlers.rs
@@ -14,6 +14,7 @@
 //! Errors are mapped to appropriate HTTP status codes via `error_to_response`.
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::time::Duration;
 
 use axum::Json;
@@ -36,12 +37,25 @@ use crate::cas_types::{
 };
 use crate::error::ClientError;
 
+/// `/v2/shards` in-stream `Error` frame mode (`set_config` + handler encoding).
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) enum ShardUploadErrorFrame {
+    #[default]
+    Off = 0,
+    Fatal = 1,
+    Retryable = 2,
+}
+
 /// Server state passed to all handlers.
 #[derive(Clone)]
 pub(crate) struct ServerState {
     pub(crate) client: Arc<dyn DirectAccessClient>,
     pub(super) latency_simulation: Arc<LatencySimulation>,
     pub(crate) deletion_client: Option<Arc<dyn DeletionControlableClient>>,
+    /// While set, `/v2/shards` emits an in-stream `Error` frame instead of committing.
+    /// Encodes [`ShardUploadErrorFrame`] as `u8`.
+    pub(crate) shard_upload_error_frame: Arc<AtomicU8>,
 }
 
 /// Represents the different forms a Range header can take.
@@ -593,7 +607,10 @@ pub async fn post_shard(State(state): State<ServerState>, body: Body) -> Respons
 /// Respects [`DirectAccessClient::v2_disabled_status_code`] so clients can exercise V2→V1 fallback.
 ///
 /// On success the response is `200` with `application/x-ndjson` frames ending in `result`.
-/// Backend upload failures map to HTTP errors (the stream never starts).
+/// Once the stream has started, failures are signaled by an in-stream `Error` frame (not a
+/// non-200 status), matching production: clients MUST treat that frame as the error signal.
+/// Use `/simulation/set_config?config=shard_upload_error_frame&value=retryable|fatal` to force
+/// that path (cleared with `off`).
 pub async fn post_shard_v2(State(state): State<ServerState>, body: Body) -> Response {
     let connection_guard = state.latency_simulation.register_connection().await;
     if let Some(simulated_error) = connection_guard.simulate_error() {
@@ -612,6 +629,14 @@ pub async fn post_shard_v2(State(state): State<ServerState>, body: Body) -> Resp
         Err(e) => return (StatusCode::BAD_REQUEST, e).into_response(),
     };
 
+    // In-stream Error frame (production contract: 200 + terminal error frame).
+    // Checked before upload so the shard is not committed while the client sees failure.
+    match state.shard_upload_error_frame.load(Ordering::Relaxed) {
+        v if v == ShardUploadErrorFrame::Fatal as u8 => return ndjson_shard_upload_error_response(false),
+        v if v == ShardUploadErrorFrame::Retryable as u8 => return ndjson_shard_upload_error_response(true),
+        _ => {},
+    }
+
     let permit = match state.client.acquire_upload_permit().await {
         Ok(p) => p,
         Err(e) => return error_to_response(e),
@@ -625,7 +650,7 @@ pub async fn post_shard_v2(State(state): State<ServerState>, body: Body) -> Resp
 
 /// Builds a minimal production-shaped NDJSON success stream for `/v2/shards`.
 fn ndjson_shard_upload_success_response() -> Response {
-    let events = [
+    ndjson_shard_upload_response(&[
         ShardUploadEvent::Validating { verified: 0, total: 1 },
         ShardUploadEvent::Validating { verified: 1, total: 1 },
         ShardUploadEvent::Committing {
@@ -635,10 +660,28 @@ fn ndjson_shard_upload_success_response() -> Response {
             stage: CommitStage::Syncing,
         },
         ShardUploadEvent::Result,
-    ];
+    ])
+}
 
+/// Builds a 200 NDJSON stream that ends in a terminal `Error` frame (production failure contract).
+fn ndjson_shard_upload_error_response(retryable: bool) -> Response {
+    let message = if retryable {
+        "simulated retryable shard upload failure"
+    } else {
+        "simulated fatal shard upload failure"
+    };
+    ndjson_shard_upload_response(&[
+        ShardUploadEvent::Validating { verified: 0, total: 1 },
+        ShardUploadEvent::Error {
+            message: message.to_string(),
+            retryable,
+        },
+    ])
+}
+
+fn ndjson_shard_upload_response(events: &[ShardUploadEvent]) -> Response {
     let mut body = Vec::new();
-    for event in &events {
+    for event in events {
         // Simulation frames are always valid `ShardUploadEvent` values.
         serde_json::to_writer(&mut body, event).expect("ShardUploadEvent serializes");
         body.push(b'\n');
@@ -852,6 +895,31 @@ pub async fn set_config(State(state): State<ServerState>, uri: Uri, body: Body) 
             },
             Err(e) => (StatusCode::BAD_REQUEST, format!("Invalid status code: {e}")).into_response(),
         },
+        "shard_upload_error_frame" => match value.trim().to_lowercase().as_str() {
+            "off" | "none" | "0" | "" => {
+                state
+                    .shard_upload_error_frame
+                    .store(ShardUploadErrorFrame::Off as u8, Ordering::Relaxed);
+                (StatusCode::OK, "Shard upload error frame cleared").into_response()
+            },
+            "fatal" => {
+                state
+                    .shard_upload_error_frame
+                    .store(ShardUploadErrorFrame::Fatal as u8, Ordering::Relaxed);
+                (StatusCode::OK, "/v2/shards will emit a fatal Error frame").into_response()
+            },
+            "retryable" => {
+                state
+                    .shard_upload_error_frame
+                    .store(ShardUploadErrorFrame::Retryable as u8, Ordering::Relaxed);
+                (StatusCode::OK, "/v2/shards will emit a retryable Error frame").into_response()
+            },
+            _ => (
+                StatusCode::BAD_REQUEST,
+                "Invalid shard_upload_error_frame value; expected retryable|fatal|off".to_string(),
+            )
+                .into_response(),
+        },
         "api_delay" => match parse_random_delay_value(value) {
             Ok((min_ms, max_ms)) => {
                 let range = if min_ms == 0 && max_ms == 0 {
@@ -876,7 +944,7 @@ pub async fn set_config(State(state): State<ServerState>, uri: Uri, body: Body) 
             format!(
                 "Unknown config: {config_name}. Supported: congestion, random_delay, \
                  global_dedup_shard_expiration, max_ranges_per_fetch, \
-                 disable_v2_endpoints, api_delay, url_expiration"
+                 disable_v2_endpoints, shard_upload_error_frame, api_delay, url_expiration"
             ),
         )
             .into_response(),

--- a/xet_client/src/cas_client/simulation/local_server/handlers.rs
+++ b/xet_client/src/cas_client/simulation/local_server/handlers.rs
@@ -32,8 +32,7 @@ use super::super::super::{DeletionControlableClient, DirectAccessClient};
 use super::latency_simulation::{LatencySimulation, ServerLatencyProfile};
 use crate::cas_types::{
     CommitStage, FileRange, HexKey, HexMerkleHash, QueryReconstructionResponseV2, ShardUploadEvent,
-    UploadShardResponse, UploadShardResponseType, UploadXorbResponse, XorbRangeDescriptor,
-    XorbReconstructionFetchInfo,
+    UploadShardResponse, UploadShardResponseType, UploadXorbResponse, XorbRangeDescriptor, XorbReconstructionFetchInfo,
 };
 use crate::error::ClientError;
 
@@ -646,10 +645,7 @@ fn ndjson_shard_upload_success_response() -> Response {
     }
 
     let mut headers = HeaderMap::new();
-    headers.insert(
-        http::header::CONTENT_TYPE,
-        HeaderValue::from_static("application/x-ndjson"),
-    );
+    headers.insert(http::header::CONTENT_TYPE, HeaderValue::from_static("application/x-ndjson"));
     (StatusCode::OK, headers, body).into_response()
 }
 

--- a/xet_client/src/cas_client/simulation/local_server/handlers.rs
+++ b/xet_client/src/cas_client/simulation/local_server/handlers.rs
@@ -845,9 +845,9 @@ pub async fn set_config(State(state): State<ServerState>, uri: Uri, body: Body) 
             },
             Err(e) => (StatusCode::BAD_REQUEST, format!("Invalid usize value: {e}")).into_response(),
         },
-        "disable_v2_reconstruction" => match value.parse::<u16>() {
+        "disable_v2_endpoints" => match value.parse::<u16>() {
             Ok(code) => {
-                state.client.disable_v2_reconstruction(code);
+                state.client.disable_v2_endpoints(code);
                 (StatusCode::OK, "V2 endpoints (reconstruction + shard upload) config set").into_response()
             },
             Err(e) => (StatusCode::BAD_REQUEST, format!("Invalid status code: {e}")).into_response(),
@@ -876,7 +876,7 @@ pub async fn set_config(State(state): State<ServerState>, uri: Uri, body: Body) 
             format!(
                 "Unknown config: {config_name}. Supported: congestion, random_delay, \
                  global_dedup_shard_expiration, max_ranges_per_fetch, \
-                 disable_v2_reconstruction, api_delay, url_expiration"
+                 disable_v2_endpoints, api_delay, url_expiration"
             ),
         )
             .into_response(),

--- a/xet_client/src/cas_client/simulation/local_server/main.rs
+++ b/xet_client/src/cas_client/simulation/local_server/main.rs
@@ -33,9 +33,11 @@
 //! - `GET /v1/chunks/{prefix}/{hash}` - Query for global deduplication shard
 //! - `HEAD /v1/xorbs/{prefix}/{hash}` - Check if XORB exists
 //! - `POST /v1/xorbs/{prefix}/{hash}` - Upload a XORB
-//! - `POST /shards` - Upload a shard
+//! - `POST /v1/shards` - Upload a shard (JSON response)
+//! - `POST /v2/shards` - Upload a shard (NDJSON progress stream)
+//! - `GET /v2/reconstructions/{file_id}` - V2 file reconstruction
 //! - `HEAD /v1/files/{file_id}` - Get file size
-//! - `GET /get_xorb/{prefix}/{hash}/` - Download XORB data
+//! - `GET /v1/get_xorb/{prefix}/{hash}/` - Download XORB data
 //!
 //! # Environment Variables
 //!

--- a/xet_client/src/cas_client/simulation/local_server/server.rs
+++ b/xet_client/src/cas_client/simulation/local_server/server.rs
@@ -166,8 +166,8 @@ impl LocalServer {
     /// Builds the Axum router with all CAS API routes.
     ///
     /// Routes follow the pattern used by RemoteClient:
-    /// - `/v1/` prefixed routes for chunks, xorbs, reconstructions, and files
-    /// - Root-level `/reconstructions` for batch queries and `/shards` for uploads
+    /// - `/v1/` prefixed routes for chunks, xorbs, reconstructions, files, and shard uploads
+    /// - `/v2/` prefixed routes for V2 reconstructions and NDJSON shard uploads
     /// - `/simulation/` prefixed routes for testing/simulation configuration and direct access
     fn create_router(&self) -> Router {
         Router::new()
@@ -184,7 +184,12 @@ impl LocalServer {
                     .route("/get_xorb/{prefix}/{hash}/", get(handlers::get_file_term_data))
                     .route("/fetch_term", get(handlers::fetch_term)),
             )
-            .nest("/v2", Router::new().route("/reconstructions/{file_id}", get(handlers::get_reconstruction_v2)))
+            .nest(
+                "/v2",
+                Router::new()
+                    .route("/reconstructions/{file_id}", get(handlers::get_reconstruction_v2))
+                    .route("/shards", post(handlers::post_shard_v2)),
+            )
             .nest(
                 "/simulation",
                 super::simulation_handlers::simulation_routes()

--- a/xet_client/src/cas_client/simulation/local_server/server.rs
+++ b/xet_client/src/cas_client/simulation/local_server/server.rs
@@ -36,6 +36,7 @@ use std::net::SocketAddr;
 use std::net::TcpListener as StdTcpListener;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::AtomicU8;
 #[cfg(test)]
 use std::time::Duration;
 
@@ -101,6 +102,8 @@ pub struct LocalServer {
     client: Arc<dyn DirectAccessClient>,
     deletion_client: Option<Arc<dyn DeletionControlableClient>>,
     latency_simulation: Arc<LatencySimulation>,
+    /// `/v2/shards` in-stream Error frame mode (see [`handlers::ShardUploadErrorFrame`]).
+    shard_upload_error_frame: Arc<AtomicU8>,
 }
 
 impl LocalServer {
@@ -125,6 +128,7 @@ impl LocalServer {
             client,
             deletion_client,
             latency_simulation,
+            shard_upload_error_frame: Arc::new(AtomicU8::new(handlers::ShardUploadErrorFrame::Off as u8)),
         })
     }
 
@@ -150,6 +154,7 @@ impl LocalServer {
             client,
             deletion_client,
             latency_simulation,
+            shard_upload_error_frame: Arc::new(AtomicU8::new(handlers::ShardUploadErrorFrame::Off as u8)),
         }
     }
 
@@ -202,6 +207,7 @@ impl LocalServer {
                 client: self.client.clone(),
                 latency_simulation: self.latency_simulation.clone(),
                 deletion_client: self.deletion_client.clone(),
+                shard_upload_error_frame: self.shard_upload_error_frame.clone(),
             })
     }
 

--- a/xet_client/src/cas_client/simulation/local_server/server.rs
+++ b/xet_client/src/cas_client/simulation/local_server/server.rs
@@ -524,8 +524,8 @@ impl DirectAccessClient for LocalTestServer {
         self.client.set_max_ranges_per_fetch(max_ranges);
     }
 
-    fn disable_v2_reconstruction(&self, status_code: u16) {
-        self.client.disable_v2_reconstruction(status_code);
+    fn disable_v2_endpoints(&self, status_code: u16) {
+        self.client.disable_v2_endpoints(status_code);
     }
 
     fn v2_disabled_status_code(&self) -> u16 {
@@ -1127,7 +1127,7 @@ mod tests {
 
         // Test 501 (Not Implemented) fallback first, before the RemoteClient
         // caches a V1 preference from a 404 fallback.
-        server.disable_v2_reconstruction(501);
+        server.disable_v2_endpoints(501);
 
         let v2_result = server.remote_client().get_reconstruction_v2(&file.file_hash, None).await;
         assert!(v2_result.is_err(), "V2 should return error when disabled with 501");
@@ -1158,13 +1158,13 @@ mod tests {
         assert_eq!(result.terms.len(), 2);
 
         // Re-enable V2, then test 404 fallback.
-        server.disable_v2_reconstruction(0);
+        server.disable_v2_endpoints(0);
 
         // Reset the RemoteClient's cached version by making a successful V2 call.
         let v2_result = server.remote_client().get_reconstruction_v2(&file.file_hash, None).await;
         assert!(v2_result.is_ok(), "V2 should work again after re-enabling");
 
-        server.disable_v2_reconstruction(404);
+        server.disable_v2_endpoints(404);
 
         let v2_result = server.remote_client().get_reconstruction_v2(&file.file_hash, None).await;
         assert!(v2_result.is_err(), "V2 should return error when disabled with 404");

--- a/xet_client/src/cas_client/simulation/local_server/simulation_control_client.rs
+++ b/xet_client/src/cas_client/simulation/local_server/simulation_control_client.rs
@@ -276,8 +276,8 @@ impl DirectAccessClient for SimulationControlClient {
         self.post_config("max_ranges_per_fetch", &max_ranges.to_string());
     }
 
-    fn disable_v2_reconstruction(&self, status_code: u16) {
-        self.post_config("disable_v2_reconstruction", &status_code.to_string());
+    fn disable_v2_endpoints(&self, status_code: u16) {
+        self.post_config("disable_v2_endpoints", &status_code.to_string());
     }
 
     async fn get_reconstruction_v1(

--- a/xet_client/src/cas_client/simulation/memory_client.rs
+++ b/xet_client/src/cas_client/simulation/memory_client.rs
@@ -315,7 +315,7 @@ impl DirectAccessClient for MemoryClient {
         self.max_ranges_per_fetch.store(max_ranges, Ordering::Relaxed);
     }
 
-    fn disable_v2_reconstruction(&self, status_code: u16) {
+    fn disable_v2_endpoints(&self, status_code: u16) {
         self.v2_disabled_status.store(status_code, Ordering::Relaxed);
     }
 

--- a/xet_client/src/cas_client/simulation/simulation_server.rs
+++ b/xet_client/src/cas_client/simulation/simulation_server.rs
@@ -1202,6 +1202,175 @@ mod tests {
         check_chunk_hashes_correctness(server).await;
         check_simulation_set_config(server).await;
         check_simulation_dummy_upload(server).await;
+        check_v2_shard_upload(server).await;
+        check_v2_shard_upload_disabled_fallback(server).await;
+    }
+
+    /// Builds raw shard bytes suitable for `/v1/shards` and `/v2/shards` upload tests.
+    fn random_shard_bytes() -> bytes::Bytes {
+        use xet_core_structures::metadata_shard::shard_format::test_routines::gen_random_shard_with_xorb_references;
+
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let shard_dir = tmp_dir.path().join("shard");
+        std::fs::create_dir_all(&shard_dir).unwrap();
+        let shard_in = gen_random_shard_with_xorb_references(0, &[16; 8], &[2; 20], true, true).unwrap();
+        let shard_path = shard_in.write_to_directory(&shard_dir, None).unwrap();
+        bytes::Bytes::from(std::fs::read(&shard_path).unwrap())
+    }
+
+    /// Verifies `/v2/shards` NDJSON streaming via raw HTTP and via `RemoteClient` progress callbacks.
+    async fn check_v2_shard_upload(server: &LocalTestServer) {
+        use std::sync::{Arc, Mutex};
+
+        use crate::cas_client::interface::{ShardUploadProgressCallback, ShardUploadProgressType};
+        use crate::cas_types::{CommitStage, ShardUploadEvent};
+
+        let shard_data = random_shard_bytes();
+
+        // Raw HTTP: response is NDJSON ending in a terminal `result` frame.
+        let http_client = reqwest::Client::new();
+        let response = http_client
+            .post(format!("{}/v2/shards", server.http_endpoint()))
+            .body(shard_data.clone())
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        let content_type = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(
+            content_type.contains("ndjson") || content_type.contains("json"),
+            "unexpected content-type: {content_type}"
+        );
+
+        let body = response.text().await.unwrap();
+        let events: Vec<ShardUploadEvent> = body
+            .lines()
+            .filter(|line| !line.is_empty())
+            .map(|line| serde_json::from_str(line).expect("valid ShardUploadEvent NDJSON line"))
+            .collect();
+        assert!(
+            events.iter().any(|e| matches!(e, ShardUploadEvent::Validating { .. })),
+            "expected validating frame(s), got {events:?}"
+        );
+        assert!(
+            events.iter().any(|e| matches!(e, ShardUploadEvent::Committing { .. })),
+            "expected committing frame(s), got {events:?}"
+        );
+        assert_eq!(events.last(), Some(&ShardUploadEvent::Result));
+
+        // RemoteClient path: progress callback receives Response frames from the NDJSON stream.
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let seen_cb = seen.clone();
+        let callback: ShardUploadProgressCallback = Arc::new(move |progress| {
+            if let ShardUploadProgressType::Response(event) = progress {
+                seen_cb.lock().unwrap().push(event.clone());
+            }
+        });
+
+        let shard_data = random_shard_bytes();
+        let permit = server.remote_client().acquire_upload_permit().await.unwrap();
+        server
+            .remote_simulation_client()
+            .upload_shard_v2(shard_data, permit, Some(callback))
+            .await
+            .unwrap();
+
+        let seen = seen.lock().unwrap().clone();
+        assert!(
+            seen.iter().any(|e| matches!(e, ShardUploadEvent::Validating { .. })),
+            "callback should see validating events, got {seen:?}"
+        );
+        assert!(
+            seen.iter().any(|e| {
+                matches!(
+                    e,
+                    ShardUploadEvent::Committing {
+                        stage: CommitStage::Uploading
+                    } | ShardUploadEvent::Committing {
+                        stage: CommitStage::Syncing
+                    }
+                )
+            }),
+            "callback should see committing events, got {seen:?}"
+        );
+        assert_eq!(seen.last(), Some(&ShardUploadEvent::Result));
+    }
+
+    /// Verifies `/v2/shards` disable + RemoteClient V2→V1 fallback (same status codes as reconstruction).
+    async fn check_v2_shard_upload_disabled_fallback(server: &LocalTestServer) {
+        let shard_data = random_shard_bytes();
+
+        // Fresh success on V2 before disabling.
+        {
+            let permit = server.remote_client().acquire_upload_permit().await.unwrap();
+            server
+                .remote_simulation_client()
+                .upload_shard_v2(shard_data.clone(), permit, None)
+                .await
+                .unwrap();
+        }
+
+        // 501 first so we don't cache a V1 preference from 404 fallback mid-test.
+        server.client().disable_v2_reconstruction(501);
+
+        let v2_err = {
+            let permit = server.remote_client().acquire_upload_permit().await.unwrap();
+            server
+                .remote_simulation_client()
+                .upload_shard_v2(shard_data.clone(), permit, None)
+                .await
+        };
+        assert!(v2_err.is_err(), "forced V2 should fail when disabled with 501");
+        assert_eq!(v2_err.unwrap_err().status(), Some(reqwest::StatusCode::NOT_IMPLEMENTED));
+
+        // Auto version override should fall back to V1 and succeed.
+        {
+            let permit = server.remote_client().acquire_upload_permit().await.unwrap();
+            server
+                .remote_simulation_client()
+                .upload_shard_with_version_override(shard_data.clone(), permit, None, None)
+                .await
+                .unwrap();
+        }
+
+        // Re-enable, confirm V2 works, then exercise 404 fallback.
+        server.client().disable_v2_reconstruction(0);
+        {
+            let permit = server.remote_client().acquire_upload_permit().await.unwrap();
+            // Force V2 so we don't stay on a cached V1 preference from the previous fallback.
+            server
+                .remote_simulation_client()
+                .upload_shard_with_version_override(random_shard_bytes(), permit, Some(2), None)
+                .await
+                .unwrap();
+        }
+
+        server.client().disable_v2_reconstruction(404);
+        let v2_err = {
+            let permit = server.remote_client().acquire_upload_permit().await.unwrap();
+            server
+                .remote_simulation_client()
+                .upload_shard_v2(random_shard_bytes(), permit, None)
+                .await
+        };
+        assert!(v2_err.is_err(), "forced V2 should fail when disabled with 404");
+        assert_eq!(v2_err.unwrap_err().status(), Some(reqwest::StatusCode::NOT_FOUND));
+
+        {
+            let permit = server.remote_client().acquire_upload_permit().await.unwrap();
+            server
+                .remote_simulation_client()
+                .upload_shard_with_version_override(random_shard_bytes(), permit, None, None)
+                .await
+                .unwrap();
+        }
+
+        // Leave V2 enabled for subsequent checks on the same server instance.
+        server.client().disable_v2_reconstruction(0);
     }
 
     /// Main test that runs all server checks with both in-memory and disk-backed storage.

--- a/xet_client/src/cas_client/simulation/simulation_server.rs
+++ b/xet_client/src/cas_client/simulation/simulation_server.rs
@@ -1241,10 +1241,20 @@ mod tests {
             .get(reqwest::header::CONTENT_TYPE)
             .and_then(|v| v.to_str().ok())
             .unwrap_or("");
-        assert!(
-            content_type.contains("ndjson") || content_type.contains("json"),
-            "unexpected content-type: {content_type}"
-        );
+        assert_eq!(content_type, "application/x-ndjson");
+
+        // Exact deterministic stream from `ndjson_shard_upload_success_response`.
+        let expected = vec![
+            ShardUploadEvent::Validating { verified: 0, total: 1 },
+            ShardUploadEvent::Validating { verified: 1, total: 1 },
+            ShardUploadEvent::Committing {
+                stage: CommitStage::Uploading,
+            },
+            ShardUploadEvent::Committing {
+                stage: CommitStage::Syncing,
+            },
+            ShardUploadEvent::Result,
+        ];
 
         let body = response.text().await.unwrap();
         let events: Vec<ShardUploadEvent> = body
@@ -1252,15 +1262,7 @@ mod tests {
             .filter(|line| !line.is_empty())
             .map(|line| serde_json::from_str(line).expect("valid ShardUploadEvent NDJSON line"))
             .collect();
-        assert!(
-            events.iter().any(|e| matches!(e, ShardUploadEvent::Validating { .. })),
-            "expected validating frame(s), got {events:?}"
-        );
-        assert!(
-            events.iter().any(|e| matches!(e, ShardUploadEvent::Committing { .. })),
-            "expected committing frame(s), got {events:?}"
-        );
-        assert_eq!(events.last(), Some(&ShardUploadEvent::Result));
+        assert_eq!(events, expected);
 
         // RemoteClient path: progress callback receives Response frames from the NDJSON stream.
         let seen = Arc::new(Mutex::new(Vec::new()));
@@ -1280,24 +1282,7 @@ mod tests {
             .unwrap();
 
         let seen = seen.lock().unwrap().clone();
-        assert!(
-            seen.iter().any(|e| matches!(e, ShardUploadEvent::Validating { .. })),
-            "callback should see validating events, got {seen:?}"
-        );
-        assert!(
-            seen.iter().any(|e| {
-                matches!(
-                    e,
-                    ShardUploadEvent::Committing {
-                        stage: CommitStage::Uploading
-                    } | ShardUploadEvent::Committing {
-                        stage: CommitStage::Syncing
-                    }
-                )
-            }),
-            "callback should see committing events, got {seen:?}"
-        );
-        assert_eq!(seen.last(), Some(&ShardUploadEvent::Result));
+        assert_eq!(seen, expected);
     }
 
     /// Verifies `/v2/shards` disable + RemoteClient V2→V1 fallback (same status codes as reconstruction).
@@ -1338,10 +1323,12 @@ mod tests {
         }
 
         // Re-enable, confirm V2 works, then exercise 404 fallback.
+        // Forced `Some(2)` does *not* clear `detected_shard_api_version` (store is gated on
+        // `forced_version.is_none()`), so this only proves the endpoint is healthy again —
+        // the 404 auto-detect case below still needs a fresh client.
         server.client().disable_v2_endpoints(0);
         {
             let permit = server.remote_client().acquire_upload_permit().await.unwrap();
-            // Force V2 so we don't stay on a cached V1 preference from the previous fallback.
             server
                 .remote_simulation_client()
                 .upload_shard_with_version_override(random_shard_bytes(), permit, Some(2), None)

--- a/xet_client/src/cas_client/simulation/simulation_server.rs
+++ b/xet_client/src/cas_client/simulation/simulation_server.rs
@@ -590,8 +590,8 @@ impl DirectAccessClient for LocalTestServer {
         self.client.set_max_ranges_per_fetch(max_ranges);
     }
 
-    fn disable_v2_reconstruction(&self, status_code: u16) {
-        self.client.disable_v2_reconstruction(status_code);
+    fn disable_v2_endpoints(&self, status_code: u16) {
+        self.client.disable_v2_endpoints(status_code);
     }
 
     async fn get_reconstruction_v1(
@@ -1088,8 +1088,8 @@ mod tests {
             reqwest::StatusCode::OK
         );
 
-        // --- disable_v2_reconstruction ---
-        assert_eq!(post_set_config(server, "disable_v2_reconstruction", "503").await, reqwest::StatusCode::OK);
+        // --- disable_v2_endpoints ---
+        assert_eq!(post_set_config(server, "disable_v2_endpoints", "503").await, reqwest::StatusCode::OK);
         // Verify effect: V2 reconstruction via HTTP should return 503
         {
             let file = server.client().upload_random_file(&[(1, (0, 3))], CHUNK_SIZE).await.unwrap();
@@ -1098,8 +1098,8 @@ mod tests {
             assert_eq!(resp.status(), reqwest::StatusCode::SERVICE_UNAVAILABLE);
         }
         // Re-enable
-        assert_eq!(post_set_config(server, "disable_v2_reconstruction", "0").await, reqwest::StatusCode::OK);
-        assert_eq!(post_set_config(server, "disable_v2_reconstruction", "xyz").await, reqwest::StatusCode::BAD_REQUEST);
+        assert_eq!(post_set_config(server, "disable_v2_endpoints", "0").await, reqwest::StatusCode::OK);
+        assert_eq!(post_set_config(server, "disable_v2_endpoints", "xyz").await, reqwest::StatusCode::BAD_REQUEST);
 
         // --- api_delay ---
         assert_eq!(post_set_config(server, "api_delay", "(50ms, 50ms)").await, reqwest::StatusCode::OK);
@@ -1315,7 +1315,7 @@ mod tests {
         }
 
         // 501 first so we don't cache a V1 preference from 404 fallback mid-test.
-        server.client().disable_v2_reconstruction(501);
+        server.client().disable_v2_endpoints(501);
 
         let v2_err = {
             let permit = server.remote_client().acquire_upload_permit().await.unwrap();
@@ -1338,7 +1338,7 @@ mod tests {
         }
 
         // Re-enable, confirm V2 works, then exercise 404 fallback.
-        server.client().disable_v2_reconstruction(0);
+        server.client().disable_v2_endpoints(0);
         {
             let permit = server.remote_client().acquire_upload_permit().await.unwrap();
             // Force V2 so we don't stay on a cached V1 preference from the previous fallback.
@@ -1349,7 +1349,7 @@ mod tests {
                 .unwrap();
         }
 
-        server.client().disable_v2_reconstruction(404);
+        server.client().disable_v2_endpoints(404);
         let v2_err = {
             let permit = server.remote_client().acquire_upload_permit().await.unwrap();
             server
@@ -1376,7 +1376,7 @@ mod tests {
         }
 
         // Leave V2 enabled for subsequent checks on the same server instance.
-        server.client().disable_v2_reconstruction(0);
+        server.client().disable_v2_endpoints(0);
     }
 
     /// Main test that runs all server checks with both in-memory and disk-backed storage.

--- a/xet_client/src/cas_client/simulation/simulation_server.rs
+++ b/xet_client/src/cas_client/simulation/simulation_server.rs
@@ -1399,7 +1399,10 @@ mod tests {
                 .unwrap();
             assert_eq!(response.status(), reqwest::StatusCode::OK);
             assert_eq!(
-                response.headers().get(reqwest::header::CONTENT_TYPE).and_then(|v| v.to_str().ok()),
+                response
+                    .headers()
+                    .get(reqwest::header::CONTENT_TYPE)
+                    .and_then(|v| v.to_str().ok()),
                 Some("application/x-ndjson")
             );
             let body = response.text().await.unwrap();
@@ -1429,10 +1432,7 @@ mod tests {
                 .upload_shard_v2(fixed_test_shard_bytes(), permit, None)
                 .await
                 .expect_err("fatal Error frame should fail the upload");
-            assert!(
-                err.to_string().contains("simulated fatal shard upload failure"),
-                "unexpected error: {err}"
-            );
+            assert!(err.to_string().contains("simulated fatal shard upload failure"), "unexpected error: {err}");
         }
 
         // RemoteClient: retryable Error stays enabled — RetryWrapper retries until exhausted, then fails.
@@ -1454,30 +1454,18 @@ mod tests {
                 .with_config("client.retry_max_duration", "10ms")
                 .unwrap();
             let ctx = XetContext::with_config(config).expect("XetContext::with_config");
-            let client =
-                RemoteClient::new(ctx, server.http_endpoint(), &None, "test-session-error-frame", false, None);
+            let client = RemoteClient::new(ctx, server.http_endpoint(), &None, "test-session-error-frame", false, None);
             let permit = client.acquire_upload_permit().await.unwrap();
             let err = client
                 .upload_shard_v2(fixed_test_shard_bytes(), permit, Some(callback))
                 .await
                 .expect_err("retryable Error frame should exhaust retries and fail");
-            assert!(
-                err.to_string().contains("simulated retryable shard upload failure"),
-                "unexpected error: {err}"
-            );
+            assert!(err.to_string().contains("simulated retryable shard upload failure"), "unexpected error: {err}");
         }
         let seen = seen.lock().unwrap().clone();
         let retryable_errors = seen
             .iter()
-            .filter(|e| {
-                matches!(
-                    e,
-                    ShardUploadEvent::Error {
-                        retryable: true,
-                        ..
-                    }
-                )
-            })
+            .filter(|e| matches!(e, ShardUploadEvent::Error { retryable: true, .. }))
             .count();
         assert!(
             retryable_errors >= 2,

--- a/xet_client/src/cas_client/simulation/simulation_server.rs
+++ b/xet_client/src/cas_client/simulation/simulation_server.rs
@@ -1360,10 +1360,16 @@ mod tests {
         assert!(v2_err.is_err(), "forced V2 should fail when disabled with 404");
         assert_eq!(v2_err.unwrap_err().status(), Some(reqwest::StatusCode::NOT_FOUND));
 
+        // Exercise the 404 branch of the *auto-detect* path on a fresh client. `server.remote_simulation_client()`
+        // already cached a V1 preference from the auto-detect fallback at 501 above (forced `Some(..)` calls never
+        // write that cache, only a real auto-detect fallback does), so reusing it here would just replay the cached
+        // V1 path and never actually touch V2 or hit the 404.
         {
-            let permit = server.remote_client().acquire_upload_permit().await.unwrap();
-            server
-                .remote_simulation_client()
+            let ctx = XetContext::default().expect("XetContext::new");
+            let fresh_client =
+                RemoteClient::new(ctx, server.http_endpoint(), &None, "test-session-404-fallback", false, None);
+            let permit = fresh_client.acquire_upload_permit().await.unwrap();
+            fresh_client
                 .upload_shard_with_version_override(random_shard_bytes(), permit, None, None)
                 .await
                 .unwrap();

--- a/xet_client/src/cas_client/simulation/simulation_server.rs
+++ b/xet_client/src/cas_client/simulation/simulation_server.rs
@@ -1101,6 +1101,15 @@ mod tests {
         assert_eq!(post_set_config(server, "disable_v2_endpoints", "0").await, reqwest::StatusCode::OK);
         assert_eq!(post_set_config(server, "disable_v2_endpoints", "xyz").await, reqwest::StatusCode::BAD_REQUEST);
 
+        // --- shard_upload_error_frame ---
+        assert_eq!(post_set_config(server, "shard_upload_error_frame", "fatal").await, reqwest::StatusCode::OK);
+        assert_eq!(post_set_config(server, "shard_upload_error_frame", "retryable").await, reqwest::StatusCode::OK);
+        assert_eq!(post_set_config(server, "shard_upload_error_frame", "off").await, reqwest::StatusCode::OK);
+        assert_eq!(
+            post_set_config(server, "shard_upload_error_frame", "bogus").await,
+            reqwest::StatusCode::BAD_REQUEST
+        );
+
         // --- api_delay ---
         assert_eq!(post_set_config(server, "api_delay", "(50ms, 50ms)").await, reqwest::StatusCode::OK);
         // Verify effect: a Client-trait API call should take at least 40ms
@@ -1204,10 +1213,15 @@ mod tests {
         check_simulation_dummy_upload(server).await;
         check_v2_shard_upload(server).await;
         check_v2_shard_upload_disabled_fallback(server).await;
+        check_v2_shard_upload_error_frame(server).await;
     }
 
-    /// Builds raw shard bytes suitable for `/v1/shards` and `/v2/shards` upload tests.
-    fn random_shard_bytes() -> bytes::Bytes {
+    /// Builds fixed raw shard bytes suitable for `/v1/shards` and `/v2/shards` upload tests.
+    ///
+    /// Uses a fixed seed so every call returns byte-identical output (duplicate-shard
+    /// re-registration, not a new sync). The shard references xorbs that are never uploaded;
+    /// that is fine while these checks do not call `verify_integrity()`.
+    fn fixed_test_shard_bytes() -> bytes::Bytes {
         use xet_core_structures::metadata_shard::shard_format::test_routines::gen_random_shard_with_xorb_references;
 
         let tmp_dir = tempfile::TempDir::new().unwrap();
@@ -1225,7 +1239,7 @@ mod tests {
         use crate::cas_client::interface::{ShardUploadProgressCallback, ShardUploadProgressType};
         use crate::cas_types::{CommitStage, ShardUploadEvent};
 
-        let shard_data = random_shard_bytes();
+        let shard_data = fixed_test_shard_bytes();
 
         // Raw HTTP: response is NDJSON ending in a terminal `result` frame.
         let http_client = reqwest::Client::new();
@@ -1273,7 +1287,7 @@ mod tests {
             }
         });
 
-        let shard_data = random_shard_bytes();
+        let shard_data = fixed_test_shard_bytes();
         let permit = server.remote_client().acquire_upload_permit().await.unwrap();
         server
             .remote_simulation_client()
@@ -1287,7 +1301,7 @@ mod tests {
 
     /// Verifies `/v2/shards` disable + RemoteClient V2→V1 fallback (same status codes as reconstruction).
     async fn check_v2_shard_upload_disabled_fallback(server: &LocalTestServer) {
-        let shard_data = random_shard_bytes();
+        let shard_data = fixed_test_shard_bytes();
 
         // Fresh success on V2 before disabling.
         {
@@ -1331,7 +1345,7 @@ mod tests {
             let permit = server.remote_client().acquire_upload_permit().await.unwrap();
             server
                 .remote_simulation_client()
-                .upload_shard_with_version_override(random_shard_bytes(), permit, Some(2), None)
+                .upload_shard_with_version_override(fixed_test_shard_bytes(), permit, Some(2), None)
                 .await
                 .unwrap();
         }
@@ -1341,7 +1355,7 @@ mod tests {
             let permit = server.remote_client().acquire_upload_permit().await.unwrap();
             server
                 .remote_simulation_client()
-                .upload_shard_v2(random_shard_bytes(), permit, None)
+                .upload_shard_v2(fixed_test_shard_bytes(), permit, None)
                 .await
         };
         assert!(v2_err.is_err(), "forced V2 should fail when disabled with 404");
@@ -1357,13 +1371,125 @@ mod tests {
                 RemoteClient::new(ctx, server.http_endpoint(), &None, "test-session-404-fallback", false, None);
             let permit = fresh_client.acquire_upload_permit().await.unwrap();
             fresh_client
-                .upload_shard_with_version_override(random_shard_bytes(), permit, None, None)
+                .upload_shard_with_version_override(fixed_test_shard_bytes(), permit, None, None)
                 .await
                 .unwrap();
         }
 
         // Leave V2 enabled for subsequent checks on the same server instance.
         server.client().disable_v2_endpoints(0);
+    }
+
+    /// Verifies in-stream `/v2/shards` `Error` frames (production 200 + terminal error contract),
+    /// including that `retryable: true` is folded into `RetryWrapper` (multiple attempts, then fail).
+    async fn check_v2_shard_upload_error_frame(server: &LocalTestServer) {
+        use std::sync::{Arc, Mutex};
+
+        use crate::cas_client::interface::{ShardUploadProgressCallback, ShardUploadProgressType};
+        use crate::cas_types::ShardUploadEvent;
+
+        // Raw HTTP: fatal Error frame arrives on a 200 NDJSON stream.
+        assert_eq!(post_set_config(server, "shard_upload_error_frame", "fatal").await, reqwest::StatusCode::OK);
+        {
+            let response = reqwest::Client::new()
+                .post(format!("{}/v2/shards", server.http_endpoint()))
+                .body(fixed_test_shard_bytes())
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(response.status(), reqwest::StatusCode::OK);
+            assert_eq!(
+                response.headers().get(reqwest::header::CONTENT_TYPE).and_then(|v| v.to_str().ok()),
+                Some("application/x-ndjson")
+            );
+            let body = response.text().await.unwrap();
+            let events: Vec<ShardUploadEvent> = body
+                .lines()
+                .filter(|line| !line.is_empty())
+                .map(|line| serde_json::from_str(line).expect("valid ShardUploadEvent NDJSON line"))
+                .collect();
+            assert_eq!(
+                events,
+                vec![
+                    ShardUploadEvent::Validating { verified: 0, total: 1 },
+                    ShardUploadEvent::Error {
+                        message: "simulated fatal shard upload failure".to_string(),
+                        retryable: false,
+                    },
+                ]
+            );
+        }
+
+        // RemoteClient: fatal Error is a hard failure (no retry success).
+        assert_eq!(post_set_config(server, "shard_upload_error_frame", "fatal").await, reqwest::StatusCode::OK);
+        {
+            let permit = server.remote_client().acquire_upload_permit().await.unwrap();
+            let err = server
+                .remote_simulation_client()
+                .upload_shard_v2(fixed_test_shard_bytes(), permit, None)
+                .await
+                .expect_err("fatal Error frame should fail the upload");
+            assert!(
+                err.to_string().contains("simulated fatal shard upload failure"),
+                "unexpected error: {err}"
+            );
+        }
+
+        // RemoteClient: retryable Error stays enabled — RetryWrapper retries until exhausted, then fails.
+        // Use a short retry budget so this stays fast; multiple Error frames prove retries ran.
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let seen_cb = seen.clone();
+        let callback: ShardUploadProgressCallback = Arc::new(move |progress| {
+            if let ShardUploadProgressType::Response(event) = progress {
+                seen_cb.lock().unwrap().push(event.clone());
+            }
+        });
+        assert_eq!(post_set_config(server, "shard_upload_error_frame", "retryable").await, reqwest::StatusCode::OK);
+        {
+            let config = xet_runtime::config::XetConfig::default()
+                .with_config("client.retry_max_attempts", 2)
+                .unwrap()
+                .with_config("client.retry_base_delay", "1ms")
+                .unwrap()
+                .with_config("client.retry_max_duration", "10ms")
+                .unwrap();
+            let ctx = XetContext::with_config(config).expect("XetContext::with_config");
+            let client =
+                RemoteClient::new(ctx, server.http_endpoint(), &None, "test-session-error-frame", false, None);
+            let permit = client.acquire_upload_permit().await.unwrap();
+            let err = client
+                .upload_shard_v2(fixed_test_shard_bytes(), permit, Some(callback))
+                .await
+                .expect_err("retryable Error frame should exhaust retries and fail");
+            assert!(
+                err.to_string().contains("simulated retryable shard upload failure"),
+                "unexpected error: {err}"
+            );
+        }
+        let seen = seen.lock().unwrap().clone();
+        let retryable_errors = seen
+            .iter()
+            .filter(|e| {
+                matches!(
+                    e,
+                    ShardUploadEvent::Error {
+                        retryable: true,
+                        ..
+                    }
+                )
+            })
+            .count();
+        assert!(
+            retryable_errors >= 2,
+            "callback should observe Error frames across retries, got {retryable_errors} in {seen:?}"
+        );
+        assert!(
+            !seen.iter().any(|e| matches!(e, ShardUploadEvent::Result)),
+            "should not see a Result frame while error frame mode is enabled, got {seen:?}"
+        );
+
+        // Clear so later checks on this server are unaffected.
+        assert_eq!(post_set_config(server, "shard_upload_error_frame", "off").await, reqwest::StatusCode::OK);
     }
 
     /// Main test that runs all server checks with both in-memory and disk-backed storage.

--- a/xet_data/src/file_reconstruction/file_reconstructor.rs
+++ b/xet_data/src/file_reconstruction/file_reconstructor.rs
@@ -1756,7 +1756,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            server.disable_v2_reconstruction(404);
+            server.disable_v2_endpoints(404);
 
             let config = test_config();
             let result = reconstruct_via_server(&server, file_contents.file_hash, None, &config)
@@ -1774,7 +1774,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            server.disable_v2_reconstruction(404);
+            server.disable_v2_endpoints(404);
 
             let file_len = file_contents.data.len() as u64;
             let range = FileRange::new(file_len / 4, file_len * 3 / 4);
@@ -1795,7 +1795,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            server.disable_v2_reconstruction(404);
+            server.disable_v2_endpoints(404);
 
             let config = test_config();
             let result = reconstruct_via_server(&server, file_contents.file_hash, None, &config)
@@ -1813,7 +1813,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            server.disable_v2_reconstruction(404);
+            server.disable_v2_endpoints(404);
 
             let config = test_config();
             let result = reconstruct_via_server(&server, file_contents.file_hash, None, &config)
@@ -1832,7 +1832,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            server.disable_v2_reconstruction(404);
+            server.disable_v2_endpoints(404);
 
             let config = test_config();
             let result = reconstruct_via_server(&server, file_contents.file_hash, None, &config)

--- a/xet_data/src/processing/test_utils.rs
+++ b/xet_data/src/processing/test_utils.rs
@@ -251,7 +251,7 @@ impl HydrateDehydrateTest {
             #[cfg(feature = "simulation")]
             HydrationMode::ServerV1Fallback => {
                 self.ensure_server_created().await;
-                self.test_server.as_ref().unwrap().client().disable_v2_reconstruction(404);
+                self.test_server.as_ref().unwrap().client().disable_v2_endpoints(404);
             },
             #[cfg(feature = "simulation")]
             HydrationMode::ServerMaxRanges2 => {


### PR DESCRIPTION
## Summary

Adds local simulation coverage for the `POST /v2/shards` NDJSON streaming endpoint, following our established pattern of exercising new CAS-facing APIs against the in-process `LocalServer`/`LocalTestServer` harness rather than only unit-testing client-side parsing logic.

- `local_server/handlers.rs`: new `post_shard_v2` handler — validates the shard via the same `DirectAccessClient::upload_shard`, then emits a production-shaped NDJSON event stream (`Validating` → `Committing` → `Result`). V2→V1 fallback is forced via `/simulation/set_config?config=disable_v2_endpoints` (renamed from `disable_v2_reconstruction`; one status code now disables both V2 reconstruction and V2 shard upload).
- `local_server/server.rs` / `main.rs`: routes `/v2/shards` and updates route docs. Registering this route flips the default shard-upload path for existing simulation tests to V2-first (auto-detect); V1's JSON path is still covered by the explicit fallback checks.
- Renames `disable_v2_reconstruction` → `disable_v2_endpoints` across the `DirectAccessClient` trait, local/memory clients, simulation config, and downstream call sites.
- `simulation_server.rs`: two new checks —
  - `check_v2_shard_upload`: verifies the exact NDJSON stream (Content-Type, frame order, counters, stages) both over raw HTTP and through `RemoteClient`'s progress callback.
  - `check_v2_shard_upload_disabled_fallback`: verifies V2→V1 fallback at both 501 and 404, including a fresh `RemoteClient` for the 404 case so the auto-detect path is actually exercised rather than replaying a cached V1 preference from the earlier 501 check.

## Test plan

- [x] `cargo test --package xet-client --lib --features simulation test_local_server` (both in-memory and disk-backed storage variants)
- [x] `cargo clippy --package xet-client --features simulation --tests -- -D warnings` (no new warnings vs. base)
- [x] Verified the 404-fallback assertion actually catches a regression: temporarily broke the `NOT_FOUND` arm in `RemoteClient::upload_shard_with_version_override` and confirmed the test fails with the real 404 surfacing, then reverted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the simulation/local-server test harness and a transitive lockfile bump; production client paths are only touched via renamed test helpers.
> 
> **Overview**
> Adds **local CAS simulation** for production-style **`POST /v2/shards`** uploads: NDJSON progress (`Validating` → `Committing` → `Result`) and **HTTP 200 + terminal `Error` frames** (fatal vs retryable), configurable via **`shard_upload_error_frame`** on `/simulation/set_config`.
> 
> Renames **`disable_v2_reconstruction` → `disable_v2_endpoints`** so one simulated status disables **both** V2 reconstruction and V2 shard upload for V2→V1 fallback tests.
> 
> **`simulation_server`** gains integration checks for the NDJSON stream (raw HTTP + `RemoteClient` callbacks), disabled-endpoint fallback (501/404, including a fresh client for 404 auto-detect), and in-stream error/retry behavior. **`Cargo.lock`** bumps `event-listener` 5.4.1 → 5.4.2.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f9ddab797bfdd7a444d472ad17bf61b70d4d265. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->