### PR TITLE
Embed input in the DataHash parse Error

### DIFF
--- a/wasm/hf_xet_thin_wasm/src/lib.rs
+++ b/wasm/hf_xet_thin_wasm/src/lib.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
-use xet_core_structures::merklehash::{DataHashHexParseError, MerkleHash, MerkleHashSubtree, xorb_hash};
+use xet_core_structures::merklehash::{DataHashError, MerkleHash, MerkleHashSubtree, xorb_hash};
 
 // un-comment following 2 sections for console_log!() printing support
 // macro_rules! console_log {
@@ -85,7 +85,7 @@ fn parse_chunks_in(chunks_array: JsValue) -> Result<Vec<(MerkleHash, u64)>, JsVa
     js_chunks
         .into_iter()
         .map(|jsc| Ok((MerkleHash::from_hex(&jsc.hash)?, jsc.length as u64)))
-        .collect::<Result<_, DataHashHexParseError>>()
+        .collect::<Result<_, DataHashError>>()
         .map_err(|e| JsValue::from(e.to_string()))
 }
 
@@ -113,7 +113,7 @@ pub fn compute_verification_hash(chunk_hashes: Vec<String>) -> Result<String, Js
     let chunk_hashes: Vec<MerkleHash> = chunk_hashes
         .into_iter()
         .map(|hash| MerkleHash::from_hex(&hash))
-        .collect::<Result<_, DataHashHexParseError>>()
+        .collect::<Result<_, DataHashError>>()
         .map_err(|e| JsValue::from(e.to_string()))?;
     Ok(xet_core_structures::metadata_shard::chunk_verification::range_hash_from_chunks(&chunk_hashes).hex())
 }

--- a/xet_client/src/chunk_cache/error.rs
+++ b/xet_client/src/chunk_cache/error.rs
@@ -4,7 +4,7 @@ use std::str::Utf8Error;
 use base64::DecodeError;
 use thiserror::Error;
 use tokio::task::JoinError;
-use xet_core_structures::merklehash::DataHashBytesParseError;
+use xet_core_structures::merklehash::DataHashError;
 
 #[derive(Debug, Error)]
 pub enum ChunkCacheError {
@@ -57,5 +57,5 @@ macro_rules! impl_parse_error_from_error {
 
 impl_parse_error_from_error!(TryFromSliceError);
 impl_parse_error_from_error!(DecodeError);
-impl_parse_error_from_error!(DataHashBytesParseError);
+impl_parse_error_from_error!(DataHashError);
 impl_parse_error_from_error!(Utf8Error);

--- a/xet_core_structures/src/error.rs
+++ b/xet_core_structures/src/error.rs
@@ -1,9 +1,7 @@
-use std::convert::Infallible;
-
 use thiserror::Error;
 use tracing::warn;
 
-use crate::merklehash::MerkleHash;
+use crate::merklehash::{DataHashError, MerkleHash};
 
 #[non_exhaustive]
 #[derive(Error, Debug)]
@@ -60,7 +58,7 @@ pub enum CoreError {
     CompressionError(#[from] lz4_flex::frame::Error),
 
     #[error("Hash parsing error: {0}")]
-    HashParsing(#[from] Infallible),
+    HashParsing(#[from] DataHashError),
 
     #[error("Chunk header parse error")]
     ChunkHeaderParse,
@@ -109,17 +107,5 @@ impl<T> Validate<T> for Result<T> {
             },
             Err(e) => Err(e),
         }
-    }
-}
-
-impl From<crate::merklehash::DataHashHexParseError> for CoreError {
-    fn from(_: crate::merklehash::DataHashHexParseError) -> Self {
-        CoreError::Other("Invalid hex input for DataHash".to_string())
-    }
-}
-
-impl From<crate::merklehash::DataHashBytesParseError> for CoreError {
-    fn from(_: crate::merklehash::DataHashBytesParseError) -> Self {
-        CoreError::Other("Invalid bytes input for DataHash".to_string())
     }
 }

--- a/xet_core_structures/src/merklehash/data_hash.rs
+++ b/xet_core_structures/src/merklehash/data_hash.rs
@@ -1,9 +1,7 @@
 use std::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
-use std::error::Error;
 use std::hash::{Hash, Hasher};
 use std::io::Write;
 use std::mem::transmute_copy;
-use std::num::ParseIntError;
 use std::ops::{Deref, DerefMut};
 use std::{fmt, str};
 
@@ -16,6 +14,8 @@ use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 use safe_transmute::{transmute_to_bytes, transmute_to_bytes_mut};
 use serde::{Deserialize, Serialize};
+
+use super::error::DataHashError;
 
 /************************************************************************* */
 /*  */
@@ -135,24 +135,6 @@ unsafe impl Zeroable for DataHash {
 #[cfg(not(target_family = "wasm"))]
 unsafe impl Pod for DataHash {}
 
-/// The error type that is returned if [DataHash::from_hex] fails.
-#[derive(Debug, Clone)]
-pub struct DataHashHexParseError;
-
-impl Error for DataHashHexParseError {}
-
-impl fmt::Display for DataHashHexParseError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Invalid hex input for DataHash")
-    }
-}
-
-impl From<ParseIntError> for DataHashHexParseError {
-    fn from(_err: ParseIntError) -> Self {
-        DataHashHexParseError {}
-    }
-}
-
 impl DataHash {
     /// Returns the hexadecimal printout of the hash.
     /// Different programming languages and platforms may have different byte order layout
@@ -177,27 +159,30 @@ impl DataHash {
     }
 
     /// Parses a hexadecimal string as a DataHash, returning
-    /// Err(DataHashHexParseError) on failure.
-    pub fn from_hex(h: &str) -> Result<DataHash, DataHashHexParseError> {
+    /// Err(DataHashError) on failure.
+    pub fn from_hex(h: &str) -> Result<DataHash, DataHashError> {
+        let parse_err = || DataHashError::InvalidHex { input: h.to_owned() };
         if h.len() != 64 {
-            return Err(DataHashHexParseError {});
+            return Err(parse_err());
         }
         let mut ret: DataHash = Default::default();
 
         let good = h.as_bytes().iter().all(|c| c.is_ascii_hexdigit());
         if !good {
-            return Err(DataHashHexParseError {});
+            return Err(parse_err());
         }
-        ret.0[0] = u64::from_str_radix(&h[..16], 16)?.to_le();
-        ret.0[1] = u64::from_str_radix(&h[16..32], 16)?.to_le();
-        ret.0[2] = u64::from_str_radix(&h[32..48], 16)?.to_le();
-        ret.0[3] = u64::from_str_radix(&h[48..64], 16)?.to_le();
+        ret.0[0] = u64::from_str_radix(&h[..16], 16).map_err(|_| parse_err())?.to_le();
+        ret.0[1] = u64::from_str_radix(&h[16..32], 16).map_err(|_| parse_err())?.to_le();
+        ret.0[2] = u64::from_str_radix(&h[32..48], 16).map_err(|_| parse_err())?.to_le();
+        ret.0[3] = u64::from_str_radix(&h[48..64], 16).map_err(|_| parse_err())?.to_le();
         Ok(ret)
     }
 
     // Converts the hash from base64 (created by base64 above) to this.  Used for testing.
-    pub fn from_base64(b64: &str) -> Result<DataHash, DataHashBytesParseError> {
-        let bytes = URL_SAFE_NO_PAD.decode(b64.as_bytes()).map_err(|_| DataHashBytesParseError {})?;
+    pub fn from_base64(b64: &str) -> Result<DataHash, DataHashError> {
+        let bytes = URL_SAFE_NO_PAD
+            .decode(b64.as_bytes())
+            .map_err(|_| DataHashError::InvalidBytes { input: b64.to_owned() })?;
         DataHash::from_slice(&bytes)
     }
 
@@ -206,9 +191,11 @@ impl DataHash {
         transmute_to_bytes(&self.0[..])
     }
 
-    pub fn from_slice(value: &[u8]) -> Result<Self, DataHashBytesParseError> {
+    pub fn from_slice(value: &[u8]) -> Result<Self, DataHashError> {
         if value.len() != 32 {
-            return Err(DataHashBytesParseError);
+            return Err(DataHashError::InvalidBytes {
+                input: DataHashError::format_bytes(value),
+            });
         }
         let mut hash: DataHash = DataHash::default();
         unsafe {
@@ -255,20 +242,8 @@ impl DataHash {
     }
 }
 
-/// The error type that is returned if TryFrom<&[u8]> fails.
-#[derive(Debug, Clone)]
-pub struct DataHashBytesParseError;
-
-impl Error for DataHashBytesParseError {}
-
-impl fmt::Display for DataHashBytesParseError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Invalid bytes input for DataHash")
-    }
-}
-
 impl TryFrom<&[u8]> for DataHash {
-    type Error = DataHashBytesParseError;
+    type Error = DataHashError;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         Self::from_slice(value)
@@ -585,5 +560,17 @@ mod tests {
 
         assert_eq!(expected_hex_string, data_hash.hex().as_str());
         assert_eq!(DataHash::from_hex(expected_hex_string).unwrap(), data_hash);
+    }
+
+    #[test]
+    fn test_from_hex_parse_error_includes_input() {
+        let empty = DataHash::from_hex("").unwrap_err();
+        assert_eq!(empty.hex_input(), "");
+
+        let short = DataHash::from_hex("abcdef").unwrap_err();
+        assert_eq!(short.hex_input(), "abcdef");
+
+        let bad_chars = DataHash::from_hex(&"g".repeat(64)).unwrap_err();
+        assert_eq!(bad_chars.hex_input(), "g".repeat(64));
     }
 }

--- a/xet_core_structures/src/merklehash/data_hash.rs
+++ b/xet_core_structures/src/merklehash/data_hash.rs
@@ -161,7 +161,7 @@ impl DataHash {
     /// Parses a hexadecimal string as a DataHash, returning
     /// Err(DataHashError) on failure.
     pub fn from_hex(h: &str) -> Result<DataHash, DataHashError> {
-        let parse_err = || DataHashError::InvalidHex { input: h.to_owned() };
+        let parse_err = || DataHashError::invalid_hex(h);
         if h.len() != 64 {
             return Err(parse_err());
         }
@@ -182,7 +182,7 @@ impl DataHash {
     pub fn from_base64(b64: &str) -> Result<DataHash, DataHashError> {
         let bytes = URL_SAFE_NO_PAD
             .decode(b64.as_bytes())
-            .map_err(|_| DataHashError::InvalidBytes { input: b64.to_owned() })?;
+            .map_err(|_| DataHashError::invalid_bytes_str(b64))?;
         DataHash::from_slice(&bytes)
     }
 
@@ -193,9 +193,7 @@ impl DataHash {
 
     pub fn from_slice(value: &[u8]) -> Result<Self, DataHashError> {
         if value.len() != 32 {
-            return Err(DataHashError::InvalidBytes {
-                input: DataHashError::format_bytes(value),
-            });
+            return Err(DataHashError::invalid_bytes_slice(value));
         }
         let mut hash: DataHash = DataHash::default();
         unsafe {
@@ -565,12 +563,40 @@ mod tests {
     #[test]
     fn test_from_hex_parse_error_includes_input() {
         let empty = DataHash::from_hex("").unwrap_err();
-        assert_eq!(empty.hex_input(), "");
+        assert_eq!(empty.input(), "");
+        assert!(empty.to_string().contains("got ''"), "{}", empty);
 
         let short = DataHash::from_hex("abcdef").unwrap_err();
-        assert_eq!(short.hex_input(), "abcdef");
+        assert_eq!(short.input(), "abcdef");
+        assert!(short.to_string().contains("got 'abcdef'"), "{}", short);
 
         let bad_chars = DataHash::from_hex(&"g".repeat(64)).unwrap_err();
-        assert_eq!(bad_chars.hex_input(), "g".repeat(64));
+        assert_eq!(bad_chars.input(), "g".repeat(64));
+        assert!(bad_chars.to_string().contains(&format!("got '{}'", "g".repeat(64))), "{}", bad_chars);
+    }
+
+    #[test]
+    fn test_from_slice_parse_error_includes_input() {
+        let err = DataHash::from_slice(&[1u8; 31]).unwrap_err();
+        let expected_hex = "01".repeat(31);
+        assert_eq!(err.input(), expected_hex);
+        assert!(err.to_string().contains(&format!("got '{expected_hex}'")), "{}", err);
+    }
+
+    #[test]
+    fn test_from_base64_parse_error_includes_input() {
+        let bad = "!!!not-base64!!!";
+        let err = DataHash::from_base64(bad).unwrap_err();
+        assert_eq!(err.input(), bad);
+        assert!(err.to_string().contains(&format!("got '{bad}'")), "{}", err);
+    }
+
+    #[test]
+    fn test_parse_error_truncates_long_input() {
+        let long = "a".repeat(200);
+        let err = DataHash::from_hex(&long).unwrap_err();
+        assert_eq!(err.input(), format!("{}...", "a".repeat(72)));
+        assert!(err.to_string().contains("..."), "{}", err);
+        assert!(!err.to_string().contains(&"a".repeat(200)), "{}", err);
     }
 }

--- a/xet_core_structures/src/merklehash/error.rs
+++ b/xet_core_structures/src/merklehash/error.rs
@@ -1,0 +1,35 @@
+use thiserror::Error;
+
+/// Errors that can occur when parsing a [`super::DataHash`].
+#[non_exhaustive]
+#[derive(Error, Debug, Clone)]
+pub enum DataHashError {
+    /// Returned when [`super::DataHash::from_hex`] fails.
+    #[error("Invalid hex input for DataHash (got '{input}')")]
+    InvalidHex {
+        /// The input string that failed to parse.
+        input: String,
+    },
+
+    /// Returned when converting bytes (or base64) to a [`super::DataHash`] fails.
+    #[error("Invalid bytes input for DataHash (got '{input}')")]
+    InvalidBytes {
+        /// Human-readable form of the bad input (hex for raw bytes, or the original string).
+        input: String,
+    },
+}
+
+impl DataHashError {
+    /// The bad hex input when this is [`Self::InvalidHex`], otherwise `""`.
+    pub fn hex_input(&self) -> &str {
+        match self {
+            Self::InvalidHex { input } => input,
+            Self::InvalidBytes { .. } => "",
+        }
+    }
+
+    /// Formats raw bytes as a lowercase hex string for error messages.
+    pub(crate) fn format_bytes(bytes: &[u8]) -> String {
+        bytes.iter().map(|b| format!("{b:02x}")).collect()
+    }
+}

--- a/xet_core_structures/src/merklehash/error.rs
+++ b/xet_core_structures/src/merklehash/error.rs
@@ -20,11 +20,11 @@ pub enum DataHashError {
 }
 
 impl DataHashError {
-    /// The bad hex input when this is [`Self::InvalidHex`], otherwise `""`.
+    /// Returns the bad input string for either variant.
     pub fn hex_input(&self) -> &str {
         match self {
             Self::InvalidHex { input } => input,
-            Self::InvalidBytes { .. } => "",
+            Self::InvalidBytes { input } => input,
         }
     }
 

--- a/xet_core_structures/src/merklehash/error.rs
+++ b/xet_core_structures/src/merklehash/error.rs
@@ -1,5 +1,8 @@
 use thiserror::Error;
 
+/// Max chars of bad input embedded in error messages (logs / Python exceptions).
+const MAX_EMBEDDED_INPUT_CHARS: usize = 72;
+
 /// Errors that can occur when parsing a [`super::DataHash`].
 #[non_exhaustive]
 #[derive(Error, Debug, Clone)]
@@ -7,29 +10,59 @@ pub enum DataHashError {
     /// Returned when [`super::DataHash::from_hex`] fails.
     #[error("Invalid hex input for DataHash (got '{input}')")]
     InvalidHex {
-        /// The input string that failed to parse.
+        /// The input string that failed to parse (possibly truncated).
         input: String,
     },
 
     /// Returned when converting bytes (or base64) to a [`super::DataHash`] fails.
     #[error("Invalid bytes input for DataHash (got '{input}')")]
     InvalidBytes {
-        /// Human-readable form of the bad input (hex for raw bytes, or the original string).
+        /// Human-readable form of the bad input (hex for raw bytes, or the original
+        /// string; possibly truncated).
         input: String,
     },
 }
 
 impl DataHashError {
-    /// Returns the bad input string for either variant.
-    pub fn hex_input(&self) -> &str {
+    /// Returns the bad input string for either variant (possibly truncated).
+    pub fn input(&self) -> &str {
         match self {
             Self::InvalidHex { input } => input,
             Self::InvalidBytes { input } => input,
         }
     }
 
+    pub(crate) fn invalid_hex(input: &str) -> Self {
+        Self::InvalidHex {
+            input: Self::truncate_for_display(input),
+        }
+    }
+
+    pub(crate) fn invalid_bytes_str(input: &str) -> Self {
+        Self::InvalidBytes {
+            input: Self::truncate_for_display(input),
+        }
+    }
+
+    pub(crate) fn invalid_bytes_slice(bytes: &[u8]) -> Self {
+        Self::InvalidBytes {
+            input: Self::truncate_for_display(&Self::format_bytes(bytes)),
+        }
+    }
+
+    /// Truncate oversized inputs before embedding them in error messages.
+    fn truncate_for_display(input: &str) -> String {
+        // Inputs are ASCII (hex / base64); truncate by byte length.
+        if input.len() <= MAX_EMBEDDED_INPUT_CHARS {
+            return input.to_owned();
+        }
+        let mut truncated = input[..MAX_EMBEDDED_INPUT_CHARS].to_owned();
+        truncated.push_str("...");
+        truncated
+    }
+
     /// Formats raw bytes as a lowercase hex string for error messages.
-    pub(crate) fn format_bytes(bytes: &[u8]) -> String {
+    fn format_bytes(bytes: &[u8]) -> String {
         bytes.iter().map(|b| format!("{b:02x}")).collect()
     }
 }

--- a/xet_core_structures/src/merklehash/error.rs
+++ b/xet_core_structures/src/merklehash/error.rs
@@ -52,11 +52,12 @@ impl DataHashError {
 
     /// Truncate oversized inputs before embedding them in error messages.
     fn truncate_for_display(input: &str) -> String {
-        // Inputs are ASCII (hex / base64); truncate by byte length.
         if input.len() <= MAX_EMBEDDED_INPUT_CHARS {
             return input.to_owned();
         }
-        let mut truncated = input[..MAX_EMBEDDED_INPUT_CHARS].to_owned();
+        // Snap back to a char boundary so multi-byte UTF-8 inputs cannot panic.
+        let end = input.floor_char_boundary(MAX_EMBEDDED_INPUT_CHARS);
+        let mut truncated = input[..end].to_owned();
         truncated.push_str("...");
         truncated
     }

--- a/xet_core_structures/src/merklehash/mod.rs
+++ b/xet_core_structures/src/merklehash/mod.rs
@@ -45,7 +45,9 @@
 #![cfg_attr(feature = "strict", deny(warnings))]
 
 pub mod data_hash;
+pub mod error;
 pub use data_hash::*;
+pub use error::*;
 pub type MerkleHash = DataHash;
 
 /// List of (chunk_hash, chunk_uncompressed_size) pairs for a file or xorb range.

--- a/xet_data/src/error.rs
+++ b/xet_data/src/error.rs
@@ -7,7 +7,7 @@ use tracing::error;
 use xet_client::ClientError;
 use xet_client::cas_client::auth::AuthError;
 use xet_core_structures::CoreError;
-use xet_core_structures::merklehash::DataHashHexParseError;
+use xet_core_structures::merklehash::DataHashError;
 use xet_runtime::RuntimeError;
 use xet_runtime::core::par_utils::ParutilsError;
 use xet_runtime::utils::errors::SingleflightError;
@@ -68,8 +68,8 @@ pub enum DataError {
     #[error("Parameter error: {0}")]
     ParameterError(String),
 
-    #[error("Unable to parse string as hex hash value")]
-    HashStringParsingFailure(#[from] DataHashHexParseError),
+    #[error("Unable to parse string as hex hash value (got '{}')", .0.hex_input())]
+    HashStringParsingFailure(#[from] DataHashError),
 
     #[error("Deprecated feature: {0}")]
     DeprecatedError(String),

--- a/xet_data/src/error.rs
+++ b/xet_data/src/error.rs
@@ -68,7 +68,7 @@ pub enum DataError {
     #[error("Parameter error: {0}")]
     ParameterError(String),
 
-    #[error("Unable to parse string as hex hash value (got '{}')", .0.hex_input())]
+    #[error("Unable to parse string as hex hash value (got '{}')", .0.input())]
     HashStringParsingFailure(#[from] DataHashError),
 
     #[error("Deprecated feature: {0}")]

--- a/xet_data/src/processing/xet_file.rs
+++ b/xet_data/src/processing/xet_file.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use xet_core_structures::merklehash::{DataHashHexParseError, MerkleHash};
+use xet_core_structures::merklehash::{DataHashError, MerkleHash};
 use xet_runtime::error_printer::ErrorPrinter;
 
 /// A struct that wraps a the Xet file information.
@@ -72,7 +72,7 @@ impl XetFileInfo {
     }
 
     /// Returns the parsed merkle hash of the file.
-    pub fn merkle_hash(&self) -> std::result::Result<MerkleHash, DataHashHexParseError> {
+    pub fn merkle_hash(&self) -> std::result::Result<MerkleHash, DataHashError> {
         MerkleHash::from_hex(&self.hash).log_error("Error parsing hash value for file info")
     }
 

--- a/xet_pkg/src/error.rs
+++ b/xet_pkg/src/error.rs
@@ -108,6 +108,7 @@ impl XetError {
             | CoreError::InvalidShard(_)
             | CoreError::ShardVersion(_)
             | CoreError::ChunkHeaderParse
+            | CoreError::HashParsing(_)
             | CoreError::MalformedData(_)
             | CoreError::CompressionError(_) => XetError::DataIntegrity(fe.to_string()),
             CoreError::InvalidRange | CoreError::InvalidArguments | CoreError::BadFilename(_) => {


### PR DESCRIPTION
## Summary
- Include the failing input in DataHash parse errors so download failures like [#895](https://github.com/huggingface/xet-core/issues/895) surface `Unable to parse string as hex hash value (got '...')` instead of an opaque message, helps debugging.
- Extract hex/bytes parse errors into `merklehash/error.rs` as a `thiserror` `DataHashError` enum (`InvalidHex` / `InvalidBytes`), both carrying the bad input for display. This has been our code style.
- Wire `CoreError::HashParsing` to `DataHashError` (replacing the unused `Infallible` stub) and map it to `XetError::DataIntegrity`.

## Test plan
- [x] Unit test that `from_hex` errors retain the bad input
- [x] Reproduce / confirm improved error text on a bad `XetFileInfo.hash` download path


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized error-type refactor with clearer diagnostics; parsing behavior unchanged aside from richer messages and explicit `HashParsing` → data-integrity classification.
> 
> **Overview**
> **DataHash parse failures now include the offending input** in error text (truncated at 72 characters), so paths like download/`XetFileInfo` hash parsing surface messages such as `Unable to parse string as hex hash value (got '...')` instead of generic failures.
> 
> The old `DataHashHexParseError` / `DataHashBytesParseError` types are replaced by a **`thiserror` `DataHashError`** enum (`InvalidHex` / `InvalidBytes`) in `merklehash/error.rs`, with `from_hex`, `from_slice`, and `from_base64` building errors via helpers that capture and truncate input. **`CoreError::HashParsing`** now wraps `DataHashError` (replacing the unused `Infallible` stub and manual `From` impls), and **`XetError`** treats hash parsing as **data integrity**. Call sites in WASM, chunk cache, and `xet_data` are updated to the unified type; unit tests assert input retention and truncation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca009c5f1914823e0737f007efb03a0a7767d818. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->