### PR TITLE
Allow selecting the reqwest TLS backend via hf-xet features

### DIFF
--- a/xet_data/Cargo.toml
+++ b/xet_data/Cargo.toml
@@ -18,7 +18,7 @@ doctest = false
 [dependencies]
 xet-runtime = { version = "1.5.4", path = "../xet_runtime" }
 xet-core-structures = { version = "1.5.4", path = "../xet_core_structures" }
-xet-client = { version = "1.5.4", path = "../xet_client" }
+xet-client = { version = "1.5.4", path = "../xet_client", default-features = false }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }
@@ -94,6 +94,11 @@ name = "reconstruction_bench"
 harness = false
 
 [features]
+default = ["rustls-tls"]
+# TLS backend for the underlying reqwest client; see the xet-client crate.
+rustls-tls = ["xet-client/rustls-tls"]
+native-tls = ["xet-client/native-tls"]
+native-tls-vendored = ["xet-client/native-tls-vendored"]
 strict = []
 smoke-test = []
 expensive_tests = []

--- a/xet_pkg/Cargo.toml
+++ b/xet_pkg/Cargo.toml
@@ -38,8 +38,8 @@ required-features = ["internal-tools"]
 [dependencies]
 xet-runtime = { version = "1.5.4", path = "../xet_runtime" }
 xet-core-structures = { version = "1.5.4", path = "../xet_core_structures" }
-xet-client = { version = "1.5.4", path = "../xet_client" }
-xet-data = { version = "1.5.4", path = "../xet_data" }
+xet-client = { version = "1.5.4", path = "../xet_client", default-features = false }
+xet-data = { version = "1.5.4", path = "../xet_data", default-features = false }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }
@@ -58,6 +58,7 @@ walkdir = { workspace = true, optional = true }
 uuid = { workspace = true, features = ["v7"] }
 
 [features]
+default = ["rustls-tls"]
 smoke-test = []
 # Internal tooling (the `xtool` binary). Off by default so the library
 # still compiles for wasm32-unknown-unknown.
@@ -65,8 +66,12 @@ internal-tools = ["dep:clap", "dep:url", "dep:walkdir"]
 fd-track = ["xet-runtime/fd-track", "xet-client/fd-track", "xet-data/fd-track"]
 python = ["xet-runtime/python", "xet-data/python", "dep:pyo3"]
 simulation = ["xet-client/simulation"]
-native-tls = ["xet-client/native-tls"]
-native-tls-vendored = ["xet-client/native-tls-vendored"]
+# TLS backend for the underlying reqwest client. rustls is the default; to use
+# the platform-native TLS stack instead, depend on this crate with
+# `default-features = false` and enable `native-tls` (or `native-tls-vendored`).
+rustls-tls = ["xet-client/rustls-tls", "xet-data/rustls-tls"]
+native-tls = ["xet-client/native-tls", "xet-data/native-tls"]
+native-tls-vendored = ["xet-client/native-tls-vendored", "xet-data/native-tls-vendored"]
 elevated_information_level = ["xet-client/elevated_information_level", "xet-runtime/elevated_information_level"]
 no-default-cache = ["xet-runtime/no-default-cache"]
 tokio-console = ["xet-runtime/tokio-console"]


### PR DESCRIPTION
requested by users of hf-xet transitively through hf-hub https://github.com/vllm-project/vllm/pull/48575#issue-4880634081

## What

Adds feature-based TLS backend selection to the `hf-xet` crate (and `xet-data`), so consumers can switch the reqwest TLS backend from rustls to the platform-native TLS stack.

`xet-client` already exposed `rustls-tls` / `native-tls` / `native-tls-vendored` features, and `hf-xet` forwarded the native ones — but since `hf-xet` depended on `xet-client` with default features on, `rustls-tls` was always enabled and could never be opted out of (cargo features are additive).

## Changes

- `xet_pkg` (`hf-xet`) and `xet_data`: depend on `xet-client` (and `xet-data`) with `default-features = false`
- Both crates re-expose the backend choice as their own features, with `default = ["rustls-tls"]`

Usage:

```toml
hf-xet = { version = "1.5.4", default-features = false, features = ["native-tls"] }
```

Note: even without `default-features = false`, enabling `native-tls` switches the runtime backend — reqwest 0.13's `TlsBackend::default()` prefers native-tls when both backends are compiled in. The `default-features = false` path additionally drops rustls from the dependency tree entirely.

## Behavior

- Default builds unchanged: rustls remains the default backend for all existing consumers (all internal dependency edges use default features).
- `Cargo.lock` unchanged — native-tls pins were already present.

## Verification

- `cargo check -p hf-xet` → `cargo tree -i rustls` shows rustls (unchanged default)
- `cargo check -p hf-xet --no-default-features --features native-tls` compiles; `cargo tree -i rustls` finds no rustls, `-i native-tls` shows native-tls wired via hyper-tls → reqwest
- `cargo check --workspace` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time dependency/feature wiring only; default rustls behavior is unchanged for normal consumers.
> 
> **Overview**
> **Enables `hf-xet` and `xet-data` consumers to choose the reqwest TLS stack** instead of always pulling in rustls through transitive default features.
> 
> Both crates now depend on `xet-client` (and `hf-xet` on `xet-data`) with **`default-features = false`**, and re-export **`rustls-tls`**, **`native-tls`**, and **`native-tls-vendored`** with **`default = ["rustls-tls"]`**. `hf-xet`’s TLS features forward to both `xet-client` and `xet-data` so the whole stack stays aligned.
> 
> Default behavior stays rustls for existing dependents. With `default-features = false` and `native-tls` (or vendored), rustls can be dropped from the dependency tree entirely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a20af96f1c027d83321b06a5e283495e23cc265. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->