### PR TITLE
fix: scope pyo3 auto-initialize to dev-dependencies (#891)

### DIFF
--- a/hf_xet/Cargo.toml
+++ b/hf_xet/Cargo.toml
@@ -19,10 +19,12 @@ pprof = { version = "0.15", features = [
     "prost",
     "protobuf-codec",
 ], optional = true }
-pyo3 = { version = "0.29", features = [
-    "abi3-py38",
-    "auto-initialize",
-] }
+# NOTE: do not add the `auto-initialize` feature here. This crate ships as a cdylib
+# extension module that is always loaded by an already-running interpreter, so it never
+# needs to start one. Enabling it also makes the pyo3 build script hard-fail against a
+# Python built with `--disable-shared` (the manylinux default). It is enabled for tests
+# only, via [dev-dependencies] below. See issue #891.
+pyo3 = { version = "0.29", features = ["abi3-py38"] }
 async-trait = "0.1"
 http = "1"
 itertools = "0.14"
@@ -64,6 +66,11 @@ split-debuginfo = "none"
 
 [dev-dependencies]
 tempfile = "3"
+# The unit tests call `Python::attach` from a plain Rust test binary, where no interpreter
+# is running yet; `auto-initialize` makes pyo3 start one on demand. Declaring it here rather
+# than in [dependencies] keeps it out of the cdylib build: under Cargo's v2/v3 feature
+# resolver, dev-dependency features are only unified when test targets are built.
+pyo3 = { version = "0.29", features = ["auto-initialize"] }
 
 [profile.opt-test]
 inherits = "dev"

--- a/hf_xet/tests/pyo3_features.rs
+++ b/hf_xet/tests/pyo3_features.rs
@@ -1,0 +1,80 @@
+//! Manifest invariants for the pyo3 dependency (see issue #891).
+//!
+//! `hf_xet` ships as a cdylib extension module, which is always loaded by an
+//! already-running interpreter and therefore never needs to start one. Enabling pyo3's
+//! `auto-initialize` feature on the regular dependency makes pyo3's build script
+//! hard-fail against a Python built with `--disable-shared` -- the standard
+//! configuration for manylinux-compliant build environments.
+//!
+//! The feature is still needed by the unit tests, which call `Python::attach` from a
+//! plain Rust test binary where no interpreter is running yet. Declaring it under
+//! `[dev-dependencies]` satisfies both: Cargo's v2/v3 feature resolver only unifies
+//! dev-dependency features when test targets are being built, so the cdylib build
+//! never sees it.
+//!
+//! These are asserted here because release CI builds wheels against interpreters that
+//! do expose a shared libpython, so a regression would not surface in CI -- only later,
+//! for downstream users building against a `--disable-shared` Python.
+
+const MANIFEST: &str = include_str!("../Cargo.toml");
+
+/// Collects the body of a top-level TOML table, with `#` comments stripped.
+///
+/// Deliberately minimal rather than pulling in a TOML parser as a dev-dependency.
+/// Comment stripping matters here: the manifest documents this very invariant in
+/// comments that mention `auto-initialize` by name.
+fn table_body(manifest: &str, header: &str) -> String {
+    let mut body = String::new();
+    let mut inside = false;
+
+    for raw_line in manifest.lines() {
+        let line = match raw_line.find('#') {
+            Some(idx) => &raw_line[..idx],
+            None => raw_line,
+        };
+        let trimmed = line.trim();
+
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            inside = trimmed == header;
+            continue;
+        }
+        if inside {
+            body.push_str(line);
+            body.push('\n');
+        }
+    }
+
+    body
+}
+
+#[test]
+fn pyo3_auto_initialize_is_not_a_regular_dependency() {
+    let dependencies = table_body(MANIFEST, "[dependencies]");
+
+    // Guard against the table_body helper silently matching nothing if the manifest
+    // is restructured, which would make the assertion below vacuously pass.
+    assert!(
+        dependencies.contains("pyo3"),
+        "no pyo3 entry found in [dependencies] -- the manifest layout changed and this \
+         test needs updating"
+    );
+
+    assert!(
+        !dependencies.contains("auto-initialize"),
+        "pyo3's `auto-initialize` feature must not be enabled in [dependencies]: it makes \
+         the pyo3 build script fail against a Python built with `--disable-shared`, which \
+         is what manylinux build environments use. It belongs in [dev-dependencies]. \
+         See issue #891."
+    );
+}
+
+#[test]
+fn pyo3_auto_initialize_is_enabled_for_tests() {
+    let dev_dependencies = table_body(MANIFEST, "[dev-dependencies]");
+
+    assert!(
+        dev_dependencies.contains("auto-initialize"),
+        "the unit tests call `Python::attach` with no interpreter running, which requires \
+         pyo3's `auto-initialize`; it must stay in [dev-dependencies]. See issue #891."
+    );
+}


### PR DESCRIPTION
Fixes #891.

## Problem

`hf_xet` enables pyo3's `auto-initialize` feature. pyo3's build script hard-fails when that feature is combined with a Python built `--disable-shared`, which is the standard configuration for manylinux build environments:

```
error: The `auto-initialize` feature is not supported when linking Python
statically instead of with a shared library.
```

The check has no `extension-module` carve-out, so it fires even though we build as an extension module. This blocks downstream builds of `huggingface-hub` and anything above it.

## Why the suggested one-line fix is insufficient

The issue suggests simply dropping the feature. That breaks `cargo test` for this crate:

```
test result: FAILED. 10 passed; 26 failed

panicked at pyo3-0.29.0/src/interpreter_lifecycle.rs:134:
assertion `left != right` failed: The Python interpreter is not initialized
and the `auto-initialize` feature is not enabled.
```

26 of the 36 unit tests call `Python::attach` from a plain Rust test binary, where no interpreter is running yet. pyo3 has an escape hatch for exactly this case, but it is gated on `CARGO_PRIMARY_PACKAGE`, which Cargo sets only when pyo3 itself is the package under test — it never applies to a downstream crate.

## Fix

Keep the feature, but scope it to test builds:

```toml
[dependencies]
pyo3 = { version = "0.29", features = ["abi3-py38"] }

[dev-dependencies]
pyo3 = { version = "0.29", features = ["auto-initialize"] }
```

Cargo's v2/v3 feature resolver only unifies dev-dependency features when test targets are built, so the cdylib build never sees it.

Verified by reading the resolved feature set on pyo3's `custom-build` unit — the unit that actually runs the build-script check — via `cargo build --unit-graph`:

| Build | `auto-initialize` |
| --- | --- |
| `cargo build --features extension-module` (how maturin builds it) | absent |
| `cargo build` | absent |
| `cargo test` | present |

## Impact

**No functional change to the shipped wheel.** Both variants go through the same one-shot `Once` in pyo3: with the feature, the first `Python::attach` calls `Py_InitializeEx` only `if Py_IsInitialized() == 0`; without it, the first call asserts `Py_IsInitialized() != 0`. An extension module always has a live interpreter by the time our code runs, so that first call is a no-op either way and every later call short-circuits on the completed `Once`.

No new dependencies, and `Cargo.lock` is unchanged — feature selection is not recorded there.

## Tests

Adds `hf_xet/tests/pyo3_features.rs`, asserting the manifest invariant directly. Release CI builds wheels against interpreters that *do* expose a shared libpython, so it would not catch someone re-adding `auto-initialize` to `[dependencies]` — the failure would only resurface downstream. The guard was mutation-tested: it fails when the feature is re-added and passes on the fix.

All 36 existing unit tests plus the 2 new tests pass; `cargo +nightly fmt --check` is clean and clippy reports no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAo54vCMnUhYQJUA82ueEw

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build and test wiring only; shipped wheel behavior is unchanged because the extension always runs under an already-initialized interpreter.
> 
> **Overview**
> Fixes **#891** by moving pyo3's **`auto-initialize`** feature out of **`[dependencies]`** and into **`[dev-dependencies]`**, with manifest comments explaining that the cdylib extension never starts an interpreter but manylinux **`--disable-shared`** builds fail when the feature is on the main dependency.
> 
> **`cargo test`** still gets **`auto-initialize`** via the dev-dependency so tests that call **`Python::attach`** without a running interpreter keep working; wheel/cdylib builds should no longer hit pyo3's static-Python build-script error.
> 
> Adds **`hf_xet/tests/pyo3_features.rs`** to parse **`Cargo.toml`** and assert **`auto-initialize`** is absent from **`[dependencies]`** and present under **`[dev-dependencies]`**, since release CI may not catch a regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b19a787ce6db6c626a4b50e7c81f744a8a4090a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->