### PR TITLE
bump hf-xet Python to 1.6.0

### DIFF
--- a/hf_xet/Cargo.lock
+++ b/hf_xet/Cargo.lock
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "hf_xet"
-version = "1.5.2"
+version = "1.6.0"
 dependencies = [
  "async-trait",
  "hf-xet",

--- a/hf_xet/Cargo.toml
+++ b/hf_xet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hf_xet"
-version = "1.5.2"
+version = "1.6.0"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version-only change with no logic or dependency updates.
> 
> **Overview**
> Bumps the **`hf_xet`** PyO3 extension package version from **1.5.2** to **1.6.0** in `hf_xet/Cargo.toml`, with the matching lockfile entry updated in `hf_xet/Cargo.lock`. No runtime or dependency changes beyond the version string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3c666988715d230ca650f3d565121b38c7eaff3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->