### PR TITLE
fix: remove double counting when reducing fragmentation

### DIFF
--- a/xet_data/src/deduplication/file_deduplication.rs
+++ b/xet_data/src/deduplication/file_deduplication.rs
@@ -197,16 +197,23 @@ impl<DataInterfaceType: DeduplicationDataInterface> FileDeduper<DataInterfaceTyp
             }
 
             if let Some((n_deduped, fse, is_external)) = dedupe_query {
-                dedup_metrics.deduped_chunks += n_deduped as u64;
-                dedup_metrics.deduped_bytes += fse.unpacked_segment_bytes as u64;
-                dedup_metrics.total_chunks += n_deduped as u64;
-                dedup_metrics.total_bytes += fse.unpacked_segment_bytes as u64;
+                let deduped_bytes = fse.unpacked_segment_bytes as u64;
 
                 // check the fragmentation state and if it is pretty fragmented,
                 // we skip dedupe.  However, continuing the previous is always fine.
                 if self.file_data_sequence_continues_current(&fse)
                     || self.defrag_tracker.allow_dedup_on_next_range(n_deduped)
                 {
+                    // Only account for the range once the dedup is actually taken. Counting it
+                    // before this check meant a defrag-prevented range was added here and then
+                    // again below as new data, inflating `total_bytes` by exactly
+                    // `defrag_prevented_dedup_bytes` — and `total_bytes` is what
+                    // `FileCleaner::finish_inner` reports as the file's size.
+                    dedup_metrics.deduped_chunks += n_deduped as u64;
+                    dedup_metrics.deduped_bytes += deduped_bytes;
+                    dedup_metrics.total_chunks += n_deduped as u64;
+                    dedup_metrics.total_bytes += deduped_bytes;
+
                     // Report this as a dependency
                     // The case where it's dededuped against the present xorb is handled
                     // when the xorb gets cut and we know the hash.
@@ -214,7 +221,7 @@ impl<DataInterfaceType: DeduplicationDataInterface> FileDeduper<DataInterfaceTyp
                         xorb_dependencies.push(FileXorbDependency {
                             file_id: self.file_id,
                             xorb_hash: fse.xorb_hash,
-                            n_bytes: fse.unpacked_segment_bytes as u64,
+                            n_bytes: deduped_bytes,
                             is_external,
                         });
                     }
@@ -225,8 +232,10 @@ impl<DataInterfaceType: DeduplicationDataInterface> FileDeduper<DataInterfaceTyp
                     cur_idx += n_deduped;
                     continue;
                 } else {
+                    // The range is not deduped: it falls through and is counted as new data
+                    // below, one chunk at a time.
                     dedup_metrics.defrag_prevented_dedup_chunks += n_deduped as u64;
-                    dedup_metrics.defrag_prevented_dedup_bytes += fse.unpacked_segment_bytes as u64;
+                    dedup_metrics.defrag_prevented_dedup_bytes += deduped_bytes;
                 }
             }
 

--- a/xet_data/src/processing/file_cleaner.rs
+++ b/xet_data/src/processing/file_cleaner.rs
@@ -17,7 +17,7 @@ use super::deduplication_interface::UploadSessionDataManager;
 use super::file_upload_session::FileUploadSession;
 use super::sha256::Sha256Generator;
 use crate::deduplication::{Chunk, Chunker, DeduplicationMetrics, FileDeduper};
-use crate::error::Result;
+use crate::error::{DataError, Result};
 use crate::progress_tracking::upload_tracking::CompletionTrackerFileId;
 
 /// Controls how SHA-256 is handled during file cleaning.
@@ -254,10 +254,27 @@ impl SingleFileCleaner {
             sha256: sha256.map(|s| s.hex()),
         };
 
-        #[cfg(debug_assertions)]
-        {
-            debug_assert_eq!(remaining_file_data.pending_file_info.len(), 1);
-            debug_assert_eq!(remaining_file_data.pending_file_info[0].0.file_size(), deduplication_metrics.total_bytes)
+        // `file_size` above is reported from `total_bytes`, an accumulated metrics counter, while
+        // the file's actual content is described by the entries in `pending_file_info`. If the two
+        // disagree, the size handed back to the caller does not describe the data that was just
+        // written. Callers persist that size alongside the file hash, so a mismatch is only
+        // detected much later — and by then the two are permanently out of step. Fail here instead.
+        //
+        // This was a debug-only assertion, which meant release builds shipped a wrong size in
+        // silence; see the defrag-prevented dedup double-count fixed in `FileDeduper`.
+        if remaining_file_data.pending_file_info.len() != 1 {
+            return Err(DataError::InternalError(format!(
+                "expected exactly one pending file info after clean, found {}",
+                remaining_file_data.pending_file_info.len()
+            )));
+        }
+        let described_size = remaining_file_data.pending_file_info[0].0.file_size();
+        if described_size != deduplication_metrics.total_bytes {
+            return Err(DataError::InternalError(format!(
+                "file size mismatch after clean: file info describes {described_size} bytes but \
+                 deduplication metrics report {}",
+                deduplication_metrics.total_bytes
+            )));
         }
 
         let mdb_file_info = if register {

--- a/xet_data/tests/test_defrag_prevented_dedup_metrics.rs
+++ b/xet_data/tests/test_defrag_prevented_dedup_metrics.rs
@@ -1,0 +1,100 @@
+//! Regression test for `total_bytes` being over-counted when defrag prevention rejects a dedup
+//! match.
+//!
+//! `FileCleaner::finish_inner` reports `DeduplicationMetrics::total_bytes` as the file's size, so
+//! any over-count there becomes a wrong `XetFileInfo::file_size`. Previously the deduped range was
+//! added to `total_bytes` *before* the defrag check, and a rejected range then fell through and was
+//! counted a second time as new data — inflating the reported size by exactly
+//! `defrag_prevented_dedup_bytes` while the file's actual content was unchanged.
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use rand::rngs::StdRng;
+use rand::{RngExt, SeedableRng};
+use xet_data::deduplication::constants::{MAX_XORB_BYTES, MAX_XORB_CHUNKS, TARGET_CHUNK_SIZE};
+use xet_data::processing::configurations::TranslatorConfig;
+use xet_data::processing::{FileUploadSession, Sha256Policy};
+use xet_runtime::config::XetConfig;
+use xet_runtime::core::XetContext;
+use xet_runtime::test_set_constants;
+
+// Small chunks so a few hundred KB of data produces enough ranges to drive the fragmentation
+// estimator.
+test_set_constants! {
+    TARGET_CHUNK_SIZE = 1024;
+    MAX_XORB_BYTES = 64 * (*TARGET_CHUNK_SIZE);
+    MAX_XORB_CHUNKS = 64;
+}
+
+fn random_data(seed: u64, len: usize) -> Vec<u8> {
+    let mut rng = StdRng::seed_from_u64(seed);
+    let mut data = vec![0u8; len];
+    rng.fill(&mut data[..]);
+    data
+}
+
+/// Interleaves unique filler with a short repeated block. Each repeat dedups against the earlier
+/// copy as a very small range, which is what defrag prevention rejects.
+fn fragmented_dedup_data(repeats: usize) -> Vec<u8> {
+    let repeated_block = random_data(0xABCD, 4 * 1024);
+    let mut data = Vec::new();
+    for i in 0..repeats {
+        data.extend_from_slice(&random_data(i as u64, 24 * 1024));
+        data.extend_from_slice(&repeated_block);
+    }
+    data
+}
+
+/// Builds a session whose defrag prevention rejects essentially every dedup match: the estimator
+/// is ready after a single range, and the target chunks-per-range is set far above anything the
+/// data can produce, so `allow_dedup_on_next_range` always takes the reject path.
+async fn upload_session_rejecting_dedup(dir: &std::path::Path) -> Arc<FileUploadSession> {
+    let config = XetConfig::default()
+        .with_config("deduplication.nranges_in_streaming_fragmentation_estimator", "1")
+        .expect("nranges config path should exist")
+        .with_config("deduplication.min_n_chunks_per_range", "100000")
+        .expect("min_n_chunks_per_range config path should exist");
+    let ctx = XetContext::with_config(config).expect("failed to build XetContext");
+    let translator = Arc::new(TranslatorConfig::local_config(&ctx, dir).expect("failed to build TranslatorConfig"));
+    FileUploadSession::new(translator).await.expect("failed to create upload session")
+}
+
+/// The reported file size must equal the bytes fed in, even when defrag prevention rejects dedup
+/// matches. Before the fix this returned `len + defrag_prevented_dedup_bytes`.
+#[tokio::test]
+async fn defrag_prevented_dedup_does_not_inflate_reported_file_size() {
+    let data = fragmented_dedup_data(24);
+    let dir = tempfile::tempdir().unwrap();
+    let session = upload_session_rejecting_dedup(dir.path()).await;
+
+    let (_, mut cleaner) = session
+        .start_clean(None, Some(data.len() as u64), Sha256Policy::Skip)
+        .expect("start_clean failed");
+    // Feed in frames rather than one buffer so chunks are produced incrementally, as they are for
+    // a streamed upload.
+    for frame in data.chunks(8 * 1024) {
+        cleaner
+            .add_data_from_bytes(Bytes::copy_from_slice(frame))
+            .await
+            .expect("add_data_from_bytes failed");
+    }
+    let (file_info, metrics) = cleaner.finish().await.expect("finish failed");
+
+    assert!(
+        metrics.defrag_prevented_dedup_bytes > 0,
+        "test did not exercise the defrag-prevented path; tune the data or the config"
+    );
+    assert_eq!(
+        metrics.total_bytes,
+        data.len() as u64,
+        "total_bytes over-counted by {} (defrag_prevented_dedup_bytes = {})",
+        metrics.total_bytes as i128 - data.len() as i128,
+        metrics.defrag_prevented_dedup_bytes
+    );
+    assert_eq!(
+        file_info.file_size,
+        Some(data.len() as u64),
+        "reported file size must match the bytes written"
+    );
+}

--- a/xet_data/tests/test_defrag_prevented_dedup_metrics.rs
+++ b/xet_data/tests/test_defrag_prevented_dedup_metrics.rs
@@ -57,7 +57,9 @@ async fn upload_session_rejecting_dedup(dir: &std::path::Path) -> Arc<FileUpload
         .expect("min_n_chunks_per_range config path should exist");
     let ctx = XetContext::with_config(config).expect("failed to build XetContext");
     let translator = Arc::new(TranslatorConfig::local_config(&ctx, dir).expect("failed to build TranslatorConfig"));
-    FileUploadSession::new(translator).await.expect("failed to create upload session")
+    FileUploadSession::new(translator)
+        .await
+        .expect("failed to create upload session")
 }
 
 /// The reported file size must equal the bytes fed in, even when defrag prevention rejects dedup
@@ -92,9 +94,5 @@ async fn defrag_prevented_dedup_does_not_inflate_reported_file_size() {
         metrics.total_bytes as i128 - data.len() as i128,
         metrics.defrag_prevented_dedup_bytes
     );
-    assert_eq!(
-        file_info.file_size,
-        Some(data.len() as u64),
-        "reported file size must match the bytes written"
-    );
+    assert_eq!(file_info.file_size, Some(data.len() as u64), "reported file size must match the bytes written");
 }


### PR DESCRIPTION
## Problem

`SingleFileCleaner::finish*` can report a `XetFileInfo::file_size` **larger than the bytes actually written**. The same input produces different sizes across runs while the file hash stays identical, so the file content is correct — only the reported size is wrong.

When defrag prevention rejects a match, the range has already been added to `total_bytes`, the
`else` branch never rolls it back, and the chunks are then counted a second time as new data.
`FileCleaner::finish_inner` reports `total_bytes` as the file size, so the over-count becomes the
file's size.

The over-count is therefore exactly `defrag_prevented_dedup_bytes`. 

Measured on the production file: reported `2150261441`, true size `2147483648`, excess `2777793`, which  matches `defrag_prevented_dedup_bytes`.

This is intermittent, only affecting dedup-heavy content.

## Changes

**1. `xet_data/src/deduplication/file_deduplication.rs`** - move the `deduped_chunks` /
`deduped_bytes` / `total_chunks` / `total_bytes` increments inside the branch where the dedup is
actually taken. `fse.unpacked_segment_bytes` is captured once as `deduped_bytes` (it was read four
times, and `fse` is moved by `add_file_data_sequence_entry`).

This also corrects `deduped_bytes` and `deduped_chunks`, which were over-counted the same way.

**2. `xet_data/src/processing/file_cleaner.rs`** - promote the existing `#[cfg(debug_assertions)]`
block to unconditional checks returning `DataError::InternalError`. That assertion already encoded
this exact invariant, but being debug-only meant release builds shipped a wrong size silently.

**3. New `xet_data/tests/test_defrag_prevented_dedup_metrics.rs`** - forces the rejected-dedup path with
tuned config for a smaller repro.

## Notes for reviewers

- **Behaviour change:** callers that previously received a silently-wrong size now get an `Err` from
  `finish()`. That is the intent, but if the double-count was occurring more widely than we know,
  this will surface it as a hard failure rather than bad metadata.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes upload dedup metrics and reported file size (persisted metadata); mismatches now error at finish instead of silently wrong sizes in release builds.
> 
> **Overview**
> Fixes **inflated `XetFileInfo::file_size`** when defrag prevention rejects a dedup match: the deduped range was counted in `total_bytes` before the defrag gate, then counted again as new data when the match was skipped.
> 
> **`file_deduplication.rs`** — Dedup/total chunk and byte metrics (and xorb dependency bytes) are updated only inside the branch where dedup is actually applied; rejected ranges only bump `defrag_prevented_*` and fall through to per-chunk “new data” accounting.
> 
> **`file_cleaner.rs`** — The debug-only size invariant is enforced in all builds: `finish_inner` returns `DataError::InternalError` if pending file info count ≠ 1 or described size ≠ `deduplication_metrics.total_bytes`.
> 
> **New regression test** — Forces the defrag-reject path and asserts `total_bytes` and reported file size match input length.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e8f24f0a38a60756c0018fba1fa80153639585a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->