### PR TITLE
feat(telemetry): runtime config group and pre-shutdown drain hook

### DIFF
--- a/xet_runtime/src/config/groups/telemetry.rs
+++ b/xet_runtime/src/config/groups/telemetry.rs
@@ -1,0 +1,133 @@
+use std::time::Duration;
+
+crate::config_group!({
+    /// Whether the client reports transfer performance telemetry to the CAS server.
+    ///
+    /// When enabled, each upload or download transfer sends a single summary document to
+    /// `POST /v1/telemetry` when it finishes, plus periodic heartbeat documents for transfers
+    /// that run longer than `heartbeat_after`. Sends are best-effort: they are never retried,
+    /// never block data movement, and failures are only logged at DEBUG.
+    ///
+    /// The payload carries no file names, paths, hashes, repository ids, or user ids.
+    ///
+    /// The default value is true.
+    ///
+    /// Use the environment variable `HF_XET_TELEMETRY_ENABLED` to set this value.
+    ref enabled: bool = true;
+
+    /// How long a transfer must run before it starts emitting heartbeat documents.
+    ///
+    /// Short transfers - the common case - only ever emit their terminal summary. Heartbeats
+    /// exist so a long transfer that hangs or is killed still reports something.
+    ///
+    /// Set to zero to disable heartbeats entirely.
+    ///
+    /// The default value is 5 minutes.
+    ///
+    /// Use the environment variable `HF_XET_TELEMETRY_HEARTBEAT_AFTER` to set this value.
+    ref heartbeat_after: Duration = Duration::from_secs(300);
+
+    /// The interval between heartbeat documents once `heartbeat_after` has elapsed.
+    ///
+    /// The default value is 5 minutes.
+    ///
+    /// Use the environment variable `HF_XET_TELEMETRY_HEARTBEAT_INTERVAL` to set this value.
+    ref heartbeat_interval: Duration = Duration::from_secs(300);
+
+    /// Whole-request budget for a single telemetry POST, including connection setup.
+    ///
+    /// The default value is 5 seconds.
+    ///
+    /// Use the environment variable `HF_XET_TELEMETRY_REQUEST_TIMEOUT` to set this value.
+    ref request_timeout: Duration = Duration::from_secs(5);
+
+    /// How long a transfer waits for its terminal telemetry document to be delivered.
+    ///
+    /// This runs after all transfer work has completed, so it delays no data movement, but it
+    /// does delay the return of `finalize()`. A short bounded wait is used because a fully
+    /// detached final send is usually lost: host processes frequently exit within milliseconds
+    /// of the transfer returning.
+    ///
+    /// Set to zero to make the terminal send fully detached.
+    ///
+    /// The default value is 2 seconds.
+    ///
+    /// Use the environment variable `HF_XET_TELEMETRY_FINAL_FLUSH_TIMEOUT` to set this value.
+    ref final_flush_timeout: Duration = Duration::from_secs(2);
+
+    /// Maximum number of telemetry requests allowed in flight at once, across the whole process.
+    ///
+    /// Documents submitted beyond this cap are dropped rather than queued; this is the
+    /// backpressure mechanism that keeps a degraded telemetry endpoint from accumulating tasks.
+    ///
+    /// The cap is process-wide rather than per-transfer, so it bounds a wide fan-out - a snapshot
+    /// download becomes many concurrent per-file transfers, and a per-transfer cap would multiply
+    /// by that count instead of limiting it.
+    ///
+    /// The default value is 32. It is sized as a process-wide number: a transfer emits one terminal
+    /// document, and heartbeats only start after `heartbeat_after`, so the realistic burst is a set
+    /// of concurrent transfers finalizing together. A much smaller ceiling would shed most of a wide
+    /// snapshot's terminal documents, which are the ones worth keeping.
+    ///
+    /// Use the environment variable `HF_XET_TELEMETRY_MAX_IN_FLIGHT` to set this value.
+    ref max_in_flight: usize = 32;
+});
+
+#[cfg(all(test, not(target_family = "wasm")))]
+mod tests {
+    use serial_test::serial;
+
+    use crate::config::XetConfig;
+    use crate::utils::EnvVarGuard;
+
+    const XET_ENABLED: &str = "HF_XET_TELEMETRY_ENABLED";
+
+    /// Clears every variable that participates in the gating decision, so a value exported in the
+    /// developer's shell cannot make these tests pass or fail spuriously.
+    fn clear_all() -> Vec<EnvVarGuard> {
+        [XET_ENABLED].into_iter().map(EnvVarGuard::unset).collect()
+    }
+
+    fn telemetry_enabled() -> bool {
+        XetConfig::default().with_env_overrides().telemetry.enabled
+    }
+
+    #[test]
+    #[serial(env)]
+    fn test_enabled_by_default() {
+        let _guards = clear_all();
+        assert!(telemetry_enabled());
+    }
+
+    #[test]
+    #[serial(env)]
+    fn test_disabled_by_own_env_var() {
+        let _guards = clear_all();
+        let _g = EnvVarGuard::set(XET_ENABLED, "0");
+        assert!(!telemetry_enabled());
+    }
+
+    #[test]
+    #[serial(env)]
+    fn test_durations_and_cap_have_expected_defaults() {
+        let _guards = clear_all();
+        let t = XetConfig::default().with_env_overrides().telemetry;
+        assert_eq!(t.heartbeat_after.as_secs(), 300);
+        assert_eq!(t.heartbeat_interval.as_secs(), 300);
+        assert_eq!(t.request_timeout.as_secs(), 5);
+        assert_eq!(t.final_flush_timeout.as_secs(), 2);
+        // Process-wide, not per-transfer - see `max_in_flight`'s docs for why it is sized this way.
+        assert_eq!(t.max_in_flight, 32);
+    }
+
+    #[test]
+    #[serial(env)]
+    fn test_durations_parse_from_env() {
+        let _guards = clear_all();
+        let _after = EnvVarGuard::set("HF_XET_TELEMETRY_HEARTBEAT_AFTER", "90s");
+        let _flush = EnvVarGuard::set("HF_XET_TELEMETRY_FINAL_FLUSH_TIMEOUT", "0s");
+        let t = XetConfig::default().with_env_overrides().telemetry;
+        assert_eq!(t.heartbeat_after.as_secs(), 90);
+        assert_eq!(t.final_flush_timeout.as_secs(), 0);
+    }
+}

--- a/xet_runtime/src/config/macros.rs
+++ b/xet_runtime/src/config/macros.rs
@@ -6,7 +6,7 @@
 #[macro_export]
 macro_rules! all_config_groups {
     ($mac:ident) => {
-        $mac!(data, shard, deduplication, chunk_cache, client, log, reconstruction, xorb, session);
+        $mac!(data, shard, deduplication, chunk_cache, client, log, reconstruction, xorb, session, telemetry);
     };
 }
 

--- a/xet_runtime/src/config/mod.rs
+++ b/xet_runtime/src/config/mod.rs
@@ -25,3 +25,4 @@ pub type ClientConfig = groups::client::ConfigValues;
 pub type LogConfig = groups::log::ConfigValues;
 pub type XorbConfig = groups::xorb::ConfigValues;
 pub type SessionConfig = groups::session::ConfigValues;
+pub type TelemetryConfig = groups::telemetry::ConfigValues;

--- a/xet_runtime/src/core/mod.rs
+++ b/xet_runtime/src/core/mod.rs
@@ -6,6 +6,8 @@ pub mod runtime;
 
 pub use common::XetCommon;
 pub use context::XetContext;
+#[cfg(not(target_family = "wasm"))]
+pub use runtime::register_pre_shutdown_drain;
 pub use runtime::{RuntimeMode, XetRuntime};
 
 pub mod sync_primatives;

--- a/xet_runtime/src/core/runtime.rs
+++ b/xet_runtime/src/core/runtime.rs
@@ -14,7 +14,7 @@ pub enum RuntimeMode {
 #[cfg(not(target_family = "wasm"))]
 mod native;
 #[cfg(not(target_family = "wasm"))]
-pub use native::XetRuntime;
+pub use native::{XetRuntime, register_pre_shutdown_drain};
 
 #[cfg(target_family = "wasm")]
 mod wasm;

--- a/xet_runtime/src/core/runtime/native.rs
+++ b/xet_runtime/src/core/runtime/native.rs
@@ -79,6 +79,25 @@ thread_local! {
 static EXTERNAL_THREADPOOL_REGISTRY: LazyLock<std::sync::RwLock<HashMap<tokio::runtime::Id, Weak<XetRuntime>>>> =
     LazyLock::new(|| std::sync::RwLock::new(HashMap::new()));
 
+/// Runs just before an owned runtime is shut down, while it can still drive tasks to completion.
+///
+/// Exists for best-effort detached work that would otherwise be cancelled by shutdown. Shutting a
+/// runtime down *cancels* pending tasks rather than completing them, so a fire-and-forget task -
+/// notably a telemetry POST - is lost unless something waits for it first. This is the only point
+/// that knows both "the runtime is still alive" and "it is about to die"; a hook registered later,
+/// at process exit, would run after the task had already been cancelled.
+///
+/// Registered from a higher layer ([`xet_client`]'s telemetry sink) so this crate stays unaware of
+/// what is being drained. A plain `fn` rather than a boxed closure: there is exactly one drain, it
+/// lives for the process, and the budget it uses is its own business.
+static PRE_SHUTDOWN_DRAIN: OnceLock<fn()> = OnceLock::new();
+
+/// Registers the pre-shutdown drain. The first registration wins; later calls are ignored, so this
+/// is safe to call on every client construction.
+pub fn register_pre_shutdown_drain(drain: fn()) {
+    let _ = PRE_SHUTDOWN_DRAIN.set(drain);
+}
+
 #[derive(Debug)]
 enum RuntimeBackend {
     External { handle_id: Option<tokio::runtime::Id> },
@@ -617,6 +636,21 @@ impl Drop for XetRuntime {
         // Avoid this by taking ownership of the runtime and using shutdown_background(),
         // which spawns a thread for the blocking shutdown work instead.
         let in_async_context = TokioRuntimeHandle::try_current().is_ok();
+
+        // Let best-effort detached work finish before the shutdown below cancels it. Only on the
+        // synchronous path: blocking inside an async context is the very thing the branch below
+        // avoids, and `shutdown_background()` does not wait for anything anyway.
+        //
+        // Deliberately after the fork and External early-returns above: a forked child has no
+        // worker threads to make progress, and an external runtime outlives us, so its tasks are
+        // never cancelled by this Drop.
+        if !in_async_context
+            && matches!(self.backend, RuntimeBackend::OwnedThreadPool { .. })
+            && let Some(drain) = PRE_SHUTDOWN_DRAIN.get()
+        {
+            drain();
+        }
+
         if let RuntimeBackend::OwnedThreadPool { runtime } = &self.backend
             && let Ok(mut guard) = runtime.write()
             && let Some(rt_arc) = guard.take()

--- a/xet_runtime/src/utils/guards.rs
+++ b/xet_runtime/src/utils/guards.rs
@@ -43,6 +43,18 @@ impl EnvVarGuard {
         }
         Self { key, prev }
     }
+
+    /// Removes the variable for the guard's lifetime, restoring it on drop.
+    ///
+    /// Useful for tests that assert default behavior and must not be perturbed by a value the
+    /// developer happens to have exported.
+    pub fn unset(key: &'static str) -> Self {
+        let prev = env::var(key).ok();
+        unsafe {
+            env::remove_var(key);
+        }
+        Self { key, prev }
+    }
 }
 
 #[cfg(not(target_family = "wasm"))]


### PR DESCRIPTION
Part 1 of 6 of the client transfer telemetry stack, split out of #919 for review. Each PR in the stack compiles and passes CI on its own.

Adds the telemetry config group (enabled, heartbeat, timeouts, in-flight cap)
and registers it with all_config_groups!, so it reaches callers as
ctx.config.telemetry.

Adds register_pre_shutdown_drain, a process-wide hook that XetRuntime::Drop
calls while the runtime can still drive tasks. Shutting a runtime down cancels
pending tasks rather than completing them, so fire-and-forget work is lost
unless something waits for it first; this is the only point that knows both
that the runtime is alive and that it is about to die. It fires only on the
synchronous path for an owned thread pool - blocking inside an async context is
what the neighbouring branch exists to avoid, and an external runtime outlives
us, so its tasks are never cancelled here.

EnvVarGuard::unset supports the config tests, which must assert default
behaviour without being perturbed by a value the developer happens to export.

No consumer yet; xet_client's telemetry sink is the first, in the next PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Infrastructure-only: new config defaults and a narrow shutdown hook with no telemetry consumer yet; owned-runtime drop may block briefly when a drain is registered later.
> 
> **Overview**
> Introduces **`telemetry`** as a new `XetConfig` group (wired through `all_config_groups!` and `TelemetryConfig`) so upcoming transfer telemetry can read **`ctx.config.telemetry`**. The group defines enablement (default on), heartbeat timing, POST timeouts, a bounded **`finalize()`** flush wait, and a **process-wide** in-flight cap with `HF_XET_*` env overrides, plus serial tests that use **`EnvVarGuard::unset`**.
> 
> Adds **`register_pre_shutdown_drain`**: a one-shot, process-wide hook invoked from **`XetRuntime::Drop`** on the synchronous owned-runtime path **before** Tokio shutdown, so best-effort detached work (e.g. telemetry POSTs) can finish instead of being cancelled. Skipped for external runtimes, forked children, and async-context drops.
> 
> **`EnvVarGuard::unset`** is new for tests that need clean default env state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50b63b82c2ab75dd729bb05e14e5871df128a4d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->