### PR TITLE
feat(telemetry): emit from session finalize, Drop, and heartbeats

### DIFF
--- a/xet_client/src/cas_client/simulation/local_server/handlers.rs
+++ b/xet_client/src/cas_client/simulation/local_server/handlers.rs
@@ -13,8 +13,8 @@
 //!
 //! Errors are mapped to appropriate HTTP status codes via `error_to_response`.
 
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use axum::Json;
@@ -53,6 +53,11 @@ pub(crate) struct ServerState {
     pub(crate) client: Arc<dyn DirectAccessClient>,
     pub(super) latency_simulation: Arc<LatencySimulation>,
     pub(crate) deletion_client: Option<Arc<dyn DeletionControlableClient>>,
+    /// Telemetry documents received on `POST /v1/telemetry`, in arrival order.
+    ///
+    /// Kept verbatim as `Value` so tests can assert on the exact wire shape, which is what a
+    /// consumer actually receives.
+    pub(crate) telemetry_docs: Arc<Mutex<Vec<serde_json::Value>>>,
     /// While set, `/v2/shards` emits an in-stream `Error` frame instead of committing.
     /// Encodes [`ShardUploadErrorFrame`] as `u8`.
     pub(crate) shard_upload_error_frame: Arc<AtomicU8>,
@@ -1003,6 +1008,30 @@ fn parse_congestion_config(value: &str) -> Result<(u64, u64, u64, f64), String> 
 /// Returns 200 OK with a simple success body. Used by the simulation to confirm the server is ready.
 pub async fn ping() -> Response {
     (StatusCode::OK, "ok").into_response()
+}
+
+/// POST /v1/telemetry
+///
+/// Stands in for the real cas_server endpoint, recording each document so tests can assert on
+/// what actually went over the wire. Mirrors the server's status contract closely enough for the
+/// client's purposes: 200 on a well-formed body, 400 otherwise.
+///
+/// Deliberately permissive about the *contents* of the body - the client is what is under test,
+/// so a mismatch should show up as a failed assertion on the recorded document rather than as an
+/// opaque 400.
+pub async fn post_telemetry(State(state): State<ServerState>, body: Bytes) -> Response {
+    let Ok(document) = serde_json::from_slice::<serde_json::Value>(&body) else {
+        return (StatusCode::BAD_REQUEST, "telemetry body is not valid JSON").into_response();
+    };
+    if !document.is_object() {
+        return (StatusCode::BAD_REQUEST, "telemetry body is not a JSON object").into_response();
+    }
+
+    let Ok(mut docs) = state.telemetry_docs.lock() else {
+        return (StatusCode::INTERNAL_SERVER_ERROR, "telemetry_docs lock poisoned").into_response();
+    };
+    docs.push(document);
+    StatusCode::OK.into_response()
 }
 
 /// POST /simulation/dummy_upload

--- a/xet_client/src/cas_client/simulation/local_server/server.rs
+++ b/xet_client/src/cas_client/simulation/local_server/server.rs
@@ -35,8 +35,8 @@ use std::net::SocketAddr;
 #[cfg(test)]
 use std::net::TcpListener as StdTcpListener;
 use std::path::PathBuf;
-use std::sync::Arc;
 use std::sync::atomic::AtomicU8;
+use std::sync::{Arc, Mutex};
 #[cfg(test)]
 use std::time::Duration;
 
@@ -102,6 +102,8 @@ pub struct LocalServer {
     client: Arc<dyn DirectAccessClient>,
     deletion_client: Option<Arc<dyn DeletionControlableClient>>,
     latency_simulation: Arc<LatencySimulation>,
+    /// Telemetry documents received on `POST /v1/telemetry`. See [`Self::telemetry_docs`].
+    telemetry_docs: Arc<Mutex<Vec<serde_json::Value>>>,
     /// `/v2/shards` in-stream Error frame mode (see [`handlers::ShardUploadErrorFrame`]).
     shard_upload_error_frame: Arc<AtomicU8>,
 }
@@ -128,6 +130,7 @@ impl LocalServer {
             client,
             deletion_client,
             latency_simulation,
+            telemetry_docs: Arc::default(),
             shard_upload_error_frame: Arc::new(AtomicU8::new(handlers::ShardUploadErrorFrame::Off as u8)),
         })
     }
@@ -154,6 +157,7 @@ impl LocalServer {
             client,
             deletion_client,
             latency_simulation,
+            telemetry_docs: Arc::default(),
             shard_upload_error_frame: Arc::new(AtomicU8::new(handlers::ShardUploadErrorFrame::Off as u8)),
         }
     }
@@ -161,6 +165,20 @@ impl LocalServer {
     /// Returns a clone of the underlying client.
     pub fn client(&self) -> Arc<dyn DirectAccessClient> {
         self.client.clone()
+    }
+
+    /// Telemetry documents received on `POST /v1/telemetry`, in arrival order.
+    ///
+    /// Returned verbatim so tests can assert on the exact wire shape - the key set and the JSON
+    /// type of each value are what a consumer actually receives.
+    pub fn telemetry_docs(&self) -> Vec<serde_json::Value> {
+        self.telemetry_docs.lock().expect("telemetry_docs lock poisoned").clone()
+    }
+
+    /// Shared handle to the received documents, so a caller can keep reading them after the
+    /// server has been moved into its serving task.
+    pub(crate) fn telemetry_docs_handle(&self) -> Arc<Mutex<Vec<serde_json::Value>>> {
+        self.telemetry_docs.clone()
     }
 
     /// Returns the server's bind address as "host:port".
@@ -187,7 +205,8 @@ impl LocalServer {
                     .route("/shards", post(handlers::post_shard))
                     .route("/files/{file_id}", head(handlers::head_file))
                     .route("/get_xorb/{prefix}/{hash}/", get(handlers::get_file_term_data))
-                    .route("/fetch_term", get(handlers::fetch_term)),
+                    .route("/fetch_term", get(handlers::fetch_term))
+                    .route("/telemetry", post(handlers::post_telemetry)),
             )
             .nest(
                 "/v2",
@@ -207,6 +226,7 @@ impl LocalServer {
                 client: self.client.clone(),
                 latency_simulation: self.latency_simulation.clone(),
                 deletion_client: self.deletion_client.clone(),
+                telemetry_docs: self.telemetry_docs.clone(),
                 shard_upload_error_frame: self.shard_upload_error_frame.clone(),
             })
     }

--- a/xet_client/src/cas_client/simulation/simulation_server.rs
+++ b/xet_client/src/cas_client/simulation/simulation_server.rs
@@ -255,6 +255,8 @@ impl LocalTestServerBuilder {
             };
 
         let server = LocalServer::from_client(client.clone(), deletion_client.clone(), host, port);
+        // Grabbed before the server moves into its serving task.
+        let telemetry_docs = server.telemetry_docs_handle();
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         tokio::spawn(async move {
             let _ = server.run_until_stopped(shutdown_rx).await;
@@ -317,6 +319,7 @@ impl LocalTestServerBuilder {
             socket_proxy,
             _ephemeral_socket_tempdir: ephemeral_tempdir,
             network_simulation_proxy: proxy_guard.clone(),
+            telemetry_docs: telemetry_docs.clone(),
         };
 
         #[cfg(not(unix))]
@@ -327,6 +330,7 @@ impl LocalTestServerBuilder {
             client,
             deletion_client,
             network_simulation_proxy: proxy_guard,
+            telemetry_docs: telemetry_docs.clone(),
         };
 
         if let Some(profile) = self.server_latency_profile {
@@ -380,6 +384,7 @@ pub struct LocalTestServer {
     client: Arc<dyn DirectAccessClient>,
     deletion_client: Option<Arc<dyn DeletionControlableClient>>,
     network_simulation_proxy: Option<Arc<NetworkSimulationProxy>>,
+    telemetry_docs: Arc<std::sync::Mutex<Vec<serde_json::Value>>>,
 
     #[cfg(unix)]
     socket_proxy: Option<UnixSocketProxy>,
@@ -442,6 +447,14 @@ impl LocalTestServer {
     }
 
     /// Returns the underlying `DirectAccessClient` for direct state access.
+    /// Telemetry documents received on `POST /v1/telemetry`, in arrival order.
+    ///
+    /// Returned verbatim so tests can assert on the exact wire shape - the key set and the JSON
+    /// type of each value are what a consumer actually receives.
+    pub fn telemetry_docs(&self) -> Vec<serde_json::Value> {
+        self.telemetry_docs.lock().expect("telemetry_docs lock poisoned").clone()
+    }
+
     pub fn client(&self) -> &Arc<dyn DirectAccessClient> {
         &self.client
     }

--- a/xet_data/src/processing/file_download_session.rs
+++ b/xet_data/src/processing/file_download_session.rs
@@ -52,14 +52,20 @@ impl FileDownloadSession {
             ctx.config.data.progress_update_speed_min_observations,
         ));
 
-        Ok(Arc::new(Self {
+        let session = Arc::new(Self {
             ctx,
             client,
             chunk_cache,
             progress,
             active_stream_abort_callbacks: Mutex::new(HashMap::new()),
             finalized: AtomicBool::new(false),
-        }))
+        });
+
+        // Only fires if this transfer outlives `heartbeat_after`; short ones never emit one.
+        #[cfg(not(target_family = "wasm"))]
+        crate::telemetry::start_download_heartbeat(&session.ctx.clone(), &session);
+
+        Ok(session)
     }
 
     /// Construct a download session from an existing CAS client.
@@ -83,6 +89,10 @@ impl FileDownloadSession {
         })
     }
 
+    pub fn client(&self) -> Arc<dyn Client> {
+        Arc::clone(&self.client)
+    }
+
     pub fn report(&self) -> crate::progress_tracking::GroupProgressReport {
         self.progress.report()
     }
@@ -93,6 +103,10 @@ impl FileDownloadSession {
 
     pub fn item_reports(&self) -> HashMap<UniqueId, crate::progress_tracking::ItemProgressReport> {
         self.progress.item_reports()
+    }
+
+    pub fn n_items(&self) -> usize {
+        self.progress.n_items()
     }
 
     fn register_stream_abort_callback(&self, id: UniqueId, callback: Box<dyn Fn() + Send + Sync>) {
@@ -193,14 +207,62 @@ impl FileDownloadSession {
         Ok(())
     }
 
-    /// Finalizes the session; in debug builds, asserts all items are complete.
+    /// Finalizes a session whose downloads all completed successfully.
+    ///
+    /// In debug builds this asserts that every item is complete; a session that ended badly must
+    /// go through [`finalize_failed`](Self::finalize_failed) instead, which makes no such claim.
     pub async fn finalize(&self) -> Result<()> {
         if self.finalized.swap(true, Ordering::AcqRel) {
             return Err(DataError::InvalidOperation("FileDownloadSession already finalized".to_string()));
         }
+
         #[cfg(debug_assertions)]
         self.progress.assert_complete();
+
+        #[cfg(not(target_family = "wasm"))]
+        self.emit_terminal(crate::telemetry::Outcome::Ok, crate::telemetry::ERROR_CLASS_NONE)
+            .await;
+
         Ok(())
+    }
+
+    /// Finalizes the session, reporting `outcome` and `error_class` on the telemetry document.
+    ///
+    /// Separate from [`finalize`](Self::finalize) because it makes no completeness claim, so it
+    /// suits both a session that ended badly (whose items legitimately are incomplete) and one
+    /// whose notion of "complete" belongs to the caller - notably a stream group, where nothing
+    /// requires every stream to be consumed.
+    ///
+    /// Callers in `xet_pkg` derive the pair with
+    /// [`classify_error`](crate::telemetry::classify_error) or
+    /// [`outcome_for_class`](crate::telemetry::outcome_for_class).
+    ///
+    /// Returns `Err` only if the session was already finalized.
+    pub async fn finalize_with(&self, outcome: crate::telemetry::Outcome, error_class: &'static str) -> Result<()> {
+        if self.finalized.swap(true, Ordering::AcqRel) {
+            return Err(DataError::InvalidOperation("FileDownloadSession already finalized".to_string()));
+        }
+
+        #[cfg(not(target_family = "wasm"))]
+        self.emit_terminal(outcome, error_class).await;
+
+        #[cfg(target_family = "wasm")]
+        let _ = (outcome, error_class);
+
+        Ok(())
+    }
+
+    /// Sends the terminal document for this session. Best-effort and infallible.
+    #[cfg(not(target_family = "wasm"))]
+    async fn emit_terminal(&self, outcome: crate::telemetry::Outcome, error_class: &'static str) {
+        crate::telemetry::emit_download_terminal(
+            &self.client,
+            outcome,
+            error_class,
+            &self.report(),
+            self.n_items() as u64,
+        )
+        .await;
     }
 
     fn setup_reconstructor(
@@ -384,6 +446,31 @@ fn range_bounds_to_file_range(range: &impl RangeBounds<u64>) -> Result<Option<Fi
         Ok(None)
     } else {
         Ok(Some(FileRange::new(start, end)))
+    }
+}
+
+/// Reports a download session that was dropped without finalizing.
+///
+/// This is the *only* telemetry coverage for `XetDownloadStreamGroup`, which holds an
+/// `Arc<FileDownloadSession>` and has no explicit `finish()` - it is freed when the last user clone
+/// drops. Detached rather than awaited, because `Drop` is synchronous.
+#[cfg(not(target_family = "wasm"))]
+impl Drop for FileDownloadSession {
+    fn drop(&mut self) {
+        if self.finalized.load(Ordering::Acquire) {
+            return;
+        }
+        // Deliberately *not* gated on `tokio::runtime::Handle::try_current()`. The send is spawned
+        // on the `XetRuntime`'s own stored handle, not the ambient one, so it does not need to run
+        // inside a runtime context - and requiring one silently disabled this path entirely for
+        // embedders that release the last `Arc` from a foreign thread, which is exactly what the
+        // Python bindings do.
+        crate::telemetry::emit_download_abandoned(
+            &self.client,
+            &self.report(),
+            self.n_items() as u64,
+            self.progress.all_items_complete(),
+        );
     }
 }
 

--- a/xet_data/src/processing/file_upload_session.rs
+++ b/xet_data/src/processing/file_upload_session.rs
@@ -45,7 +45,7 @@ use crate::progress_tracking::{GroupProgressReport, ItemProgressReport, UploadGr
 /// and xorbs needed to reconstruct those files are properly uploaded and registered.
 pub struct FileUploadSession {
     pub(crate) ctx: XetContext,
-    pub(crate) client: Arc<dyn Client + Send + Sync>,
+    pub(crate) client: Arc<dyn Client>,
     pub(crate) shard_interface: SessionShardInterface,
 
     /// Tracking upload completion between xorbs and files.
@@ -62,6 +62,10 @@ pub struct FileUploadSession {
 
     /// Set to true after finalize() has been called.
     finalized: AtomicBool,
+
+    /// Session start, for the telemetry `duration_ms` and `ingest_ms`.
+    #[cfg(not(target_family = "wasm"))]
+    started_at: std::time::Instant,
 }
 
 // Constructors
@@ -99,7 +103,7 @@ impl FileUploadSession {
             SessionShardInterface::new(&ctx, config.clone(), client.clone(), completion_tracker.clone(), dry_run)
                 .await?;
 
-        Ok(Arc::new(Self {
+        let session = Arc::new(Self {
             ctx,
             shard_interface,
             client,
@@ -108,7 +112,15 @@ impl FileUploadSession {
             deduplication_metrics: Mutex::new(DeduplicationMetrics::default()),
             xorb_upload_tasks: Mutex::new(JoinSet::new()),
             finalized: AtomicBool::new(false),
-        }))
+            #[cfg(not(target_family = "wasm"))]
+            started_at: std::time::Instant::now(),
+        });
+
+        // Only fires if this transfer outlives `heartbeat_after`; short ones never emit one.
+        #[cfg(not(target_family = "wasm"))]
+        crate::telemetry::start_upload_heartbeat(&session.ctx.clone(), &session);
+
+        Ok(session)
     }
 
     #[cfg(not(target_family = "wasm"))]
@@ -567,16 +579,62 @@ impl FileUploadSession {
         self.completion_tracker.register_dependencies(xorb_dependencies);
     }
 
-    /// Finalize everything.
+    /// Finalize everything, then report the outcome as telemetry.
+    ///
+    /// The telemetry hook lives here rather than in `xet_pkg` because `XetUploadCommit::commit`
+    /// returns early on a finalize error - hooking at that layer would silently lose exactly the
+    /// failures worth measuring. Reporting is best-effort and cannot fail, so `result` is returned
+    /// untouched either way.
     #[instrument(skip_all, name="FileUploadSession::finalize", fields(session.id))]
     async fn finalize_impl(
         self: Arc<Self>,
         return_files: bool,
+        #[cfg_attr(target_family = "wasm", allow(unused_variables))] reported_failure: Option<(
+            crate::telemetry::Outcome,
+            &'static str,
+        )>,
     ) -> Result<(DeduplicationMetrics, Vec<MDBFileInfo>, GroupProgressReport)> {
         if self.finalized.swap(true, Ordering::AcqRel) {
             return Err(DataError::InvalidOperation("FileUploadSession already finalized".to_string()));
         }
 
+        #[cfg(not(target_family = "wasm"))]
+        let ingest_ms = elapsed_ms(self.started_at);
+        #[cfg(not(target_family = "wasm"))]
+        let finalize_started = std::time::Instant::now();
+
+        let result = self.clone().finalize_inner(return_files).await;
+
+        #[cfg(not(target_family = "wasm"))]
+        {
+            // On the error path the dedup metrics were never taken out of the session, so read
+            // them back rather than reporting zeros.
+            let dedup = match &result {
+                Ok((metrics, ..)) => *metrics,
+                Err(_) => *self.deduplication_metrics.lock().await,
+            };
+            crate::telemetry::emit_upload_terminal(
+                &self.client,
+                &result,
+                reported_failure,
+                crate::telemetry::UploadSnapshot {
+                    progress: &self.report(),
+                    dedup: &dedup,
+                    n_files: self.n_items() as u64,
+                    ingest_ms,
+                    finalize_ms: elapsed_ms(finalize_started),
+                },
+            )
+            .await;
+        }
+
+        result
+    }
+
+    async fn finalize_inner(
+        self: Arc<Self>,
+        return_files: bool,
+    ) -> Result<(DeduplicationMetrics, Vec<MDBFileInfo>, GroupProgressReport)> {
         // Register the remaining xorbs for upload.
         let data_agg = take(&mut *self.current_session_data.lock().await);
         self.process_aggregated_data_as_xorb(data_agg).await?;
@@ -595,8 +653,6 @@ impl FileUploadSession {
             result??;
         }
 
-        let mut metrics = take(&mut *self.deduplication_metrics.lock().await);
-
         let all_file_info = if return_files {
             self.shard_interface.session_file_info_list().await?
         } else {
@@ -605,7 +661,13 @@ impl FileUploadSession {
 
         // Upload and register the current shards in the session, moving them
         // to the cache.
-        metrics.shard_bytes_uploaded = self.shard_interface.upload_and_register_session_shards().await?;
+        let shard_bytes_uploaded = self.shard_interface.upload_and_register_session_shards().await?;
+
+        // Taken only once both fallible calls above have succeeded, so that a failure in either
+        // leaves the metrics in the session for the error path to report. Nothing writes to them
+        // after the join above, so taking here captures the same values as taking earlier would.
+        let mut metrics = take(&mut *self.deduplication_metrics.lock().await);
+        metrics.shard_bytes_uploaded = shard_bytes_uploaded;
         metrics.total_bytes_uploaded = metrics.shard_bytes_uploaded + metrics.xorb_bytes_uploaded;
 
         #[cfg(debug_assertions)]
@@ -653,8 +715,18 @@ impl FileUploadSession {
         Ok(())
     }
 
-    pub fn client(&self) -> Arc<dyn Client + Send + Sync> {
+    pub fn client(&self) -> Arc<dyn Client> {
         Arc::clone(&self.client)
+    }
+
+    /// A copy of the running dedup metrics, or `None` if a task currently holds the lock.
+    ///
+    /// Non-blocking on purpose: the callers are the telemetry heartbeat and `Drop`, neither of
+    /// which may stall a runtime worker. Contention means a xorb upload is mid-write, in which
+    /// case the snapshot would be incomplete anyway - skipping one heartbeat is the right answer.
+    #[cfg(not(target_family = "wasm"))]
+    pub(crate) fn dedup_snapshot(&self) -> Option<DeduplicationMetrics> {
+        self.deduplication_metrics.try_lock().ok().map(|m| *m)
     }
 
     pub fn progress(&self) -> &Arc<UploadGroupProgress> {
@@ -673,18 +745,78 @@ impl FileUploadSession {
         self.completion_tracker.progress().item_reports()
     }
 
+    pub fn n_items(&self) -> usize {
+        self.completion_tracker.progress().n_items()
+    }
+
     pub async fn finalize(self: Arc<Self>) -> Result<DeduplicationMetrics> {
-        Ok(self.finalize_impl(false).await?.0)
+        Ok(self.finalize_impl(false, None).await?.0)
     }
 
     pub async fn finalize_with_report(self: Arc<Self>) -> Result<(DeduplicationMetrics, GroupProgressReport)> {
-        let (metrics, _file_info, report) = self.finalize_impl(false).await?;
+        let (metrics, _file_info, report) = self.finalize_impl(false, None).await?;
+        Ok((metrics, report))
+    }
+
+    /// Finalizes and reports the transfer as already failed, for a caller holding a failure the
+    /// session cannot see.
+    ///
+    /// `XetUploadCommit` finalizes each file's ingestion before it finalizes the session and
+    /// returns that error afterwards, so the session can finalize cleanly for a commit that fails.
+    /// Mirrors [`FileDownloadSession::finalize_with`](super::FileDownloadSession::finalize_with).
+    /// A failure in this finalize still takes precedence, matching which error the caller returns.
+    pub async fn finalize_with(
+        self: Arc<Self>,
+        outcome: crate::telemetry::Outcome,
+        error_class: &'static str,
+    ) -> Result<(DeduplicationMetrics, GroupProgressReport)> {
+        let (metrics, _file_info, report) = self.finalize_impl(false, Some((outcome, error_class))).await?;
         Ok((metrics, report))
     }
 
     pub async fn finalize_with_file_info(self: Arc<Self>) -> Result<(DeduplicationMetrics, Vec<MDBFileInfo>)> {
-        let (metrics, file_info, _report) = self.finalize_impl(true).await?;
+        let (metrics, file_info, _report) = self.finalize_impl(true, None).await?;
         Ok((metrics, file_info))
+    }
+}
+
+/// Milliseconds since `start`, saturating rather than wrapping.
+#[cfg(not(target_family = "wasm"))]
+fn elapsed_ms(start: std::time::Instant) -> u64 {
+    u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX)
+}
+
+/// Reports a session that was abandoned without finalizing - an `abort()`, a cancelled task tree,
+/// or a panic.
+///
+/// Detached rather than awaited, because `Drop` is synchronous; delivery is correspondingly less
+/// likely, but the alternative is no visibility at all into aborted uploads.
+#[cfg(not(target_family = "wasm"))]
+impl Drop for FileUploadSession {
+    fn drop(&mut self) {
+        if self.finalized.load(Ordering::Acquire) {
+            return;
+        }
+        // Deliberately *not* gated on `tokio::runtime::Handle::try_current()`. The send is spawned
+        // on the `XetRuntime`'s own stored handle, not the ambient one, so it does not need to run
+        // inside a runtime context - and requiring one silently disabled this path entirely for
+        // embedders that release the last `Arc` from a foreign thread.
+        //
+        // `try_lock` rather than `blocking_lock`: Drop can run on a runtime worker thread, where
+        // blocking would stall it. A contended lock here means a task is still writing metrics,
+        // in which case the report would be incomplete anyway.
+        let dedup = self.deduplication_metrics.try_lock().map(|m| *m).unwrap_or_default();
+
+        crate::telemetry::emit_upload_abandoned(
+            &self.client,
+            crate::telemetry::UploadSnapshot {
+                progress: &self.report(),
+                dedup: &dedup,
+                n_files: self.n_items() as u64,
+                ingest_ms: elapsed_ms(self.started_at),
+                finalize_ms: 0,
+            },
+        );
     }
 }
 

--- a/xet_data/src/processing/test_utils.rs
+++ b/xet_data/src/processing/test_utils.rs
@@ -473,4 +473,10 @@ impl TestEnvironment {
             _server: server,
         }
     }
+
+    /// Telemetry documents the simulation server has received, in arrival order.
+    #[cfg(feature = "simulation")]
+    pub fn telemetry_docs(&self) -> Vec<serde_json::Value> {
+        self._server.as_ref().map(|s| s.telemetry_docs()).unwrap_or_default()
+    }
 }

--- a/xet_data/src/progress_tracking/progress_types.rs
+++ b/xet_data/src/progress_tracking/progress_types.rs
@@ -142,10 +142,42 @@ impl GroupProgress {
         items.iter().map(|(id, item)| (*id, item.report())).collect()
     }
 
+    /// How many items are registered, without snapshotting any of them.
+    pub fn n_items(&self) -> usize {
+        self.items.lock().unwrap().len()
+    }
+
     /// Snapshot of one item's progress.
     pub fn item_report(&self, id: UniqueId) -> Option<ItemProgressReport> {
         let items = self.items.lock().unwrap();
         items.get(&id).map(|item| item.report())
+    }
+
+    /// True when every registered item has a finalized size and has delivered every byte of it.
+    ///
+    /// Requires at least one item: a group that never registered a download has not "completed"
+    /// anything, and reporting it as complete would turn a no-op session into a success.
+    ///
+    /// Checking `size_finalized` is load-bearing rather than redundant with the byte comparison.
+    /// When an item's size is discovered incrementally - an open-ended stream range, where
+    /// [`update_item_size`](ItemProgressUpdater::update_item_size) is called with `is_final =
+    /// false` per block - `total_bytes` tracks only what the prefetcher has found so far while
+    /// `bytes_completed` tracks what the consumer has taken. A consumer that catches up to the
+    /// prefetch frontier makes the two equal *mid-transfer*, so the byte comparison alone would
+    /// report an abandoned download as a finished one. `size_finalized` is set only once the
+    /// prefetcher reaches the real end of the file, which is the fact that actually distinguishes
+    /// "read to the end" from "stopped reading".
+    ///
+    /// Completions are read before totals so that a concurrent size discovery can only make this
+    /// predicate stricter, never falsely satisfy it.
+    pub fn all_items_complete(&self) -> bool {
+        let items = self.items.lock().unwrap();
+        !items.is_empty()
+            && items.values().all(|item| {
+                let completed = item.bytes_completed.load(Ordering::Acquire);
+                let total = item.total_bytes.load(Ordering::Acquire);
+                item.size_finalized.load(Ordering::Acquire) && completed >= total
+            })
     }
 
     /// Debug verification that all items are complete.
@@ -421,6 +453,11 @@ impl UploadGroupProgress {
         self.file_data.item_reports()
     }
 
+    /// How many items are registered, without snapshotting any of them.
+    pub fn n_items(&self) -> usize {
+        self.file_data.n_items()
+    }
+
     /// Snapshot of one item's progress.
     pub fn item_report(&self, id: UniqueId) -> Option<ItemProgressReport> {
         self.file_data.item_report(id)
@@ -666,6 +703,79 @@ mod tests {
         assert_eq!(group.total_transfer_bytes_completed.load(Ordering::Relaxed), 30);
     }
 
+    /// The case that motivates inferring an outcome at all: a download that transferred everything
+    /// but whose caller never called `finish()`.
+    #[test]
+    fn test_all_items_complete_when_every_item_finished() {
+        let group = Arc::new(GroupProgress::new());
+        for name in ["a.bin", "b.bin"] {
+            let updater = group.new_item(UniqueId::new(), name);
+            updater.update_item_size(100, true);
+            updater.report_bytes_completed(100);
+        }
+
+        assert!(group.all_items_complete());
+    }
+
+    /// A group with no registered items has not completed anything, so it must not read as
+    /// complete - otherwise a session that was created and dropped without a single download
+    /// would be indistinguishable from a successful one (0 bytes of 0 bytes).
+    #[test]
+    fn test_all_items_complete_rejects_an_empty_group() {
+        let group = Arc::new(GroupProgress::new());
+        assert!(!group.all_items_complete());
+    }
+
+    #[test]
+    fn test_all_items_complete_rejects_a_partial_item() {
+        let group = Arc::new(GroupProgress::new());
+        let done = group.new_item(UniqueId::new(), "done.bin");
+        done.update_item_size(100, true);
+        done.report_bytes_completed(100);
+
+        let partial = group.new_item(UniqueId::new(), "partial.bin");
+        partial.update_item_size(100, true);
+        partial.report_bytes_completed(40);
+
+        assert!(!group.all_items_complete());
+    }
+
+    /// The trap: an item whose size is still being discovered can transiently show
+    /// `bytes_completed == total_bytes` when the consumer catches up to the prefetch frontier. A
+    /// byte comparison alone would call this complete and report an abandoned stream as a success,
+    /// so an unfinalized size must disqualify the item no matter how the bytes compare.
+    #[test]
+    fn test_all_items_complete_rejects_an_unfinalized_size_at_equal_bytes() {
+        let group = Arc::new(GroupProgress::new());
+        let updater = group.new_item(UniqueId::new(), "stream");
+        // Prefetcher has discovered 60 bytes so far and the consumer has taken all 60.
+        updater.update_item_size(60, false);
+        updater.report_bytes_completed(60);
+
+        assert_eq!(updater.item().bytes_completed.load(Ordering::Relaxed), 60);
+        assert_eq!(updater.item().total_bytes.load(Ordering::Relaxed), 60);
+        assert!(
+            !group.all_items_complete(),
+            "an item whose size is not finalized must not count as complete even at equal bytes"
+        );
+
+        // Reaching the real end of the file finalizes the size, and only then is it complete.
+        updater.update_item_size(60, true);
+        assert!(group.all_items_complete());
+    }
+
+    /// A stream abandoned while the prefetcher was still ahead of the consumer - the ordinary
+    /// abandoned shape, caught by the byte comparison rather than the finalized flag.
+    #[test]
+    fn test_all_items_complete_rejects_an_abandoned_stream() {
+        let group = Arc::new(GroupProgress::new());
+        let updater = group.new_item(UniqueId::new(), "stream");
+        updater.update_item_size(100, false);
+        updater.report_bytes_completed(30);
+
+        assert!(!group.all_items_complete());
+    }
+
     #[test]
     fn test_update_item_size_finalized() {
         let group = Arc::new(GroupProgress::new());
@@ -732,6 +842,7 @@ mod tests {
         assert_eq!(reports.len(), 2);
         assert_eq!(reports[&id1].bytes_completed, 60);
         assert_eq!(reports[&id2].bytes_completed, 200);
+        assert_eq!(group.n_items(), reports.len());
     }
 
     #[test]

--- a/xet_data/src/telemetry/emit.rs
+++ b/xet_data/src/telemetry/emit.rs
@@ -1,0 +1,297 @@
+//! Bridges a finished (or abandoned) session to the telemetry sink in `xet_client`.
+//!
+//! Everything here is best-effort and infallible by construction: no function returns a `Result`,
+//! so a telemetry problem can never be propagated into a transfer.
+
+use std::sync::Arc;
+
+use xet_client::cas_client::{Client, Direction, TransferTelemetry};
+
+use super::outcome::{ERROR_CLASS_NONE, Outcome};
+use super::payload::{CommonInputs, CommonMetrics, DownloadMetrics, TransferIdentity, UploadMetrics};
+use crate::deduplication::DeduplicationMetrics;
+use crate::error::DataError;
+use crate::progress_tracking::GroupProgressReport;
+
+/// Reads the aggregator off a client, if it has one.
+///
+/// `None` for local, in-memory, and simulation clients, for dry runs, on wasm, and whenever
+/// telemetry is disabled - so every call site below is a cheap no-op in tests.
+pub(crate) fn telemetry_of(client: &Arc<dyn Client>) -> Option<Arc<TransferTelemetry>> {
+    client.transfer_telemetry()
+}
+
+/// Derives the outcome and error class from a session's finalize result.
+///
+/// `reported_failure` is for a caller that already knows the transfer failed for a reason the
+/// session cannot see - `XetUploadCommit` finalizes a file's ingestion before it finalizes the
+/// session, and returns that error afterwards. Without it a session that finalizes cleanly reports
+/// `ok` for a transfer its caller reports as failed.
+///
+/// The session's own failure wins when there is one, matching what the caller returns: it takes the
+/// finalize error in preference to the one it was already holding.
+fn classify<T>(
+    result: &Result<T, DataError>,
+    reported_failure: Option<(Outcome, &'static str)>,
+) -> (Outcome, &'static str) {
+    match (result, reported_failure) {
+        (Err(e), _) => super::outcome::classify_error(e),
+        (Ok(_), Some(failure)) => failure,
+        (Ok(_), None) => (Outcome::Ok, ERROR_CLASS_NONE),
+    }
+}
+
+/// Everything an upload document needs beyond the transfer's own identity.
+pub(crate) struct UploadSnapshot<'a> {
+    pub progress: &'a GroupProgressReport,
+    pub dedup: &'a DeduplicationMetrics,
+    pub n_files: u64,
+    /// Chunking, hashing, and xorb upload: session start until `finalize` was called.
+    pub ingest_ms: u64,
+    /// Shard consolidation, upload, and registration. Zero on the abandoned path, which never
+    /// reached finalization.
+    pub finalize_ms: u64,
+}
+
+/// Builds an upload document.
+fn upload_metrics(
+    telemetry: &TransferTelemetry,
+    snapshot: &UploadSnapshot<'_>,
+    outcome: Outcome,
+    error_class: &'static str,
+) -> serde_json::Value {
+    let common = CommonMetrics::new(
+        TransferIdentity::from(telemetry),
+        CommonInputs {
+            direction: Direction::Upload,
+            outcome,
+            error_class,
+            terminal: true,
+            seq: 0,
+            n_files: snapshot.n_files,
+            progress: snapshot.progress,
+        },
+    );
+    to_value(UploadMetrics::new(
+        common,
+        snapshot.dedup,
+        snapshot.progress,
+        snapshot.ingest_ms,
+        snapshot.finalize_ms,
+    ))
+}
+
+/// Builds a download document.
+fn download_metrics(
+    telemetry: &TransferTelemetry,
+    progress: &GroupProgressReport,
+    n_files: u64,
+    outcome: Outcome,
+    error_class: &'static str,
+) -> serde_json::Value {
+    let common = CommonMetrics::new(
+        TransferIdentity::from(telemetry),
+        CommonInputs {
+            direction: Direction::Download,
+            outcome,
+            error_class,
+            terminal: true,
+            seq: 0,
+            n_files,
+            progress,
+        },
+    );
+    to_value(DownloadMetrics::new(common))
+}
+
+/// Serializes, falling back to an empty object rather than panicking.
+///
+/// Unreachable in practice - every field is a scalar - but a telemetry payload must never be able
+/// to take down a transfer.
+fn to_value<T: serde::Serialize>(metrics: T) -> serde_json::Value {
+    serde_json::to_value(metrics).unwrap_or_else(|e| {
+        tracing::debug!(target: "xet_telemetry", error = %e, "failed to serialize telemetry metrics");
+        serde_json::Value::Object(Default::default())
+    })
+}
+
+/// Emits an upload session's terminal document, waiting up to `final_flush_timeout`.
+pub(crate) async fn emit_upload_terminal<T>(
+    client: &Arc<dyn Client>,
+    result: &Result<T, DataError>,
+    reported_failure: Option<(Outcome, &'static str)>,
+    snapshot: UploadSnapshot<'_>,
+) {
+    let Some(telemetry) = telemetry_of(client) else {
+        return;
+    };
+    let (outcome, error_class) = classify(result, reported_failure);
+    let metrics = upload_metrics(&telemetry, &snapshot, outcome, error_class);
+    telemetry.emit_terminal(Direction::Upload.terminal_event(), metrics).await;
+}
+
+/// Emits an upload session's terminal document from `Drop`, without waiting.
+pub(crate) fn emit_upload_abandoned(client: &Arc<dyn Client>, snapshot: UploadSnapshot<'_>) {
+    let Some(telemetry) = telemetry_of(client) else {
+        return;
+    };
+    let metrics = upload_metrics(&telemetry, &snapshot, Outcome::Aborted, ERROR_CLASS_NONE);
+    telemetry.emit_terminal_detached(Direction::Upload.terminal_event(), metrics);
+}
+
+/// Emits a download session's terminal document, waiting up to `final_flush_timeout`.
+///
+/// Takes an already-classified `(outcome, error_class)` rather than a `Result`, because the
+/// callers that know how a download ended live in `xet_pkg` and hold a `XetError`, not a
+/// [`DataError`]. Use [`classify_error`] or [`outcome_for_class`] to produce the pair.
+pub(crate) async fn emit_download_terminal(
+    client: &Arc<dyn Client>,
+    outcome: Outcome,
+    error_class: &'static str,
+    progress: &GroupProgressReport,
+    n_files: u64,
+) {
+    let Some(telemetry) = telemetry_of(client) else {
+        return;
+    };
+    let metrics = download_metrics(&telemetry, progress, n_files, outcome, error_class);
+    telemetry.emit_terminal(Direction::Download.terminal_event(), metrics).await;
+}
+
+/// Emits a download session's terminal document from `Drop`, without waiting.
+///
+/// This is the only coverage for `XetDownloadStreamGroup`, which holds a `FileDownloadSession` and
+/// never calls `finalize()`.
+///
+/// `all_items_complete` decides the outcome, because reaching `Drop` says nothing about whether the
+/// transfer succeeded - only that nobody called `finalize()`. Since `finish()` is additive and
+/// existing callers have not adopted it, the overwhelmingly common case here is a download that
+/// transferred everything and simply had no explicit finalize; reporting that as
+/// [`Outcome::Dropped`] would make `dropped` mean "probably fine" and leave a failure-rate
+/// dashboard with no usable signal. Deciding from the progress state instead keeps `dropped`
+/// meaning genuinely abandoned. See
+/// [`GroupProgress::all_items_complete`](crate::progress_tracking::GroupProgress::all_items_complete)
+/// for why that predicate is not just a byte comparison.
+pub(crate) fn emit_download_abandoned(
+    client: &Arc<dyn Client>,
+    progress: &GroupProgressReport,
+    n_files: u64,
+    all_items_complete: bool,
+) {
+    let Some(telemetry) = telemetry_of(client) else {
+        return;
+    };
+    let outcome = if all_items_complete {
+        Outcome::Ok
+    } else {
+        Outcome::Dropped
+    };
+    let metrics = download_metrics(&telemetry, progress, n_files, outcome, ERROR_CLASS_NONE);
+    telemetry.emit_terminal_detached(Direction::Download.terminal_event(), metrics);
+}
+
+/// Starts the heartbeat for an upload session.
+pub(crate) fn start_upload_heartbeat(
+    ctx: &xet_runtime::core::XetContext,
+    session: &Arc<crate::processing::FileUploadSession>,
+) {
+    let Some(telemetry) = telemetry_of(&session.client()) else {
+        return;
+    };
+    let identity = Arc::clone(&telemetry);
+
+    telemetry.start_heartbeat(ctx, session, move |session, seq| {
+        let progress = session.report();
+        // `dedup_snapshot` uses `try_lock`, so an in-flight xorb upload recording its transmitted
+        // bytes costs this one beat and nothing more.
+        let dedup = session.dedup_snapshot()?;
+        let common = CommonMetrics::new(
+            TransferIdentity::from(identity.as_ref()),
+            CommonInputs {
+                direction: Direction::Upload,
+                outcome: Outcome::InProgress,
+                error_class: ERROR_CLASS_NONE,
+                terminal: false,
+                seq,
+                n_files: session.n_items() as u64,
+                progress: &progress,
+            },
+        );
+        // `ingest_ms` is still accruing and `finalize_ms` has not started; zero rather than a
+        // half-truth, and `duration_ms` already carries elapsed time.
+        Some(to_value(UploadMetrics::new(common, &dedup, &progress, 0, 0)))
+    });
+}
+
+/// Starts the heartbeat for a download session.
+pub(crate) fn start_download_heartbeat(
+    ctx: &xet_runtime::core::XetContext,
+    session: &Arc<crate::processing::FileDownloadSession>,
+) {
+    let Some(telemetry) = telemetry_of(&session.client()) else {
+        return;
+    };
+    let identity = Arc::clone(&telemetry);
+
+    telemetry.start_heartbeat(ctx, session, move |session, seq| {
+        let progress = session.report();
+        let common = CommonMetrics::new(
+            TransferIdentity::from(identity.as_ref()),
+            CommonInputs {
+                direction: Direction::Download,
+                outcome: Outcome::InProgress,
+                error_class: ERROR_CLASS_NONE,
+                terminal: false,
+                seq,
+                n_files: session.n_items() as u64,
+                progress: &progress,
+            },
+        );
+        Some(to_value(DownloadMetrics::new(common)))
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ok_classifies_as_ok_with_no_error_class() {
+        let (outcome, class) = classify::<()>(&Ok(()), None);
+        assert_eq!(outcome, Outcome::Ok);
+        assert_eq!(class, ERROR_CLASS_NONE);
+    }
+
+    #[test]
+    fn test_failure_classifies_as_error() {
+        let (outcome, class) = classify::<()>(&Err(DataError::InternalError("boom".into())), None);
+        assert_eq!(outcome, Outcome::Error);
+        assert_eq!(class, "internal");
+    }
+
+    /// Cancellation must not land in the `error` bucket, or user interrupts inflate failure rates.
+    #[test]
+    fn test_cancellation_classifies_as_cancelled_not_error() {
+        let err = DataError::RuntimeError(xet_runtime::error::RuntimeError::KeyboardInterrupt);
+        let (outcome, class) = classify::<()>(&Err(err), None);
+        assert_eq!(outcome, Outcome::Cancelled);
+        assert_eq!(class, "cancelled");
+    }
+
+    /// A clean finalize under a caller that already failed must report the caller's failure.
+    #[test]
+    fn test_reported_failure_overrides_a_clean_finalize() {
+        let (outcome, class) = classify::<()>(&Ok(()), Some((Outcome::Error, "network")));
+        assert_eq!(outcome, Outcome::Error);
+        assert_eq!(class, "network");
+    }
+
+    /// The session's own failure is what the caller returns, so it is what gets reported.
+    #[test]
+    fn test_finalize_failure_wins_over_a_reported_failure() {
+        let result: Result<(), DataError> = Err(DataError::InternalError("boom".into()));
+        let (outcome, class) = classify(&result, Some((Outcome::Cancelled, "cancelled")));
+        assert_eq!(outcome, Outcome::Error);
+        assert_eq!(class, "internal");
+    }
+}

--- a/xet_data/src/telemetry/mod.rs
+++ b/xet_data/src/telemetry/mod.rs
@@ -15,10 +15,17 @@
 //! outcome vocabulary stays ungated because it appears in `FileDownloadSession`'s public
 //! signatures, and gating it would push `#[cfg]` onto every caller that merely names an outcome.
 
+#[cfg(not(target_family = "wasm"))]
+mod emit;
 mod outcome;
 #[cfg(not(target_family = "wasm"))]
 mod payload;
 
+#[cfg(not(target_family = "wasm"))]
+pub(crate) use emit::{
+    UploadSnapshot, emit_download_abandoned, emit_download_terminal, emit_upload_abandoned, emit_upload_terminal,
+    start_download_heartbeat, start_upload_heartbeat,
+};
 pub use outcome::{ERROR_CLASS_NONE, Outcome, classify_error, error_class, outcome_for_class};
 #[cfg(not(target_family = "wasm"))]
 pub use payload::{

--- a/xet_data/tests/test_transfer_telemetry.rs
+++ b/xet_data/tests/test_transfer_telemetry.rs
@@ -1,0 +1,409 @@
+//! End-to-end coverage for client transfer telemetry, against the simulation CAS server.
+//!
+//! These tests matter more than they look. `Client::transfer_telemetry` has a *default* body
+//! returning `None`, so a `RemoteClient` override with a mistyped signature would compile cleanly
+//! and silently never be called - no unit test in `xet_client` or `xet_data` would notice. Only
+//! driving a real transfer through a real HTTP server catches that.
+//!
+//! They also pin the wire shape. What a consumer receives is the serialized document, not the Rust
+//! struct, so the key set is asserted here as well as in the payload unit tests.
+//!
+//! Every test here is `#[serial(env)]`: several set process-global environment variables, and
+//! `serial` serializes a test against other *serial* tests, not against the parallel ones it would
+//! otherwise poison.
+
+#![cfg(feature = "simulation")]
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use serde_json::Value;
+use xet_client::cas_client::LocalTestServerBuilder;
+use xet_data::processing::configurations::TranslatorConfig;
+use xet_data::processing::test_utils::TestEnvironment;
+use xet_data::processing::{FileDownloadSession, FileUploadSession, Sha256Policy, XetFileInfo};
+use xet_runtime::config::XetConfig;
+use xet_runtime::core::XetContext;
+use xet_runtime::utils::EnvVarGuard;
+
+/// The exact key set an upload document must carry. Mirrors `UPLOAD_KEYS` in
+/// `xet_data/src/telemetry/payload.rs`, asserted here against what actually crossed the wire.
+const UPLOAD_KEYS: &[&str] = &[
+    "arch",
+    "client_version",
+    "compression_ratio",
+    "cpu_count",
+    "dedup_bytes",
+    "dedup_chunks",
+    "dedup_ratio",
+    "defrag_prevented_dedup_bytes",
+    "defrag_prevented_dedup_chunks",
+    "direction",
+    "duration_ms",
+    "endpoint_host",
+    "error_class",
+    "ewma_throughput_bps",
+    "finalize_ms",
+    "global_dedup_bytes",
+    "global_dedup_chunks",
+    "ingest_ms",
+    "logical_throughput_bps",
+    "n_files",
+    "new_bytes",
+    "new_chunks",
+    "os",
+    "outcome",
+    "peak_concurrency",
+    "schema_version",
+    "seq",
+    "shard_bytes_uploaded",
+    "shard_validation_entries",
+    "shards_completed",
+    "shards_total",
+    "terminal",
+    "throughput_bps",
+    "total_bytes",
+    "total_bytes_completed",
+    "total_chunks",
+    "transfer_bytes",
+    "transfer_bytes_completed",
+    "transfer_id",
+    "xorb_bytes_uploaded",
+];
+
+async fn upload_bytes(session: &Arc<FileUploadSession>, name: &str, data: &[u8]) -> XetFileInfo {
+    let (_id, mut cleaner) = session
+        .start_clean(Some(name.into()), Some(data.len() as u64), Sha256Policy::Compute)
+        .unwrap();
+    cleaner.add_data(data).await.unwrap();
+    cleaner.finish().await.unwrap().0
+}
+
+/// Waits for at least `n` documents to arrive.
+///
+/// Terminal documents on the finalize path are awaited by the client, but the `Drop` path and
+/// heartbeats are detached, so their arrival is inherently racy.
+async fn wait_for_docs(fetch: impl Fn() -> Vec<Value>, n: usize) -> Vec<Value> {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let docs = fetch();
+        if docs.len() >= n {
+            return docs;
+        }
+        if Instant::now() > deadline {
+            panic!("timed out waiting for {n} telemetry document(s); got {}", docs.len());
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+fn sorted_keys(metrics: &Value) -> Vec<String> {
+    let mut keys: Vec<_> = metrics
+        .as_object()
+        .expect("metrics must be an object")
+        .keys()
+        .cloned()
+        .collect();
+    keys.sort();
+    keys
+}
+
+/// Asserts the five-key envelope the server validates.
+fn assert_envelope(doc: &Value, expected_event: &str) {
+    let mut keys: Vec<_> = doc.as_object().unwrap().keys().cloned().collect();
+    keys.sort();
+    assert_eq!(keys, vec!["event", "metrics", "session_id", "time", "user_agent"]);
+
+    assert_eq!(doc["event"], expected_event);
+    assert!(doc["session_id"].as_str().is_some_and(|s| !s.is_empty()));
+    assert!(doc["user_agent"].as_str().is_some_and(|s| !s.is_empty()));
+    chrono::DateTime::parse_from_rfc3339(doc["time"].as_str().unwrap()).expect("time must be RFC3339");
+
+    // The camelCase spelling is only a server-side alias for older clients, and a body carrying
+    // both is rejected as a duplicate field.
+    assert!(doc.get("userAgent").is_none(), "must not send the camelCase spelling too");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial_test::serial(env)]
+async fn test_upload_emits_one_terminal_document() {
+    let env = TestEnvironment::new().await;
+
+    let session = FileUploadSession::new(env.config.clone()).await.unwrap();
+    upload_bytes(&session, "a.bin", &vec![0xAB; 64 * 1024]).await;
+    upload_bytes(&session, "b.bin", &vec![0xCD; 32 * 1024]).await;
+    session.finalize().await.unwrap();
+
+    let docs = env.telemetry_docs();
+    assert_eq!(docs.len(), 1, "expected exactly one terminal document, got {docs:#?}");
+
+    let doc = &docs[0];
+    assert_envelope(doc, "xet_upload_summary");
+
+    let metrics = &doc["metrics"];
+    assert_eq!(sorted_keys(metrics), UPLOAD_KEYS, "the wire key set drifted from the payload definition");
+    assert_eq!(metrics["direction"], "upload");
+    assert_eq!(metrics["outcome"], "ok");
+    assert_eq!(metrics["error_class"], "none");
+    assert_eq!(metrics["terminal"], true);
+    assert_eq!(metrics["seq"], 0);
+    assert_eq!(metrics["n_files"], 2);
+    assert_eq!(metrics["total_bytes"], 96 * 1024);
+    assert!(metrics["new_bytes"].as_u64().unwrap() > 0);
+    assert!(metrics["xorb_bytes_uploaded"].as_u64().unwrap() > 0);
+    assert!(metrics["endpoint_host"].as_str().unwrap().starts_with("127.0.0.1"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial_test::serial(env)]
+async fn test_download_emits_one_terminal_document() {
+    let env = TestEnvironment::new().await;
+
+    let data = vec![0x5A; 128 * 1024];
+    let upload = FileUploadSession::new(env.config.clone()).await.unwrap();
+    let xfi = upload_bytes(&upload, "f.bin", &data).await;
+    upload.finalize().await.unwrap();
+
+    let download = FileDownloadSession::new(env.config.clone(), None).await.unwrap();
+    let out = env.base_dir.join("out.bin");
+    download.download_file(&xfi, &out).await.unwrap();
+    download.finalize().await.unwrap();
+
+    assert_eq!(std::fs::read(&out).unwrap(), data);
+
+    let docs = env.telemetry_docs();
+    assert_eq!(docs.len(), 2, "expected one upload and one download document, got {docs:#?}");
+
+    let doc = docs
+        .iter()
+        .find(|d| d["event"] == "xet_download_summary")
+        .expect("no download document");
+    assert_envelope(doc, "xet_download_summary");
+
+    let metrics = &doc["metrics"];
+    assert_eq!(metrics["direction"], "download");
+    assert_eq!(metrics["outcome"], "ok");
+    assert_eq!(metrics["terminal"], true);
+    assert_eq!(metrics["n_files"], 1);
+    assert!(metrics.get("expansion_ratio").is_some(), "download-only key missing");
+    // Upload-only keys must not appear on a download document.
+    assert!(metrics.get("dedup_ratio").is_none());
+    assert!(metrics.get("ingest_ms").is_none());
+}
+
+/// Upload and download in the same session share a `session_id` but must be distinguishable.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial_test::serial(env)]
+async fn test_transfer_id_separates_directions() {
+    let env = TestEnvironment::new().await;
+
+    let upload = FileUploadSession::new(env.config.clone()).await.unwrap();
+    let xfi = upload_bytes(&upload, "f.bin", &vec![0x11; 16 * 1024]).await;
+    upload.finalize().await.unwrap();
+
+    let download = FileDownloadSession::new(env.config.clone(), None).await.unwrap();
+    download.download_file(&xfi, &env.base_dir.join("o.bin")).await.unwrap();
+    download.finalize().await.unwrap();
+
+    let docs = env.telemetry_docs();
+    assert_eq!(docs.len(), 2);
+
+    let ids: Vec<_> = docs.iter().map(|d| d["metrics"]["transfer_id"].as_str().unwrap()).collect();
+    assert_ne!(ids[0], ids[1], "each transfer needs its own id");
+    let directions: Vec<_> = docs.iter().map(|d| d["metrics"]["direction"].as_str().unwrap()).collect();
+    assert!(directions.contains(&"upload") && directions.contains(&"download"));
+}
+
+/// A download that ended badly must say so. `finalize()` alone can only ever report `ok`, so a
+/// failed transfer has to go through `finalize_with` or every document claims success and the
+/// failure-rate signal is silently always zero.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial_test::serial(env)]
+async fn test_failed_download_reports_error_outcome_and_class() {
+    let env = TestEnvironment::new().await;
+
+    let download = FileDownloadSession::new(env.config.clone(), None).await.unwrap();
+    download
+        .finalize_with(xet_data::telemetry::Outcome::Error, "network")
+        .await
+        .unwrap();
+
+    let docs = env.telemetry_docs();
+    assert_eq!(docs.len(), 1, "expected one terminal document, got {docs:#?}");
+
+    let doc = &docs[0];
+    assert_envelope(doc, "xet_download_summary");
+    assert_eq!(doc["metrics"]["outcome"], "error");
+    assert_eq!(doc["metrics"]["error_class"], "network");
+    assert_eq!(doc["metrics"]["terminal"], true);
+}
+
+/// Cancellation is a user action, so it must not land in the `error` bucket that failure-rate
+/// alerts watch.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial_test::serial(env)]
+async fn test_cancelled_download_is_not_counted_as_an_error() {
+    let env = TestEnvironment::new().await;
+
+    let outcome = xet_data::telemetry::outcome_for_class("cancelled");
+    assert_eq!(outcome, xet_data::telemetry::Outcome::Cancelled);
+
+    let download = FileDownloadSession::new(env.config.clone(), None).await.unwrap();
+    download.finalize_with(outcome, "cancelled").await.unwrap();
+
+    let docs = env.telemetry_docs();
+    assert_eq!(docs[0]["metrics"]["outcome"], "cancelled");
+    assert_eq!(docs[0]["metrics"]["error_class"], "cancelled");
+}
+
+/// The `Drop` fallback must fire even when the last reference is released from a thread that is
+/// not inside a tokio runtime.
+///
+/// This is the shape every embedder produces - notably the Python bindings, where the interpreter
+/// thread drops the session. A `Handle::try_current()` guard here silently disabled download
+/// telemetry entirely in production while every in-process test still passed, because tests drop
+/// inside an async block where a runtime context happens to exist.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial_test::serial(env)]
+async fn test_download_session_dropped_off_runtime_still_reports() {
+    let env = TestEnvironment::new().await;
+
+    let download = FileDownloadSession::new(env.config.clone(), None).await.unwrap();
+    // A plain OS thread has no ambient tokio runtime, so `Handle::try_current()` fails there.
+    std::thread::spawn(move || {
+        assert!(
+            tokio::runtime::Handle::try_current().is_err(),
+            "this test is meaningless if the spawning thread has a runtime context"
+        );
+        drop(download);
+    })
+    .join()
+    .unwrap();
+
+    let docs = wait_for_docs(|| env.telemetry_docs(), 1).await;
+    assert_envelope(&docs[0], "xet_download_summary");
+    assert_eq!(docs[0]["metrics"]["outcome"], "dropped");
+}
+
+/// A download session dropped without `finalize()` still reports.
+///
+/// `dropped` rather than `ok` because this session never registered a download: the `Drop` path
+/// infers its outcome from progress, and an empty session has completed nothing. A session that
+/// transferred everything and skipped `finalize()` reports `ok` instead - see
+/// `stream_group_without_finish_reports_ok_when_fully_read` in `xet_pkg`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial_test::serial(env)]
+async fn test_dropped_download_session_reports_as_dropped() {
+    let env = TestEnvironment::new().await;
+
+    {
+        let download = FileDownloadSession::new(env.config.clone(), None).await.unwrap();
+        drop(download);
+    }
+
+    let docs = wait_for_docs(|| env.telemetry_docs(), 1).await;
+    let doc = &docs[0];
+    assert_envelope(doc, "xet_download_summary");
+    assert_eq!(doc["metrics"]["outcome"], "dropped");
+    assert_eq!(doc["metrics"]["terminal"], true);
+}
+
+/// An upload session dropped without finalizing reports as aborted.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial_test::serial(env)]
+async fn test_dropped_upload_session_reports_as_aborted() {
+    let env = TestEnvironment::new().await;
+
+    {
+        let upload = FileUploadSession::new(env.config.clone()).await.unwrap();
+        upload_bytes(&upload, "a.bin", &vec![0x22; 8 * 1024]).await;
+        drop(upload);
+    }
+
+    let docs = wait_for_docs(|| env.telemetry_docs(), 1).await;
+    let doc = &docs[0];
+    assert_envelope(doc, "xet_upload_summary");
+    assert_eq!(doc["metrics"]["outcome"], "aborted");
+    assert_eq!(doc["metrics"]["finalize_ms"], 0, "an abandoned session never reached finalization");
+}
+
+/// A session that finalizes normally and is then dropped must not emit twice.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial_test::serial(env)]
+async fn test_finalize_then_drop_emits_once() {
+    let env = TestEnvironment::new().await;
+
+    {
+        let session = FileUploadSession::new(env.config.clone()).await.unwrap();
+        upload_bytes(&session, "a.bin", &vec![0x33; 8 * 1024]).await;
+        session.finalize().await.unwrap();
+        // `session` drops here, after finalize already reported.
+    }
+
+    // Give any (incorrect) detached Drop emission time to land.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert_eq!(env.telemetry_docs().len(), 1, "finalize and Drop both emitted");
+}
+
+/// Builds an environment with an explicit config, for the gating tests.
+async fn env_with_config(
+    config: XetConfig,
+) -> (xet_client::cas_client::LocalTestServer, Arc<TranslatorConfig>, tempfile::TempDir) {
+    let temp = tempfile::TempDir::new().unwrap();
+    let ctx = XetContext::with_config(config).unwrap();
+    let server = LocalTestServerBuilder::new().start().await;
+    let translator = Arc::new(TranslatorConfig::test_server_config(&ctx, server.http_endpoint(), temp.path()).unwrap());
+    (server, translator, temp)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial_test::serial(env)]
+async fn test_disabled_emits_nothing() {
+    let mut config = XetConfig::default();
+    config.telemetry.enabled = false;
+    let (server, translator, _temp) = env_with_config(config).await;
+
+    let session = FileUploadSession::new(translator).await.unwrap();
+    upload_bytes(&session, "a.bin", &vec![0x44; 16 * 1024]).await;
+    session.finalize().await.unwrap();
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert!(server.telemetry_docs().is_empty(), "telemetry was disabled but documents were sent");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial_test::serial(env)]
+async fn test_dry_run_emits_nothing() {
+    let (server, translator, _temp) = env_with_config(XetConfig::default()).await;
+
+    let session = FileUploadSession::dry_run(translator).await.unwrap();
+    upload_bytes(&session, "a.bin", &vec![0x66; 16 * 1024]).await;
+    session.finalize().await.unwrap();
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert!(server.telemetry_docs().is_empty(), "a dry run must not report");
+}
+
+/// Every metric value must be a scalar, and none may be null. `serde_json` renders NaN and
+/// infinity as null, and one such document poisons the field's type for a consumer.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial_test::serial(env)]
+async fn test_wire_values_are_all_non_null_scalars() {
+    let env = TestEnvironment::new().await;
+
+    let session = FileUploadSession::new(env.config.clone()).await.unwrap();
+    // Zero-byte file: the degenerate case most likely to produce a division by zero.
+    upload_bytes(&session, "empty.bin", &[]).await;
+    session.finalize().await.unwrap();
+
+    let docs = env.telemetry_docs();
+    assert_eq!(docs.len(), 1);
+
+    for (key, value) in docs[0]["metrics"].as_object().unwrap() {
+        assert!(!value.is_null(), "{key} arrived as null");
+        assert!(
+            matches!(value, Value::Bool(_) | Value::String(_) | Value::Number(_)),
+            "{key} arrived as a non-scalar: {value:?}"
+        );
+    }
+}


### PR DESCRIPTION
Part 4 of 6 of the client transfer telemetry stack, split out of #919 for review. Each PR in the stack compiles and passes CI on its own.

Wires the payloads to real transfers. Upload and download sessions report a
terminal document on finalize, an abandoned one from Drop, and periodic
heartbeats for transfers long enough to be worth observing in flight.

A download's Drop outcome is inferred from its progress rather than assumed:
GroupProgress::all_items_complete checks size_finalized as well as the byte
counts, because for an open-ended stream range total_bytes tracks only what the
prefetcher has found so far. A consumer that catches up to the prefetch
frontier makes the counts equal mid-transfer, so the byte comparison alone
would report an abandoned download as a finished one.

n_items counts registered items without snapshotting every one of them, which
matters on the heartbeat path where the count is all that is wanted.

Adds the simulation server's telemetry receive route, which exists so these
integration tests can assert what is actually delivered. The tests also guard
the Client::transfer_telemetry override: it has a default body, so a mistyped
signature would compile and silently never be called.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session lifecycle (`finalize`, `Drop`, heartbeats) and outcome classification for metrics; behavior is best-effort and should not fail transfers, but mis-inferred Drop outcomes or duplicate/missing events would skew observability.
> 
> **Overview**
> **Connects real transfers to client transfer telemetry** (non-wasm): upload and download sessions now start periodic heartbeats at creation, send a terminal summary on `finalize` / `finalize_with`, and send a best-effort detached terminal when dropped without finalizing.
> 
> Upload telemetry runs inside `FileUploadSession::finalize_impl` (including optional **reported failure** when the caller already knows the commit failed), tracks `ingest_ms` / `finalize_ms`, and uses non-blocking dedup snapshots for heartbeats and `Drop`. Download adds `finalize_with` for explicit outcomes; `Drop` infers **ok vs dropped** via new `GroupProgress::all_items_complete()` (requires `size_finalized`, not byte equality alone).
> 
> Adds **`xet_data::telemetry::emit`** to build payloads and call `TransferTelemetry`, plus **`n_items`** on progress types for cheap counts.
> 
> The **simulation local server** gains `POST /v1/telemetry` with in-memory recorded docs exposed on `LocalTestServer` / `TestEnvironment` for **`test_transfer_telemetry`** end-to-end wire-shape and gating tests (disabled telemetry, dry run, no double-emit after finalize).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d51cbedb70872ed18934489b2d8e8e60e4174e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->