### PR TITLE
feat(telemetry): classify xet_pkg errors and report from session groups

### DIFF
--- a/xet_pkg/src/error.rs
+++ b/xet_pkg/src/error.rs
@@ -1,3 +1,4 @@
+use http::StatusCode;
 use thiserror::Error;
 use xet_client::ClientError;
 use xet_core_structures::CoreError;
@@ -44,9 +45,26 @@ pub enum XetError {
     #[error("Authentication error: {0}")]
     Authentication(String),
 
-    /// Network-level failures: DNS, HTTP 5xx, connection reset, etc.
+    /// Network-level failures: DNS, connection reset, TLS, and any HTTP failure whose status did
+    /// not survive to this point.
     #[error("Network error: {0}")]
     Network(String),
+
+    /// The server shed load: HTTP 429.
+    ///
+    /// Split out from [`Network`](Self::Network) because a 429 is not a network fault - it is the
+    /// server asking for less traffic, and it needs to be distinguishable when reading failure
+    /// rates. Maps to the same Python exception as `Network`.
+    #[error("Rate limited: {0}")]
+    RateLimited(String),
+
+    /// The server failed to serve the request: HTTP 5xx.
+    ///
+    /// Split out from [`Network`](Self::Network) for the same reason as
+    /// [`RateLimited`](Self::RateLimited): a server-side failure and a client-side connection
+    /// problem call for different responses. Maps to the same Python exception as `Network`.
+    #[error("Server error: {0}")]
+    ServerError(String),
 
     /// A network request timed out.
     #[error("Timeout: {0}")]
@@ -84,6 +102,53 @@ pub enum XetError {
 impl XetError {
     pub fn other(msg: impl std::fmt::Display) -> Self {
         Self::Internal(msg.to_string())
+    }
+
+    /// Classifies this error for telemetry as an `(outcome, error_class)` pair.
+    ///
+    /// By the time a group finishes, the originating [`DataError`] has usually been flattened into
+    /// a string variant here, so `xet_data`'s `error_class` cannot be applied directly. This maps
+    /// the surviving categories onto the *same* coarse class vocabulary, so documents produced by
+    /// this path aggregate together with those classified inside `xet_data`.
+    ///
+    /// That aggregation depends on HTTP status surviving the flattening, which is why
+    /// [`RateLimited`](Self::RateLimited) and [`ServerError`](Self::ServerError) exist as distinct
+    /// variants. Collapsing them into [`Network`](Self::Network) - as this type used to - made
+    /// `rate_limited` and `server_error` unreachable for downloads while uploads still reported
+    /// them, so a 429 meant two different things depending on the direction.
+    ///
+    /// One gap remains on purpose: a 404 that arrives as a `reqwest` status still classifies as
+    /// `network` here, whereas `xet_data` maps it to `not_found`. Routing it to
+    /// [`NotFound`](Self::NotFound) would change the Python exception type callers see, which is a
+    /// user-visible change rather than a telemetry fix.
+    ///
+    /// Deliberately coarse, matching `xet_data::telemetry::error_class`: the question is "are
+    /// downloads failing more than they were, and is it the network or the server", and error text
+    /// can contain paths, so none of it is carried.
+    pub fn telemetry_class(&self) -> (xet_data::telemetry::Outcome, &'static str) {
+        use xet_data::telemetry::outcome_for_class;
+
+        let class = match self {
+            // Cancellation is a user action, not a failure. `outcome_for_class` maps these to
+            // `Outcome::Cancelled` so they stay out of failure-rate alerts.
+            XetError::KeyboardInterrupt | XetError::UserCancelled(_) | XetError::Cancelled(_) => "cancelled",
+            XetError::Authentication(_) => "auth",
+            XetError::Network(_) => "network",
+            XetError::RateLimited(_) => "rate_limited",
+            XetError::ServerError(_) => "server_error",
+            XetError::Timeout(_) => "timeout",
+            XetError::NotFound(_) => "not_found",
+            XetError::DataIntegrity(_) => "format",
+            XetError::Io(_) => "io",
+            XetError::Configuration(_) | XetError::InvalidTaskID(_) | XetError::WrongRuntimeMode(_) => "internal",
+            XetError::Internal(_) => "internal",
+            // A task failed and its cause was reduced to a message; the class is genuinely
+            // unknown. Matched exhaustively on purpose - a new variant should not silently
+            // become "other" without someone deciding that is right.
+            XetError::TaskError(_) | XetError::PreviousTaskError(_) | XetError::AlreadyCompleted => "other",
+        };
+
+        (outcome_for_class(class), class)
     }
 
     pub fn wrong_mode(msg: impl std::fmt::Display) -> Self {
@@ -125,8 +190,15 @@ impl XetError {
                 XetError::Authentication(ce.to_string())
             },
             ClientError::ReqwestError(e, _) if e.is_timeout() => XetError::Timeout(ce.to_string()),
-            ClientError::ReqwestError(_, _) | ClientError::ReqwestMiddlewareError(_) => {
-                XetError::Network(ce.to_string())
+            // Status wins over transport, matching `xet_data::telemetry::error_class`. Without
+            // this, every HTTP failure flattened to `Network` and a download could never report
+            // `rate_limited` or `server_error` - the two classes that distinguish "the server is
+            // shedding load" from "the network is broken". `ClientError::status()` covers the
+            // middleware variant too, where the status is otherwise unreachable.
+            ClientError::ReqwestError(_, _) | ClientError::ReqwestMiddlewareError(_) => match ce.status() {
+                Some(StatusCode::TOO_MANY_REQUESTS) => XetError::RateLimited(ce.to_string()),
+                Some(status) if status.is_server_error() => XetError::ServerError(ce.to_string()),
+                _ => XetError::Network(ce.to_string()),
             },
             ClientError::FileNotFound(_) | ClientError::XORBNotFound(_) => XetError::NotFound(ce.to_string()),
             ClientError::ConfigurationError(_)
@@ -302,7 +374,12 @@ impl From<XetError> for pyo3::PyErr {
             XetError::KeyboardInterrupt => PyKeyboardInterrupt::new_err(msg),
             XetError::Authentication(_) => XetAuthenticationError::new_err(msg),
             XetError::NotFound(_) => XetObjectNotFoundError::new_err(msg),
-            XetError::Network(_) => PyConnectionError::new_err(msg),
+            // 429 and 5xx deliberately raise the same Python exception as a plain network failure:
+            // they are split out for telemetry classification, and remapping them would change the
+            // exception type callers already catch.
+            XetError::Network(_) | XetError::RateLimited(_) | XetError::ServerError(_) => {
+                PyConnectionError::new_err(msg)
+            },
             XetError::Timeout(_) => PyTimeoutError::new_err(msg),
             XetError::Io(_) => PyOSError::new_err(msg),
             XetError::Configuration(_) | XetError::InvalidTaskID(_) => PyValueError::new_err(msg),
@@ -360,6 +437,61 @@ mod tests {
     fn client_nested_format_maps_using_format_rules() {
         let err = XetError::from(ClientError::FormatError(CoreError::InvalidRange));
         assert!(matches!(err, XetError::Configuration(_)));
+    }
+
+    /// Builds a `ClientError` carrying a real `reqwest` error with `status`, which is the only way
+    /// the status-based classification can be exercised - `reqwest::Error` cannot be constructed
+    /// directly, so it has to come from a response.
+    fn client_error_with_status(status: u16) -> ClientError {
+        use xet_client::cas_client::exports::reqwest;
+
+        let response = http::Response::builder().status(status).body(String::new()).unwrap();
+        let err = reqwest::Response::from(response)
+            .error_for_status()
+            .expect_err("a 4xx/5xx response must produce an error");
+        ClientError::ReqwestError(err, "cas.example.invalid".to_string())
+    }
+
+    /// A 429 is the server shedding load, not a network fault, and it has to stay distinguishable
+    /// all the way to the telemetry class - see `telemetry_class`.
+    #[test]
+    fn client_429_maps_to_rate_limited() {
+        let err = XetError::from(client_error_with_status(429));
+        assert!(matches!(err, XetError::RateLimited(_)), "got {err:?}");
+        assert_eq!(err.telemetry_class(), (xet_data::telemetry::Outcome::Error, "rate_limited"));
+    }
+
+    #[test]
+    fn client_5xx_maps_to_server_error() {
+        for status in [500, 502, 503] {
+            let err = XetError::from(client_error_with_status(status));
+            assert!(matches!(err, XetError::ServerError(_)), "status {status} gave {err:?}");
+            assert_eq!(err.telemetry_class(), (xet_data::telemetry::Outcome::Error, "server_error"));
+        }
+    }
+
+    /// The deliberate remaining gap, pinned so it is a decision rather than a surprise: a 404
+    /// arriving as a `reqwest` status stays `network`, because routing it to `NotFound` would change
+    /// the Python exception type callers already catch.
+    #[test]
+    fn client_404_status_stays_network() {
+        let err = XetError::from(client_error_with_status(404));
+        assert!(matches!(err, XetError::Network(_)), "got {err:?}");
+        assert_eq!(err.telemetry_class().1, "network");
+    }
+
+    /// The whole point of A4: every class the upload path can report for an HTTP failure is now
+    /// reachable from the download path too, so a 429 does not mean two different things depending
+    /// on direction.
+    #[test]
+    fn http_failure_classes_match_the_upload_side_vocabulary() {
+        use xet_data::telemetry::classify_error;
+
+        for status in [429, 500] {
+            let via_download = XetError::from(client_error_with_status(status)).telemetry_class();
+            let via_upload = classify_error(&DataError::ClientError(client_error_with_status(status)));
+            assert_eq!(via_download, via_upload, "status {status} classifies differently per direction");
+        }
     }
 
     #[test]

--- a/xet_pkg/src/legacy/data_client.rs
+++ b/xet_pkg/src/legacy/data_client.rs
@@ -177,7 +177,12 @@ pub async fn download_async(
 
     let mut paths = Vec::with_capacity(tasks.len());
     for ((file_path, handle), bridge) in tasks.into_iter().zip(bridges) {
-        handle.await??;
+        // Not `handle.await??`: the session has to be finalized before the error propagates, or a
+        // failed download returns early and reports nothing.
+        if let Err(e) = handle.await.map_err(DataError::from).and_then(|r| r.map(|_| ())) {
+            finalize_download_session(&session, Some(&e)).await;
+            return Err(e);
+        }
 
         if let Some(bridge) = bridge {
             bridge.finalize().await;
@@ -186,5 +191,20 @@ pub async fn download_async(
         paths.push(file_path);
     }
 
+    finalize_download_session(&session, None).await;
+
     Ok(paths)
+}
+
+/// Finalizes a download session, reporting how it ended.
+///
+/// Telemetry is best-effort, so a double-finalize `Err` is discarded rather than propagated.
+async fn finalize_download_session(session: &Arc<FileDownloadSession>, error: Option<&DataError>) {
+    let _ = match error {
+        None => session.finalize().await,
+        Some(e) => {
+            let (outcome, class) = xet_data::telemetry::classify_error(e);
+            session.finalize_with(outcome, class).await
+        },
+    };
 }

--- a/xet_pkg/src/xet_session/download_stream_group.rs
+++ b/xet_pkg/src/xet_session/download_stream_group.rs
@@ -16,6 +16,7 @@ use std::sync::{Arc, Mutex};
 
 use tracing::info;
 use xet_data::processing::{FileDownloadSession, XetFileInfo};
+use xet_data::telemetry::{ERROR_CLASS_NONE, Outcome};
 use xet_runtime::utils::UniqueId;
 
 use super::auth_group_builder::{AuthGroupBuilder, AuthOptions};
@@ -157,6 +158,78 @@ impl XetDownloadStreamGroup {
     /// Returns the unique ID for this stream group.
     pub(super) fn id(&self) -> UniqueId {
         self.inner.group_id
+    }
+
+    /// Marks the group as finished, releasing its session and reporting transfer telemetry.
+    ///
+    /// Streams are created and consumed independently, so unlike
+    /// [`XetFileDownloadGroup`](super::XetFileDownloadGroup) there is no point at which the group
+    /// can tell on its own that the caller is done. Calling this says so explicitly.
+    ///
+    /// Entirely optional: a group that is never finished still works and still reports. Its `Drop`
+    /// path derives the outcome from what actually transferred, so a group whose streams were all
+    /// read to the end reports [`Outcome::Ok`](xet_data::telemetry::Outcome::Ok) either way, and
+    /// only a genuinely partial transfer reports
+    /// [`Outcome::Dropped`](xet_data::telemetry::Outcome::Dropped). Existing callers need no change.
+    ///
+    /// What calling this does buy:
+    ///
+    /// - **Delivery.** The terminal document is awaited here, bounded by `final_flush_timeout`, whereas the `Drop` path
+    ///   is detached and is frequently lost - host processes routinely exit within milliseconds of a transfer
+    ///   returning.
+    /// - **An explicit outcome rather than an inferred one.** This reports success unconditionally, so it suits a
+    ///   caller whose notion of "done" is not "every byte of every stream" - a deliberately partial read that `Drop`
+    ///   would classify as `Dropped`.
+    /// - **Closing the group**, which nothing else does.
+    ///
+    /// Consume every stream you intend to consume first — the report is a snapshot taken here, and
+    /// the group is **closed** afterwards, so starting a new stream returns an error. Streams
+    /// already handed out remain usable. Calling this more than once is a no-op.
+    ///
+    /// For a caller giving up rather than completing, use [`abort`](Self::abort) instead.
+    pub async fn finish(&self) {
+        info!(group_id = %self.id(), "Download stream group finish");
+        let _ = self.inner.download_session.finalize_with(Outcome::Ok, ERROR_CLASS_NONE).await;
+    }
+
+    /// Blocking version of [`finish`](Self::finish).
+    ///
+    /// # Panics
+    ///
+    /// Panics if called from within a tokio async runtime on an Owned-mode session.
+    #[cfg(not(target_family = "wasm"))]
+    pub fn finish_blocking(&self) -> Result<(), XetError> {
+        info!(group_id = %self.id(), "Download stream group finish");
+        let session = self.inner.download_session.clone();
+        self.task_runtime.bridge_sync("download_stream_group_finish", async move {
+            let _ = session.finalize_with(Outcome::Ok, ERROR_CLASS_NONE).await;
+            Ok(())
+        })
+    }
+
+    /// Cancels every active stream in this group and closes it, abandoning the transfer.
+    ///
+    /// The counterpart to [`finish`](Self::finish) for a caller that is giving up rather than
+    /// completing - notably a `with` block exiting on an exception.
+    ///
+    /// The group is **closed** afterwards, like [`finish`](Self::finish): this cancels the group's
+    /// task subtree, so `download_stream`, `download_unordered_stream`, and `finish` all return
+    /// [`XetError::UserCancelled`]. Only the subtree under this group is cancelled, so the rest of
+    /// the session keeps running.
+    ///
+    /// Emits **no** telemetry, matching
+    /// [`XetFileDownloadGroup::abort`](super::XetFileDownloadGroup::abort). Calling `finish` here
+    /// instead would report [`Outcome::Ok`](xet_data::telemetry::Outcome::Ok) and record a failed
+    /// transfer as a successful one. Cancellation is not finalization: the session is left
+    /// unfinalized so its `Drop` derives the outcome from what actually transferred - `dropped` for
+    /// a genuinely partial transfer, and `ok` only when every stream really was consumed to its
+    /// end, which is the honest answer when the transfer completed and the exception came from the
+    /// caller's own code.
+    pub fn abort(&self) -> Result<(), XetError> {
+        info!(group_id = %self.id(), "Download stream group abort");
+        self.task_runtime.cancel_subtree()?;
+        self.inner.download_session.abort_active_streams();
+        Ok(())
     }
 
     fn session(&self) -> &XetSession {

--- a/xet_pkg/src/xet_session/file_download_group.rs
+++ b/xet_pkg/src/xet_session/file_download_group.rs
@@ -254,10 +254,15 @@ impl XetFileDownloadGroup {
         info!(group_id = %self.id(), "Download group finish");
         let inner = self.inner.clone();
         let download_session = self.inner.download_session.clone();
-        let downloads = self
+        // Not `?` on the bridge: the result is needed to finalize the session before it is
+        // propagated, otherwise a failed download - the case most worth reporting - would return
+        // early and emit nothing.
+        let result = self
             .task_runtime
             .bridge_async_finalizing("download_finish", false, async move { inner.handle_finish().await })
-            .await?;
+            .await;
+        finalize_download_session(&download_session, &result).await;
+        let downloads = result?;
         let progress = download_session.report();
         Ok(XetDownloadGroupReport { progress, downloads })
     }
@@ -306,12 +311,33 @@ impl XetFileDownloadGroup {
         info!(group_id = %self.id(), "Download group finish");
         let inner = self.inner.clone();
         let download_session = self.inner.download_session.clone();
+        // Finalize *inside* the bridged future: it is async, and this is the last point at which
+        // an async context is available before the result is propagated to a sync caller.
+        let ds = download_session.clone();
         let downloads = self
             .task_runtime
-            .bridge_sync_finalizing("download_finish_blocking", false, async move { inner.handle_finish().await })?;
+            .bridge_sync_finalizing("download_finish_blocking", false, async move {
+                let result = inner.handle_finish().await;
+                finalize_download_session(&ds, &result).await;
+                result
+            })?;
         let progress = download_session.report();
         Ok(XetDownloadGroupReport { progress, downloads })
     }
+}
+
+/// Finalizes `session`, reporting how the group actually ended.
+///
+/// Telemetry is best-effort, so the `Err` from a double-finalize is discarded: a session may
+/// already have been finalized by a concurrent path, and that is not a caller error.
+pub(super) async fn finalize_download_session<T>(session: &Arc<FileDownloadSession>, result: &Result<T, XetError>) {
+    let _ = match result {
+        Ok(_) => session.finalize().await,
+        Err(e) => {
+            let (outcome, class) = e.telemetry_class();
+            session.finalize_with(outcome, class).await
+        },
+    };
 }
 
 pub(super) struct XetFileDownloadGroupInner {

--- a/xet_pkg/src/xet_session/upload_commit.rs
+++ b/xet_pkg/src/xet_session/upload_commit.rs
@@ -296,7 +296,16 @@ impl XetUploadCommitInner {
             }
         }
 
-        let finalize_result = self.upload_session.clone().finalize_with_report().await;
+        let session = self.upload_session.clone();
+        let finalize_result = match &first_error {
+            None => session.finalize_with_report().await,
+            // This commit is going to return `first_error`, so the session must not report `ok`
+            // just because its own finalize succeeded.
+            Some(e) => {
+                let (outcome, class) = e.telemetry_class();
+                session.finalize_with(outcome, class).await
+            },
+        };
         let (dedup_metrics, progress) = match finalize_result {
             Ok(v) => v,
             Err(e) => return Err(e.into()),

--- a/xet_pkg/tests/test_download_telemetry.rs
+++ b/xet_pkg/tests/test_download_telemetry.rs
@@ -1,0 +1,319 @@
+//! Telemetry coverage driven through the *public group API*, not the session underneath it.
+//!
+//! `xet_data`'s telemetry tests call `FileDownloadSession::finalize()` directly. That proves the
+//! emit machinery works, but it cannot prove anything about whether a real caller ever reaches it -
+//! and for a long time none did: `XetFileDownloadGroup::finish()` read the session's progress
+//! report and returned without finalizing, so downloads through the Python bindings emitted no
+//! telemetry at all while every test still passed.
+//!
+//! These tests therefore go through `finish_blocking()` / `finish()` and assert on what the server
+//! received. Keep them that way: a test that calls `finalize()` itself re-opens the same gap.
+
+#![cfg(feature = "simulation")]
+
+use std::fs;
+use std::time::{Duration, Instant};
+
+use serde_json::Value;
+use serial_test::serial;
+use tempfile::{TempDir, tempdir};
+use xet::xet_session::{Sha256Policy, XetFileInfo, XetSession, XetSessionBuilder};
+use xet_client::cas_client::{LocalTestServer, LocalTestServerBuilder};
+
+/// Starts a simulation CAS server on its own runtime.
+///
+/// The tests below are deliberately *not* `#[tokio::test]`: `finish_blocking` panics inside a
+/// tokio runtime, and the whole point is to exercise the blocking path the bindings use. The
+/// server still needs an async context to start, so it gets a dedicated one.
+fn start_server() -> (LocalTestServer, tokio::runtime::Runtime) {
+    let rt = tokio::runtime::Builder::new_multi_thread().enable_all().build().unwrap();
+    let server = rt.block_on(async { LocalTestServerBuilder::new().start().await });
+    (server, rt)
+}
+
+fn upload_bytes_sync(session: &XetSession, endpoint: &str, data: &[u8], name: &str) -> XetFileInfo {
+    let commit = session
+        .new_upload_commit()
+        .unwrap()
+        .with_endpoint(endpoint)
+        .build_blocking()
+        .unwrap();
+    let handle = commit
+        .upload_bytes_blocking(data.to_vec(), Sha256Policy::Compute, Some(name.into()))
+        .unwrap();
+    let file_meta = handle.finalize_ingestion_blocking().unwrap();
+    commit.commit_blocking().unwrap();
+    file_meta.xet_info
+}
+
+/// Waits for at least `n` documents. The terminal send is awaited by the client, but a document
+/// still has to cross a socket, so a bare read can race.
+fn wait_for_docs(server: &LocalTestServer, n: usize) -> Vec<Value> {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let docs = server.telemetry_docs();
+        if docs.len() >= n {
+            return docs;
+        }
+        assert!(Instant::now() < deadline, "timed out waiting for {n} telemetry document(s); got {}", docs.len());
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn download_doc(docs: &[Value]) -> &Value {
+    docs.iter()
+        .find(|d| d["event"] == "xet_download_summary")
+        .unwrap_or_else(|| panic!("no download document among {docs:#?}"))
+}
+
+/// The regression test for the gap itself: finishing a download group must emit.
+#[test]
+#[serial(env)]
+fn finish_blocking_emits_a_download_document() {
+    let temp: TempDir = tempdir().unwrap();
+    let (server, _rt) = start_server();
+    let endpoint = server.http_endpoint();
+
+    let session = XetSessionBuilder::new().build().unwrap();
+    let data = vec![0x5Au8; 96 * 1024];
+    let file_info = upload_bytes_sync(&session, endpoint, &data, "f.bin");
+
+    let dest = temp.path().join("f.out");
+    let group = session
+        .new_file_download_group()
+        .unwrap()
+        .with_endpoint(endpoint)
+        .build_blocking()
+        .unwrap();
+    group.download_file_to_path_blocking(file_info, dest.clone()).unwrap();
+    group.finish_blocking().unwrap();
+
+    assert_eq!(fs::read(&dest).unwrap(), data, "the download itself must still work");
+
+    let docs = wait_for_docs(&server, 2);
+    let doc = download_doc(&docs);
+
+    assert_eq!(doc["metrics"]["direction"], "download");
+    assert_eq!(doc["metrics"]["outcome"], "ok");
+    assert_eq!(doc["metrics"]["error_class"], "none");
+    assert_eq!(doc["metrics"]["terminal"], true);
+    assert_eq!(doc["metrics"]["n_files"], 1);
+    assert_eq!(doc["metrics"]["total_bytes"], data.len());
+}
+
+/// Exactly one document per group: `finish` must not emit a second one on top of `Drop`.
+#[test]
+#[serial(env)]
+fn finishing_then_dropping_emits_one_document() {
+    let temp: TempDir = tempdir().unwrap();
+    let (server, _rt) = start_server();
+    let endpoint = server.http_endpoint();
+
+    let session = XetSessionBuilder::new().build().unwrap();
+    let data = vec![0x11u8; 32 * 1024];
+    let file_info = upload_bytes_sync(&session, endpoint, &data, "g.bin");
+
+    {
+        let group = session
+            .new_file_download_group()
+            .unwrap()
+            .with_endpoint(endpoint)
+            .build_blocking()
+            .unwrap();
+        group
+            .download_file_to_path_blocking(file_info, temp.path().join("g.out"))
+            .unwrap();
+        group.finish_blocking().unwrap();
+    }
+
+    let docs = wait_for_docs(&server, 2);
+    // Give a stray Drop-path document time to show up before asserting there is none.
+    std::thread::sleep(Duration::from_millis(300));
+
+    let downloads: Vec<_> = server
+        .telemetry_docs()
+        .into_iter()
+        .filter(|d| d["event"] == "xet_download_summary")
+        .collect();
+    assert_eq!(downloads.len(), 1, "expected exactly one download document, got {downloads:#?}");
+    let _ = docs;
+}
+
+/// A stream group has no natural completion point, so it gets an explicit `finish`.
+#[test]
+#[serial(env)]
+fn stream_group_finish_emits_a_clean_document() {
+    let (server, _rt) = start_server();
+    let endpoint = server.http_endpoint();
+
+    let session = XetSessionBuilder::new().build().unwrap();
+    let data = vec![0x77u8; 48 * 1024];
+    let file_info = upload_bytes_sync(&session, endpoint, &data, "s.bin");
+
+    let group = session
+        .new_download_stream_group()
+        .unwrap()
+        .with_endpoint(endpoint)
+        .build_blocking()
+        .unwrap();
+
+    let mut stream = group.download_stream_blocking(file_info, None).unwrap();
+    let mut received = 0usize;
+    while let Some(chunk) = stream.blocking_next().unwrap() {
+        received += chunk.len();
+    }
+    assert_eq!(received, data.len());
+
+    group.finish_blocking().unwrap();
+
+    let docs = wait_for_docs(&server, 2);
+    let doc = download_doc(&docs);
+    assert_eq!(doc["metrics"]["outcome"], "ok", "an explicitly finished stream group is not 'dropped'");
+}
+
+/// `finish` is additive: a caller that never calls it keeps working exactly as before, and still
+/// reports.
+///
+/// The outcome is `ok`, not `dropped`, because the transfer genuinely completed - every stream was
+/// read to its end. Since `finish()` is new and existing embedders have not adopted it, this is the
+/// common shape for stream-group downloads; reporting it as `dropped` would make that outcome mean
+/// "probably fine" and leave a failure-rate dashboard with nothing to measure.
+///
+/// This is also the compatibility guarantee for existing embedders: `finish` must stay optional.
+#[test]
+#[serial(env)]
+fn stream_group_without_finish_reports_ok_when_fully_read() {
+    let (server, _rt) = start_server();
+    let endpoint = server.http_endpoint();
+
+    let session = XetSessionBuilder::new().build().unwrap();
+    let data = vec![0x33u8; 48 * 1024];
+    let file_info = upload_bytes_sync(&session, endpoint, &data, "n.bin");
+
+    {
+        let group = session
+            .new_download_stream_group()
+            .unwrap()
+            .with_endpoint(endpoint)
+            .build_blocking()
+            .unwrap();
+
+        let mut stream = group.download_stream_blocking(file_info, None).unwrap();
+        let mut received = 0usize;
+        while let Some(chunk) = stream.blocking_next().unwrap() {
+            received += chunk.len();
+        }
+        assert_eq!(received, data.len(), "the data must still arrive without finish()");
+        // Deliberately no `finish()`; the group and its session drop here.
+    }
+
+    let docs = wait_for_docs(&server, 2);
+    let doc = download_doc(&docs);
+    assert_eq!(doc["metrics"]["outcome"], "ok", "a fully-read group is not 'dropped' just for skipping finish()");
+    assert_eq!(doc["metrics"]["terminal"], true);
+}
+
+/// The counterpart: a stream abandoned part-way must still report `dropped`, so the outcome keeps
+/// distinguishing a real abandonment from a caller that merely skipped `finish()`.
+///
+/// The file is large enough to span several chunks, so stopping after the first leaves the transfer
+/// genuinely incomplete.
+#[test]
+#[serial(env)]
+fn stream_group_abandoned_part_way_reports_dropped() {
+    let (server, _rt) = start_server();
+    let endpoint = server.http_endpoint();
+
+    let session = XetSessionBuilder::new().build().unwrap();
+    let data = vec![0x5au8; 4 * 1024 * 1024];
+    let file_info = upload_bytes_sync(&session, endpoint, &data, "partial.bin");
+
+    {
+        let group = session
+            .new_download_stream_group()
+            .unwrap()
+            .with_endpoint(endpoint)
+            .build_blocking()
+            .unwrap();
+
+        let mut stream = group.download_stream_blocking(file_info, None).unwrap();
+        let first = stream
+            .blocking_next()
+            .unwrap()
+            .expect("the stream must yield at least one chunk");
+        assert!(first.len() < data.len(), "this test needs a file that does not arrive in a single chunk");
+        // Abandon the stream and the group here, without reading the rest and without `finish()`.
+    }
+
+    let docs = wait_for_docs(&server, 2);
+    let doc = download_doc(&docs);
+    assert_eq!(doc["metrics"]["outcome"], "dropped", "an abandoned stream must still report as dropped");
+    assert_eq!(doc["metrics"]["terminal"], true);
+}
+
+/// `abort` must not report success. This is the path a Python `with` block takes when its body
+/// raises: `__exit__` calls `abort` rather than `finish`, because `finish` claims `Outcome::Ok` and
+/// would record a failed transfer as a successful one.
+///
+/// `abort` emits nothing itself - it cancels the streams and leaves the session unfinalized, so the
+/// `Drop` path derives the outcome from what actually transferred. Matches
+/// `XetFileDownloadGroup::abort`, which is also telemetry-silent.
+#[test]
+#[serial(env)]
+fn stream_group_abort_does_not_report_success() {
+    let (server, _rt) = start_server();
+    let endpoint = server.http_endpoint();
+
+    let session = XetSessionBuilder::new().build().unwrap();
+    let data = vec![0x6bu8; 4 * 1024 * 1024];
+    let file_info = upload_bytes_sync(&session, endpoint, &data, "aborted.bin");
+
+    {
+        let group = session
+            .new_download_stream_group()
+            .unwrap()
+            .with_endpoint(endpoint)
+            .build_blocking()
+            .unwrap();
+
+        let mut stream = group.download_stream_blocking(file_info, None).unwrap();
+        stream
+            .blocking_next()
+            .unwrap()
+            .expect("the stream must yield at least one chunk");
+
+        // What `__exit__` now does on the exception path.
+        group.abort().unwrap();
+    }
+
+    let docs = wait_for_docs(&server, 2);
+    let doc = download_doc(&docs);
+    assert_eq!(doc["metrics"]["outcome"], "dropped", "an aborted partial transfer must not be reported as 'ok'");
+    assert_eq!(doc["metrics"]["terminal"], true);
+}
+
+/// After `finish`, the group is closed: new streams cannot be started. Documents the sharp edge
+/// that comes with the context-manager form.
+#[test]
+#[serial(env)]
+fn stream_group_rejects_new_streams_after_finish() {
+    let (server, _rt) = start_server();
+    let endpoint = server.http_endpoint();
+
+    let session = XetSessionBuilder::new().build().unwrap();
+    let data = vec![0x44u8; 16 * 1024];
+    let file_info = upload_bytes_sync(&session, endpoint, &data, "c.bin");
+
+    let group = session
+        .new_download_stream_group()
+        .unwrap()
+        .with_endpoint(endpoint)
+        .build_blocking()
+        .unwrap();
+    group.finish_blocking().unwrap();
+
+    assert!(
+        group.download_stream_blocking(file_info, None).is_err(),
+        "a finished group must not hand out new streams"
+    );
+}


### PR DESCRIPTION
Part 5 of 6 of the client transfer telemetry stack, split out of #919 for review. Each PR in the stack compiles and passes CI on its own.

Splits RateLimited (429) and ServerError (5xx) out of the catch-all Network
variant. A 429 is not a network fault - it is the server asking for less
traffic - and collapsing them made rate_limited and server_error unreachable
for downloads while uploads still reported them, so the same status meant two
different things depending on direction. Both map to the same Python exception
as Network, so this is not a user-visible change.

XetError gains a telemetry classifier mapping the surviving categories onto the
same coarse vocabulary xet_data uses, so documents from this path aggregate
with those classified further down. One gap is deliberate: a 404 arriving as a
reqwest status still classifies as network here, because routing it to NotFound
would change the exception type callers see.

The session groups report their own outcome: an upload commit reports its own
failure rather than only the session's, a group closes on abort as its callers
already promise, and a with-block that raises aborts rather than finishes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transfer telemetry emission and error classification across download/upload group APIs and Python bindings paths; behavior is well-tested but affects observability and lifecycle semantics (finish vs abort vs drop).
> 
> **Overview**
> **Telemetry and error taxonomy** — `XetError` adds `RateLimited` and `ServerError` for HTTP 429/5xx from `ClientError`, plus `telemetry_class()` so flattened public errors use the same coarse classes as `xet_data` (Python still maps those variants to `PyConnectionError`).
> 
> **Session finalization** — File download groups, legacy `download_async`, and upload commits now call `finalize` / `finalize_with` with the real outcome before returning errors, so failed transfers are not silently omitted from metrics. Upload commits avoid reporting `ok` when a per-file error will be returned.
> 
> **Download stream groups** — New optional `finish` / `finish_blocking` (explicit success telemetry and group close) and `abort` (cancel subtree, no success telemetry; `Drop` still infers partial vs complete). Integration tests assert `xet_download_summary` through the public group APIs, not direct session `finalize`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 010ff3256d6c7f768f96dc8cc76beeeb19dbbf52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->