### PR TITLE
feat(telemetry): python stream-group semantics and user documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,31 @@ RUST_LOG=info                # enable hf-xet logging
 HF_XET_LOG_FILE=/tmp/xet.log # write logs to a file (defaults to stdout)
 ```
 
+### Telemetry
+
+hf-xet reports a small performance summary — byte counts, dedup effectiveness, throughput, and
+wall time — to the CAS server at the end of each upload or download. It is best-effort: never
+retried, and it cannot delay or fail a transfer. The payload contains **no file names, paths,
+hashes, repository ids, or user ids**.
+
+To turn it off, use any of:
+
+```bash
+HF_XET_TELEMETRY_ENABLED=0   # hf-xet specific
+HF_HUB_DISABLE_TELEMETRY=1   # shared with the rest of the huggingface_hub stack
+HF_HUB_OFFLINE=1             # implies the above
+```
+
+Tuning (rarely needed):
+
+```bash
+HF_XET_TELEMETRY_FINAL_FLUSH_TIMEOUT=2s  # how long a transfer waits for its final report; 0 = don't wait
+HF_XET_TELEMETRY_HEARTBEAT_AFTER=5m      # long transfers report progress after this; 0 disables
+HF_XET_TELEMETRY_HEARTBEAT_INTERVAL=5m   # and then at this interval
+HF_XET_TELEMETRY_REQUEST_TIMEOUT=5s      # per-request budget
+HF_XET_TELEMETRY_MAX_IN_FLIGHT=4         # concurrent reports before dropping
+```
+
 ## Local Development
 
 ### Repo Organization

--- a/README.md
+++ b/README.md
@@ -108,12 +108,10 @@ wall time — to the CAS server at the end of each upload or download. It is bes
 retried, and it cannot delay or fail a transfer. The payload contains **no file names, paths,
 hashes, repository ids, or user ids**.
 
-To turn it off, use any of:
+To turn it off:
 
 ```bash
-HF_XET_TELEMETRY_ENABLED=0   # hf-xet specific
-HF_HUB_DISABLE_TELEMETRY=1   # shared with the rest of the huggingface_hub stack
-HF_HUB_OFFLINE=1             # implies the above
+HF_XET_TELEMETRY_ENABLED=0
 ```
 
 Tuning (rarely needed):

--- a/api_changes/update_260728_client_transfer_telemetry.md
+++ b/api_changes/update_260728_client_transfer_telemetry.md
@@ -46,11 +46,6 @@ default is sized as a process-wide number accordingly: a transfer emits one term
 heartbeats only begin after `heartbeat_after`, so the realistic burst is a set of concurrent
 transfers finalizing together.
 
-`HF_HUB_DISABLE_TELEMETRY` and `HF_HUB_OFFLINE` also force it off, and win over
-`HF_XET_TELEMETRY_ENABLED=1`. These are applied at the end of `XetConfig::with_env_overrides`
-rather than through `ENVIRONMENT_NAME_ALIASES`, because that table maps names with identical
-polarity and these are inverted.
-
 ### `Client` trait gained a method — **with a default body**
 
 ```rust

--- a/api_changes/update_260728_client_transfer_telemetry.md
+++ b/api_changes/update_260728_client_transfer_telemetry.md
@@ -1,0 +1,170 @@
+# Client transfer telemetry
+
+**Date**: 2026-07-28
+**Crates**: `xet-runtime` (new `telemetry` config group), `xet-client`
+(`cas_client::telemetry`, `Client` trait), `xet-data` (`telemetry` module, session hooks)
+
+## What changed
+
+The client now reports one performance summary per transfer to `POST /v1/telemetry` on the CAS
+server, where a companion change adds the endpoint. Reporting is best-effort: it is never retried,
+never surfaces an error, and never blocks data movement.
+
+### Wire format: the envelope is entirely snake_case
+
+The body carries exactly five keys — `time`, `event`, `session_id`, `user_agent`, `metrics` — and
+**every one is snake_case**, matching the naming convention across the whole document (envelope,
+`metrics`, and the fields the server stamps itself).
+
+`user_agent` was previously emitted as camelCase `userAgent`. The server accepts that spelling as a
+serde alias for older clients, so both work, but a body carrying **both** is rejected as a
+duplicate-field 400 — so exactly one must be sent, and it is now the snake_case one. The key set is
+pinned by `test_envelope_has_exactly_the_five_contract_keys`.
+
+`metrics` carries **40 keys on an upload document and 23 on a download**, pinned by
+`UPLOAD_KEYS`/`DOWNLOAD_KEYS`. There is no `dry_run` key: a dry run never builds a
+`TransferTelemetry` at all (`maybe_new` returns `None`), so the field could only ever serialize
+`false` — a constant in every document, and key names are over half a document's bytes.
+
+### New config group: `telemetry`
+
+| Field | Env var | Default |
+|---|---|---|
+| `enabled` | `HF_XET_TELEMETRY_ENABLED` | `true` |
+| `heartbeat_after` | `HF_XET_TELEMETRY_HEARTBEAT_AFTER` | `300s` |
+| `heartbeat_interval` | `HF_XET_TELEMETRY_HEARTBEAT_INTERVAL` | `300s` |
+| `request_timeout` | `HF_XET_TELEMETRY_REQUEST_TIMEOUT` | `5s` |
+| `final_flush_timeout` | `HF_XET_TELEMETRY_FINAL_FLUSH_TIMEOUT` | `2s` |
+| `max_in_flight` | `HF_XET_TELEMETRY_MAX_IN_FLIGHT` | `32` |
+
+`max_in_flight` is a **process-wide** ceiling: one counter is shared by every sink, so the total
+number of in-flight telemetry POSTs is bounded no matter how many transfers run at once. A per-sink
+counter would have bounded each transfer separately and multiplied by the transfer count, which puts
+the backpressure in the wrong place — a snapshot download fans out into many concurrent per-file
+transfers, so the heaviest telemetry moment would have been the one with no aggregate limit. The
+default is sized as a process-wide number accordingly: a transfer emits one terminal document and
+heartbeats only begin after `heartbeat_after`, so the realistic burst is a set of concurrent
+transfers finalizing together.
+
+`HF_HUB_DISABLE_TELEMETRY` and `HF_HUB_OFFLINE` also force it off, and win over
+`HF_XET_TELEMETRY_ENABLED=1`. These are applied at the end of `XetConfig::with_env_overrides`
+rather than through `ENVIRONMENT_NAME_ALIASES`, because that table maps names with identical
+polarity and these are inverted.
+
+### `Client` trait gained a method — **with a default body**
+
+```rust
+#[cfg(not(target_family = "wasm"))]
+fn transfer_telemetry(&self) -> Option<Arc<TransferTelemetry>> { None }
+```
+
+**No existing implementor needs to change.** Only `RemoteClient` overrides it; the local,
+in-memory, and simulation clients inherit `None` and report nothing.
+
+Note the failure mode this creates: an override with a mistyped signature compiles cleanly and is
+silently never called. `xet_data/tests/test_transfer_telemetry.rs` exists to catch that and should
+not be deleted.
+
+There is a second, subtler failure mode: the emit machinery can work perfectly while no production
+caller ever reaches it. Tests that drive `FileDownloadSession` directly cannot see that, because
+they call `finalize()` themselves. `xet_pkg/tests/test_download_telemetry.rs` exists to close the
+gap — it goes through `XetFileDownloadGroup::finish_blocking()` and asserts on what the server
+received. Keep new coverage at that altitude; a test that calls `finalize()` itself re-opens it.
+
+### Session behavior
+
+- `FileUploadSession::finalize_impl` now delegates to a new private `finalize_inner` and reports on
+  both the success and error paths. Public signatures are unchanged.
+- `FileDownloadSession::finalize` likewise, and reports a successful transfer. It keeps the debug
+  assertion that every item completed, so it must only be used on a clean-completion path.
+- **New:** `FileDownloadSession::finalize_with(outcome, error_class)` finalizes while reporting an
+  explicit outcome, and makes no completeness claim. Use it for a session that ended badly, and for
+  one whose notion of "complete" belongs to the caller. `finalize` alone can only ever report `ok`,
+  so a download that failed has to go through this or the failure-rate signal is always zero.
+- **Download groups now finalize their session.** `XetFileDownloadGroup::finish`/`finish_blocking`
+  and the legacy `data_client::download_async` finalize on both the success and error paths, the
+  latter classified via the new `XetError::telemetry_class()`. Previously nothing called
+  `FileDownloadSession::finalize`, so downloads through the Python bindings reported nothing at all.
+- **`XetError` gained two variants: `RateLimited(String)` and `ServerError(String)`**, for HTTP 429
+  and 5xx respectively. Additive, and the enum is already `#[non_exhaustive]`.
+  - **Python-visible behavior is unchanged**: both map to `PyConnectionError`, exactly as
+    `XetError::Network` did before. Only the message prefix differs (`Rate limited:` /
+    `Server error:` instead of `Network error:`).
+  - They exist because HTTP status did not survive the flattening into `XetError`. Every HTTP failure
+    became `Network`, so `telemetry_class()` could never return `rate_limited` or `server_error`,
+    while the upload path — which classifies from `DataError` and inspects `reqwest::Error::status()`
+    — reported both. A 429 therefore meant two different things depending on direction, defeating the
+    point of a shared `error_class` vocabulary.
+  - One gap is deliberately left: a 404 arriving as a `reqwest` status still classifies as `network`,
+    not `not_found`. Routing it correctly would change the Python exception type callers catch, which
+    is a user-visible change rather than a telemetry fix. Pinned by a test so it stays a decision.
+- **New:** `XetDownloadStreamGroup::finish`/`finish_blocking` (and `finish()` plus context-manager
+  support on the Python class). Streams are consumed independently, so the group cannot detect
+  completion itself, and `finish` is how a caller states it explicitly. **Purely additive** - a
+  group that is never finished behaves exactly as before and still reports, so no existing caller
+  has to change. Note that `finish` closes the group: streams already handed out stay usable, but
+  opening a new one afterwards is an error.
+- **New:** `XetDownloadStreamGroup::abort` (and `abort()` on the Python class) — the counterpart to
+  `finish` for a caller giving up rather than completing. Cancels every active stream.
+  - It emits **no** telemetry, matching `XetFileDownloadGroup::abort`. The session is left
+    unfinalized so its `Drop` derives the outcome from what actually transferred.
+  - `__exit__` now branches on `exc_type`, as the upload-commit and file-download-group context
+    managers already did: normal exit finishes, an exception aborts. Previously it called `finish`
+    unconditionally, which reports `ok` — so a `with` block that raised recorded the failed transfer
+    as a successful one, and `Drop` never got to correct it because `finish` had already set
+    `terminal_sent`.
+  - Reporting `error` on that path would have been wrong: the exception is often from the caller's
+    own code rather than the transfer, and classifying those as failures would inflate the very
+    failure rate this feature exists to measure. `cancelled` is reserved for a real user interrupt.
+    Deriving the outcome from progress avoids guessing.
+- **Both sessions gained a `Drop` impl**, emitting a terminal summary when the session was never
+  finalized — the safety net for callers that abandon a session. It is deliberately *not* gated on
+  an ambient tokio runtime: the send is spawned on the `XetRuntime`'s own stored handle, so
+  requiring `Handle::try_current()` only served to disable the path for embedders that release the
+  last `Arc` from a foreign thread, which is exactly what the Python bindings do.
+  - An abandoned **upload** reports `aborted`: the commit never happened, so nothing was durably
+    transferred.
+  - An abandoned **download** reports `ok` or `dropped` depending on what actually transferred, via
+    the new `GroupProgress::all_items_complete()`. Reaching `Drop` only means nobody called
+    `finalize()`, which for downloads is the common case rather than a failure — `finish` is new and
+    existing embedders have not adopted it. Reporting all of those as `dropped` would make the
+    outcome field mean "probably fine" and leave a failure-rate dashboard nothing to measure, so
+    `dropped` is reserved for a genuinely incomplete transfer.
+  - `all_items_complete()` requires every item to have a **finalized size** as well as all of its
+    bytes delivered, and requires at least one item. The size check is not redundant: for an
+    open-ended stream range the size is discovered incrementally, so `bytes_completed` can equal
+    `total_bytes` mid-transfer whenever the consumer catches up to the prefetch frontier. A byte
+    comparison alone would report an abandoned stream as a success.
+- New public accessors: `FileDownloadSession::client()`, and
+  `TestEnvironment::telemetry_docs()` under the `simulation` feature.
+- New public helpers: `xet_data::telemetry::{classify_error, outcome_for_class}`, for callers that
+  need to produce an `(outcome, error_class)` pair themselves.
+
+### Simulation server
+
+`POST /v1/telemetry` is now routed by the local test server, and received documents are readable
+via `LocalServer::telemetry_docs()` / `LocalTestServer::telemetry_docs()`.
+
+### New dependencies
+
+`chrono` and `uuid` were added to `xet-client`, gated to non-wasm targets.
+
+## Why
+
+We had no client-side view of upload/download performance, so a throughput regression shipped in
+an `hf-xet` release was undetectable. Server-side metrics cover CAS request latency but not
+end-to-end client throughput, dedup effectiveness, or where a transfer's wall time goes.
+
+## Notes for downstream agents
+
+- **The metric key set is a contract.** `xet_data/src/telemetry/payload.rs` is the source of truth.
+  Adding a key is safe; changing an existing key's JSON type is not — consumers assign a field
+  type on first sight and cannot change it in place, so a type change breaks ingestion for every
+  document carrying it. `test_upload_key_set_is_exact` and `test_numeric_types_stable` enforce this.
+- **All `f64` values must go through the finite guard** in that module. `serde_json` renders NaN
+  and infinity as `null`, and a single such document poisons the field's type for a consumer.
+- **No PII.** The payload carries no file names, paths, hashes, repository ids, or user ids; the
+  server derives identity from the request's JWT.
+- A follow-up PR adds the generated schema (`telemetry/metrics.schema.json`) and a CI
+  compatibility gate. Until then the const key lists in the tests are the only thing pinning the
+  contract.

--- a/hf_xet/src/py_download_stream_group.rs
+++ b/hf_xet/src/py_download_stream_group.rs
@@ -7,7 +7,7 @@ use xet_pkg::xet_session::{XetDownloadStreamGroup, XetFileInfo, XetSession};
 use crate::convert_xet_error;
 use crate::headers::{build_header_map, build_headers_with_user_agent};
 use crate::py_download_stream_handle::{PyXetDownloadStream, PyXetUnorderedDownloadStream};
-
+use crate::utils::blocking_call_with_signal_check;
 // ── build_download_stream_group ───────────────────────────────────────────────
 
 /// Create an :class:`XetDownloadStreamGroup` from a session and optional configuration.
@@ -65,6 +65,82 @@ pub struct PyXetDownloadStreamGroup {
 impl PyXetDownloadStreamGroup {
     fn __repr__(&self) -> &'static str {
         "XetDownloadStreamGroup()"
+    }
+
+    // ── Context manager ──────────────────────────────────────────────────────
+
+    fn __enter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    fn __exit__(
+        &self,
+        py: Python<'_>,
+        exc_type: Bound<'_, pyo3::PyAny>,
+        _exc_val: Bound<'_, pyo3::PyAny>,
+        _exc_tb: Bound<'_, pyo3::PyAny>,
+    ) -> PyResult<bool> {
+        if exc_type.is_none() {
+            // Normal exit: the caller is done, so report a clean finish.
+            self.finish(py)?;
+        } else {
+            // Exception: cancel the streams and leave the session unfinalized, so its `Drop`
+            // derives the outcome from what actually transferred. Calling `finish` here would
+            // report `ok` and record a failed transfer as a successful one.
+            if let Err(e) = self.abort(py) {
+                tracing::warn!("abort() failed during __exit__ exception path: {e}");
+            }
+        }
+        Ok(false) // do not suppress the exception
+    }
+
+    /// Mark the group as finished, reporting transfer telemetry.
+    ///
+    /// Streams are consumed independently, so the group cannot tell on its own when the caller is
+    /// done; this says so.
+    ///
+    /// **Optional.** A group that is never finished behaves exactly as before and still reports
+    /// when it is collected. The reported outcome comes from what actually transferred, so a group
+    /// whose streams were all read to the end is recorded as successful either way — only a
+    /// genuinely partial transfer is recorded as abandoned. Existing code needs no change.
+    ///
+    /// What calling it does buy:
+    ///
+    /// - **Delivery.** The report is sent before this returns, whereas the collected-without-finish path sends it in
+    ///   the background and frequently loses it, because processes often exit within milliseconds of a transfer
+    ///   finishing.
+    /// - **An explicit result rather than an inferred one.** This records success unconditionally, which suits a caller
+    ///   whose notion of "done" is not "every byte of every stream" — a deliberately partial read would otherwise be
+    ///   recorded as abandoned.
+    /// - **Closing the group**, which nothing else does.
+    ///
+    /// Open every stream you intend to open first: the group is **closed** afterwards, so
+    /// :meth:`download_stream` and :meth:`download_unordered_stream` raise once it has been
+    /// called. Streams already returned stay usable.
+    ///
+    /// Called automatically when exiting a ``with`` block that does not raise; on an exception
+    /// :meth:`abort` is called instead. Calling it twice is a no-op.
+    pub fn finish(&self, py: Python<'_>) -> PyResult<()> {
+        let group = self.inner.clone();
+        blocking_call_with_signal_check(py, move || group.finish_blocking())
+    }
+
+    /// Cancel every active stream in this group and close it, abandoning the transfer.
+    ///
+    /// The counterpart to :meth:`finish` for a caller giving up rather than completing. Called
+    /// automatically when a ``with`` block exits on an exception.
+    ///
+    /// The group is **closed** afterwards, like :meth:`finish`: :meth:`download_stream`,
+    /// :meth:`download_unordered_stream`, and :meth:`finish` all raise once it has been called.
+    /// Streams already returned stay usable, though the active ones stop yielding. Calling it
+    /// twice is a no-op.
+    ///
+    /// Unlike :meth:`finish`, this reports no outcome of its own: the transfer is recorded from
+    /// what actually transferred once the group is collected, so an abandoned partial download is
+    /// not counted as a success.
+    pub fn abort(&self, py: Python<'_>) -> PyResult<()> {
+        let group = self.inner.clone();
+        blocking_call_with_signal_check(py, move || group.abort())
     }
 
     // ── Stream constructors ──────────────────────────────────────────────────

--- a/hf_xet/tests/test_stream_download.py
+++ b/hf_xet/tests/test_stream_download.py
@@ -13,8 +13,12 @@ Covers:
   - Full-file unordered stream (reassemble from offsets), small and large
   - Bounded range unordered on large files
   - Open-ended range unordered on large files
+  - finish() closing the group, abort() stopping an unstarted stream
+  - Context manager: finish on a clean exit, abort on an exception
 Not covered here (require a real CAS server):
   - token, token_refresh_url, custom_headers kwargs
+  - The telemetry outcome each path reports, which needs a server to read the
+    document back from (see xet_pkg/tests/test_download_telemetry.rs)
 """
 
 import pytest
@@ -216,3 +220,85 @@ class TestDownloadUnorderedStream:
         assert assembled == _LARGE_DATA[:_RANGE_END]
 
 
+
+
+# ── Context manager ──────────────────────────────────────────────────────────
+
+class TestDownloadStreamGroupContextManager:
+    def test_context_manager_finishes_on_normal_exit(self, endpoint):
+        data = b"context manager stream"
+        info = upload_bytes_get_info(endpoint, data)
+        group = hf_xet.XetSession().new_download_stream_group(endpoint=endpoint)
+        with group as entered:
+            chunks = list(entered.download_stream(info))
+        assert b"".join(chunks) == data
+        with pytest.raises(Exception) as exc:
+            group.download_stream(info)
+        assert "already finalized" in str(exc.value)
+
+    def test_context_manager_aborts_on_exception(self, endpoint):
+        info = upload_bytes_get_info(endpoint, _LARGE_DATA)
+        group = hf_xet.XetSession().new_download_stream_group(endpoint=endpoint)
+        raised = False
+        try:
+            with group as entered:
+                stream = entered.download_stream(info)
+                next(iter(stream))
+                raise ValueError("intentional error")
+        except ValueError:
+            raised = True
+        assert raised
+        with pytest.raises(Exception) as exc:
+            group.download_stream(info)
+        assert "cancelled" in str(exc.value).lower()
+
+
+# ── finish() / abort() ───────────────────────────────────────────────────────
+
+class TestDownloadStreamGroupFinishAbort:
+    def test_finish_closes_the_group(self, endpoint):
+        info = upload_bytes_get_info(endpoint, DATA)
+        group = hf_xet.XetSession().new_download_stream_group(endpoint=endpoint)
+        assert b"".join(group.download_stream(info)) == DATA
+
+        group.finish()
+        with pytest.raises(Exception) as ordered:
+            group.download_stream(info)
+        assert "already finalized" in str(ordered.value)
+        with pytest.raises(Exception) as unordered:
+            group.download_unordered_stream(info)
+        assert "already finalized" in str(unordered.value)
+
+    def test_finish_twice_no_op(self, endpoint):
+        group = hf_xet.XetSession().new_download_stream_group(endpoint=endpoint)
+        group.finish()
+        group.finish()
+
+    def test_abort_stops_a_stream(self, endpoint):
+        info = upload_bytes_get_info(endpoint, _LARGE_DATA)
+        group = hf_xet.XetSession().new_download_stream_group(endpoint=endpoint)
+        stream = group.download_stream(info)
+        group.abort()
+        assert b"".join(stream) == b""
+
+    def test_abort_closes_the_group(self, endpoint):
+        info = upload_bytes_get_info(endpoint, DATA)
+        group = hf_xet.XetSession().new_download_stream_group(endpoint=endpoint)
+        group.abort()
+
+        for open_stream in (group.download_stream, group.download_unordered_stream):
+            with pytest.raises(Exception) as exc:
+                open_stream(info)
+            assert "cancelled" in str(exc.value).lower()
+
+    def test_abort_makes_finish_fail(self, endpoint):
+        group = hf_xet.XetSession().new_download_stream_group(endpoint=endpoint)
+        group.abort()
+        with pytest.raises(Exception) as exc:
+            group.finish()
+        assert "cancelled" in str(exc.value).lower()
+
+    def test_abort_twice_is_a_no_op(self, endpoint):
+        group = hf_xet.XetSession().new_download_stream_group(endpoint=endpoint)
+        group.abort()
+        group.abort()


### PR DESCRIPTION
Part 6 of 6 of the client transfer telemetry stack, split out of #919 for review. Each PR in the stack compiles and passes CI on its own.

Makes the Python download stream group abort rather than finish when its with
block raises, so an exception is reported as an abandoned transfer instead of a
successful one, and documents the telemetry the client now emits along with how
to turn it off.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly additive Python API surface and documentation. Telemetry outcome reporting changes only for stream-group context-manager exception paths; transfer behavior is otherwise unchanged.
> 
> **Overview**
> Exposes **`finish()`** and **`abort()`** on the Python `XetDownloadStreamGroup`, plus context-manager support, so callers can explicitly close a stream group and report transfer telemetry.
> 
> On a clean `with` exit the group finishes; on an exception it **aborts** instead, leaving the session unfinalized so `Drop` derives the outcome from what actually transferred rather than recording a failed download as `ok`.
> 
> Also documents client transfer telemetry in the README (what is sent, how to disable it, and tuning knobs) and adds the stack’s API-change note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bf2fc6df5b41b6b6b8b201a116be9fec8f3e21d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->