### PR TITLE
fix(telemetry): do not cancel the finalize that reports an interrupted transfer

### DIFF
--- a/xet_data/src/processing/file_download_session.rs
+++ b/xet_data/src/processing/file_download_session.rs
@@ -457,7 +457,21 @@ fn range_bounds_to_file_range(range: &impl RangeBounds<u64>) -> Result<Option<Fi
 #[cfg(not(target_family = "wasm"))]
 impl Drop for FileDownloadSession {
     fn drop(&mut self) {
-        if self.finalized.load(Ordering::Acquire) {
+        self.finalize_abandoned();
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl FileDownloadSession {
+    /// Reports this session as abandoned, inferring the outcome from progress, and marks it
+    /// finalized so [`Drop`] does not report it a second time. Idempotent.
+    ///
+    /// `Drop` is the normal caller. It is also public because `Drop` is too late for a caller that
+    /// is about to tear the runtime down: `XetSession::sigint_abort` destroys the tokio runtime
+    /// while the group is still alive, so a session left to report from `Drop` would have nothing
+    /// to send on by the time it ran. Such a caller reports here first, while sending still works.
+    pub fn finalize_abandoned(&self) {
+        if self.finalized.swap(true, Ordering::AcqRel) {
             return;
         }
         // Deliberately *not* gated on `tokio::runtime::Handle::try_current()`. The send is spawned

--- a/xet_data/src/processing/file_download_session.rs
+++ b/xet_data/src/processing/file_download_session.rs
@@ -463,13 +463,12 @@ impl Drop for FileDownloadSession {
 
 #[cfg(not(target_family = "wasm"))]
 impl FileDownloadSession {
-    /// Reports this session as abandoned, inferring the outcome from progress, and marks it
-    /// finalized so [`Drop`] does not report it a second time. Idempotent.
+    /// Reports this session as abandoned, inferring the outcome from progress. Idempotent, and
+    /// marks the session finalized so [`Drop`] does not report it again.
     ///
-    /// `Drop` is the normal caller. It is also public because `Drop` is too late for a caller that
-    /// is about to tear the runtime down: `XetSession::sigint_abort` destroys the tokio runtime
-    /// while the group is still alive, so a session left to report from `Drop` would have nothing
-    /// to send on by the time it ran. Such a caller reports here first, while sending still works.
+    /// `Drop` is the normal caller. This is also public for `XetSession::sigint_abort`, which
+    /// destroys the tokio runtime while the group is still alive - too late for `Drop` to send
+    /// anything - so such a caller reports here first, while sending still works.
     pub fn finalize_abandoned(&self) {
         if self.finalized.swap(true, Ordering::AcqRel) {
             return;

--- a/xet_pkg/src/xet_session/file_download_group.rs
+++ b/xet_pkg/src/xet_session/file_download_group.rs
@@ -177,6 +177,11 @@ impl XetFileDownloadGroup {
     /// Cancel all active downloads in this group.
     pub fn abort(&self) -> Result<(), XetError> {
         info!(group_id = %self.id(), "Download group abort");
+        // Report before cancelling. The only other place an abandoned download reports is the
+        // session's `Drop`, and callers that abort are frequently about to destroy the runtime
+        // (`sigint_abort` on Ctrl-C), leaving that `Drop` with nothing to send on. Idempotent, so
+        // the later `Drop` stays a no-op and this does not double-report.
+        self.inner.download_session.finalize_abandoned();
         self.task_runtime.cancel_subtree()?;
         for handle in self.inner.active_tasks.read()?.values() {
             handle.cancel();

--- a/xet_pkg/src/xet_session/file_download_group.rs
+++ b/xet_pkg/src/xet_session/file_download_group.rs
@@ -259,15 +259,18 @@ impl XetFileDownloadGroup {
         info!(group_id = %self.id(), "Download group finish");
         let inner = self.inner.clone();
         let download_session = self.inner.download_session.clone();
-        // Not `?` on the bridge: the result is needed to finalize the session before it is
-        // propagated, otherwise a failed download - the case most worth reporting - would return
-        // early and emit nothing.
-        let result = self
+        // Finalize *inside* the bridged future, not after: `enter_finalizing`'s guard only
+        // covers the bridge's duration, so finalizing after it returns would let a concurrent
+        // `sigint_abort` tear the runtime down before the report is sent.
+        let ds = download_session.clone();
+        let downloads = self
             .task_runtime
-            .bridge_async_finalizing("download_finish", false, async move { inner.handle_finish().await })
-            .await;
-        finalize_download_session(&download_session, &result).await;
-        let downloads = result?;
+            .bridge_async_finalizing("download_finish", false, async move {
+                let result = inner.handle_finish().await;
+                finalize_download_session(&ds, &result).await;
+                result
+            })
+            .await?;
         let progress = download_session.report();
         Ok(XetDownloadGroupReport { progress, downloads })
     }

--- a/xet_pkg/src/xet_session/session.rs
+++ b/xet_pkg/src/xet_session/session.rs
@@ -349,7 +349,11 @@ impl XetSession {
         let _fd_scope = track_fd_scope(format!("XetSession::sigint_abort({})", self.inner.id));
 
         info!("Session SIGINT abort, session_id={}", self.inner.id);
-        self.inner.ctx.runtime.perform_sigint_shutdown();
+
+        // Cancel before tearing anything down. In-flight work observes the token and returns
+        // promptly, which lets the finalizing bridge it is running under reach its tail - the
+        // terminal telemetry report - while the runtime can still send it.
+        self.inner.task_runtime.cancel_subtree()?;
 
         let active_download_stream_groups = std::mem::take(&mut *self.inner.active_download_stream_groups.lock()?);
         for (_id, weak_group) in active_download_stream_groups {
@@ -357,6 +361,19 @@ impl XetSession {
                 inner.abort();
             }
         }
+
+        // Those reports are produced on whichever thread called `finish`, not this one - the
+        // Python bindings run it on a spawned thread so they can poll for signals - so wait for
+        // them rather than racing them. Bounded, because an interrupt must stay responsive and a
+        // report is best-effort; the budget is the telemetry flush budget, since delivering that
+        // report is the whole reason for waiting.
+        let deadline = std::time::Instant::now() + self.inner.ctx.config.telemetry.final_flush_timeout;
+        while self.inner.ctx.runtime.finalizing_in_flight() > 0 && std::time::Instant::now() < deadline {
+            std::thread::sleep(std::time::Duration::from_millis(2));
+        }
+
+        // Only now: this cancels every remaining task, and drains pending telemetry first.
+        self.inner.ctx.runtime.perform_sigint_shutdown();
 
         #[cfg(feature = "fd-track")]
         report_fd_count("XetSession::sigint_abort complete");

--- a/xet_pkg/src/xet_session/session.rs
+++ b/xet_pkg/src/xet_session/session.rs
@@ -362,11 +362,9 @@ impl XetSession {
             }
         }
 
-        // Those reports are produced on whichever thread called `finish`, not this one - the
-        // Python bindings run it on a spawned thread so they can poll for signals - so wait for
-        // them rather than racing them. Bounded, because an interrupt must stay responsive and a
-        // report is best-effort; the budget is the telemetry flush budget, since delivering that
-        // report is the whole reason for waiting.
+        // Reports are produced on whichever thread called `finish`, not this one, so wait for
+        // them rather than racing them. Bounded by the telemetry flush budget, since an interrupt
+        // must stay responsive and the report is best-effort.
         let deadline = std::time::Instant::now() + self.inner.ctx.config.telemetry.final_flush_timeout;
         while self.inner.ctx.runtime.finalizing_in_flight() > 0 && std::time::Instant::now() < deadline {
             std::thread::sleep(std::time::Duration::from_millis(2));

--- a/xet_pkg/src/xet_session/task_runtime.rs
+++ b/xet_pkg/src/xet_session/task_runtime.rs
@@ -286,37 +286,35 @@ impl TaskRuntime {
         self.bridge_async_finalizing_inner(task_name, allow_repeat, Box::pin(fut), true)
     }
 
-    fn bridge_async_finalizing_inner<T>(
+    async fn bridge_async_finalizing_inner<T>(
         &self,
         task_name: &'static str,
         allow_repeat: bool,
         fut: BoxedBridgeFuture<T>,
         cancellable: bool,
-    ) -> impl Future<Output = Result<T, XetError>> + MaybeSend + '_
+    ) -> Result<T, XetError>
     where
         T: MaybeSend + 'static,
     {
-        async move {
-            self.transition_to_finalizing(task_name, allow_repeat)?;
-            // A terminal report is produced at the tail of `fut`; hold the runtime open until it
-            // has. `sigint_abort` polls this rather than sleeping a fixed budget.
-            #[cfg(not(target_family = "wasm"))]
-            let _finalizing = self.runtime.enter_finalizing();
+        self.transition_to_finalizing(task_name, allow_repeat)?;
+        // A terminal report is produced at the tail of `fut`; hold the runtime open until it
+        // has. `sigint_abort` polls this rather than sleeping a fixed budget.
+        #[cfg(not(target_family = "wasm"))]
+        let _finalizing = self.runtime.enter_finalizing();
 
-            let result = if cancellable {
-                self.run_inner_async(task_name, fut).await
-            } else {
-                self.run_inner_async_to_completion(task_name, fut).await
-            };
-            match &result {
-                Ok(_) => self.set_state(XetTaskState::Completed)?,
-                Err(XetError::UserCancelled(_)) => {
-                    self.set_state(XetTaskState::UserCancelled)?;
-                },
-                Err(e) => self.set_state(XetTaskState::Error(e.to_string()))?,
-            }
-            result
+        let result = if cancellable {
+            self.run_inner_async(task_name, fut).await
+        } else {
+            self.run_inner_async_to_completion(task_name, fut).await
+        };
+        match &result {
+            Ok(_) => self.set_state(XetTaskState::Completed)?,
+            Err(XetError::UserCancelled(_)) => {
+                self.set_state(XetTaskState::UserCancelled)?;
+            },
+            Err(e) => self.set_state(XetTaskState::Error(e.to_string()))?,
         }
+        result
     }
 }
 

--- a/xet_pkg/src/xet_session/task_runtime.rs
+++ b/xet_pkg/src/xet_session/task_runtime.rs
@@ -251,14 +251,10 @@ impl TaskRuntime {
 
     /// Finalizing bridge for inner work that observes the cancellation token itself.
     ///
-    /// The future is run to completion rather than raced against the token. These bridges wrap
-    /// work whose tail *is* the terminal report, so racing the bridge drops that report along with
-    /// the cancelled work - an interrupted transfer then goes unreported entirely. The inner work
-    /// still returns promptly on cancel, via the per-task handles that do watch the token.
-    ///
-    /// Callers whose inner future does **not** watch the token must use
-    /// [`bridge_async_finalizing_cancellable`](Self::bridge_async_finalizing_cancellable), or a
-    /// cancel would block here instead of returning.
+    /// Runs the future to completion instead of racing it against the token, so its tail - the
+    /// terminal report - always runs. Use
+    /// [`bridge_async_finalizing_cancellable`](Self::bridge_async_finalizing_cancellable) instead
+    /// if the inner future doesn't watch the token itself.
     pub(super) fn bridge_async_finalizing<T, F>(
         &self,
         task_name: &'static str,
@@ -274,10 +270,9 @@ impl TaskRuntime {
 
     /// Finalizing bridge that races the inner future against cancellation.
     ///
-    /// Only for inner work that cannot observe the token itself - the race is then the sole thing
-    /// making a cancel prompt. It costs the terminal report when it fires, so prefer
-    /// [`bridge_async_finalizing`](Self::bridge_async_finalizing) wherever the inner work watches
-    /// the token.
+    /// Only for inner work that cannot observe the token itself; costs the terminal report when
+    /// the race fires, so prefer [`bridge_async_finalizing`](Self::bridge_async_finalizing)
+    /// wherever the inner work watches the token.
     pub(super) fn bridge_async_finalizing_cancellable<T, F>(
         &self,
         task_name: &'static str,

--- a/xet_pkg/src/xet_session/task_runtime.rs
+++ b/xet_pkg/src/xet_session/task_runtime.rs
@@ -249,6 +249,16 @@ impl TaskRuntime {
         }
     }
 
+    /// Finalizing bridge for inner work that observes the cancellation token itself.
+    ///
+    /// The future is run to completion rather than raced against the token. These bridges wrap
+    /// work whose tail *is* the terminal report, so racing the bridge drops that report along with
+    /// the cancelled work - an interrupted transfer then goes unreported entirely. The inner work
+    /// still returns promptly on cancel, via the per-task handles that do watch the token.
+    ///
+    /// Callers whose inner future does **not** watch the token must use
+    /// [`bridge_async_finalizing_cancellable`](Self::bridge_async_finalizing_cancellable), or a
+    /// cancel would block here instead of returning.
     pub(super) fn bridge_async_finalizing<T, F>(
         &self,
         task_name: &'static str,
@@ -259,11 +269,50 @@ impl TaskRuntime {
         F: Future<Output = Result<T, XetError>> + MaybeSend + 'static,
         T: MaybeSend + 'static,
     {
-        let fut: BoxedBridgeFuture<T> = Box::pin(fut);
+        self.bridge_async_finalizing_inner(task_name, allow_repeat, Box::pin(fut), false)
+    }
+
+    /// Finalizing bridge that races the inner future against cancellation.
+    ///
+    /// Only for inner work that cannot observe the token itself - the race is then the sole thing
+    /// making a cancel prompt. It costs the terminal report when it fires, so prefer
+    /// [`bridge_async_finalizing`](Self::bridge_async_finalizing) wherever the inner work watches
+    /// the token.
+    pub(super) fn bridge_async_finalizing_cancellable<T, F>(
+        &self,
+        task_name: &'static str,
+        allow_repeat: bool,
+        fut: F,
+    ) -> impl Future<Output = Result<T, XetError>> + MaybeSend + '_
+    where
+        F: Future<Output = Result<T, XetError>> + MaybeSend + 'static,
+        T: MaybeSend + 'static,
+    {
+        self.bridge_async_finalizing_inner(task_name, allow_repeat, Box::pin(fut), true)
+    }
+
+    fn bridge_async_finalizing_inner<T>(
+        &self,
+        task_name: &'static str,
+        allow_repeat: bool,
+        fut: BoxedBridgeFuture<T>,
+        cancellable: bool,
+    ) -> impl Future<Output = Result<T, XetError>> + MaybeSend + '_
+    where
+        T: MaybeSend + 'static,
+    {
         async move {
             self.transition_to_finalizing(task_name, allow_repeat)?;
+            // A terminal report is produced at the tail of `fut`; hold the runtime open until it
+            // has. `sigint_abort` polls this rather than sleeping a fixed budget.
+            #[cfg(not(target_family = "wasm"))]
+            let _finalizing = self.runtime.enter_finalizing();
 
-            let result = self.run_inner_async(task_name, fut).await;
+            let result = if cancellable {
+                self.run_inner_async(task_name, fut).await
+            } else {
+                self.run_inner_async_to_completion(task_name, fut).await
+            };
             match &result {
                 Ok(_) => self.set_state(XetTaskState::Completed)?,
                 Err(XetError::UserCancelled(_)) => {
@@ -325,6 +374,21 @@ impl TaskRuntime {
         }
     }
 
+    /// Like [`run_inner_async`](Self::run_inner_async) but without the cancellation race, so the
+    /// future's tail - the terminal report - still runs after cancelled work returns.
+    fn run_inner_async_to_completion<T, F>(
+        &self,
+        task_name: &'static str,
+        fut: F,
+    ) -> impl Future<Output = Result<T, XetError>> + Send + 'static
+    where
+        F: Future<Output = Result<T, XetError>> + Send + 'static,
+        T: Send + 'static,
+    {
+        let runtime = self.runtime.clone();
+        async move { runtime.bridge_async(task_name, fut).await.map_err(XetError::from)? }
+    }
+
     pub(super) fn bridge_sync<T, F>(&self, task_name: &'static str, fut: F) -> Result<T, XetError>
     where
         F: Future<Output = Result<T, XetError>> + Send + 'static,
@@ -349,6 +413,10 @@ impl TaskRuntime {
         result
     }
 
+    /// Blocking counterpart of [`bridge_async_finalizing`](Self::bridge_async_finalizing): runs
+    /// the future to completion so its terminal report survives a cancel. See that method for
+    /// when to use [`bridge_sync_finalizing_cancellable`](Self::bridge_sync_finalizing_cancellable)
+    /// instead.
     pub(super) fn bridge_sync_finalizing<T, F>(
         &self,
         task_name: &'static str,
@@ -359,12 +427,46 @@ impl TaskRuntime {
         F: Future<Output = Result<T, XetError>> + Send + 'static,
         T: Send + 'static,
     {
+        self.bridge_sync_finalizing_inner(task_name, allow_repeat, fut, false)
+    }
+
+    /// Blocking counterpart of
+    /// [`bridge_async_finalizing_cancellable`](Self::bridge_async_finalizing_cancellable).
+    pub(super) fn bridge_sync_finalizing_cancellable<T, F>(
+        &self,
+        task_name: &'static str,
+        allow_repeat: bool,
+        fut: F,
+    ) -> Result<T, XetError>
+    where
+        F: Future<Output = Result<T, XetError>> + Send + 'static,
+        T: Send + 'static,
+    {
+        self.bridge_sync_finalizing_inner(task_name, allow_repeat, fut, true)
+    }
+
+    fn bridge_sync_finalizing_inner<T, F>(
+        &self,
+        task_name: &'static str,
+        allow_repeat: bool,
+        fut: F,
+        cancellable: bool,
+    ) -> Result<T, XetError>
+    where
+        F: Future<Output = Result<T, XetError>> + Send + 'static,
+        T: Send + 'static,
+    {
         self.transition_to_finalizing(task_name, allow_repeat)?;
+        // See the async variant: keeps the runtime alive until the terminal report is produced.
+        let _finalizing = self.runtime.enter_finalizing();
 
         let token = self.cancellation_token.clone();
         let result = self
             .runtime
             .bridge_sync(async move {
+                if !cancellable {
+                    return fut.await;
+                }
                 tokio::select! {
                     _ = token.cancelled() => Err(XetError::UserCancelled(
                         format!("{task_name} cancelled by user"),
@@ -407,5 +509,19 @@ impl TaskRuntime {
                 result = fut => result,
             }
         }
+    }
+
+    /// Like [`run_inner_async`](Self::run_inner_async) but without the cancellation race, so the
+    /// future's tail - the terminal report - still runs after cancelled work returns.
+    fn run_inner_async_to_completion<T, F>(
+        &self,
+        _task_name: &'static str,
+        fut: F,
+    ) -> impl Future<Output = Result<T, XetError>> + 'static
+    where
+        F: Future<Output = Result<T, XetError>> + 'static,
+        T: 'static,
+    {
+        fut
     }
 }

--- a/xet_pkg/src/xet_session/upload_commit.rs
+++ b/xet_pkg/src/xet_session/upload_commit.rs
@@ -1491,17 +1491,17 @@ mod tests {
 
     #[test]
     fn test_blocking_upload_round_trip_in_smol() {
-        assert_blocking_upload_round_trip(|fut| smol::block_on(fut));
+        assert_blocking_upload_round_trip(smol::block_on);
     }
 
     #[test]
     fn test_blocking_upload_round_trip_in_futures_executor() {
-        assert_blocking_upload_round_trip(|fut| futures::executor::block_on(fut));
+        assert_blocking_upload_round_trip(futures::executor::block_on);
     }
 
     #[test]
     fn test_blocking_upload_round_trip_in_async_std() {
-        assert_blocking_upload_round_trip(|fut| async_std::task::block_on(fut));
+        assert_blocking_upload_round_trip(async_std::task::block_on);
     }
 
     // ── External-mode _blocking guard ────────────────────────────────────────

--- a/xet_pkg/src/xet_session/upload_stream_handle.rs
+++ b/xet_pkg/src/xet_session/upload_stream_handle.rs
@@ -142,7 +142,9 @@ impl XetStreamUpload {
         let result_cell = self.inner.result.clone();
         let meta = self
             .task_runtime
-            .bridge_async_finalizing("upload_stream_finish", false, async move { inner.finish().await })
+            // `cleaner.finish()` does not observe the cancellation token, so the bridge's race is the
+            // only thing making a cancel prompt here. Costs the terminal report when it fires.
+            .bridge_async_finalizing_cancellable("upload_stream_finish", false, async move { inner.finish().await })
             .await?;
         let _ = result_cell.set(meta.clone());
         Ok(meta)
@@ -160,7 +162,10 @@ impl XetStreamUpload {
         let result_cell = self.inner.result.clone();
         let meta = self
             .task_runtime
-            .bridge_sync_finalizing("upload_stream_finish_blocking", false, async move { inner.finish().await })?;
+            // See the async variant: `cleaner.finish()` is not cancellation-aware.
+            .bridge_sync_finalizing_cancellable("upload_stream_finish_blocking", false, async move {
+                inner.finish().await
+            })?;
         let _ = result_cell.set(meta.clone());
         Ok(meta)
     }

--- a/xet_pkg/tests/test_download_telemetry.rs
+++ b/xet_pkg/tests/test_download_telemetry.rs
@@ -333,7 +333,9 @@ fn sigint_abort_still_reports_the_abandoned_download() {
     let endpoint = server.http_endpoint();
 
     let session = XetSessionBuilder::new().build().unwrap();
-    let data = vec![0x5Au8; 96 * 1024];
+    // Large and multi-chunk, like the sibling abandonment tests, so the transfer cannot
+    // complete in the gap between starting it and calling `abort()` below.
+    let data = vec![0x5Au8; 4 * 1024 * 1024];
     let file_info = upload_bytes_sync(&session, endpoint, &data, "aborted.bin");
 
     let dest = temp.path().join("aborted.out");
@@ -360,14 +362,9 @@ fn sigint_abort_still_reports_the_abandoned_download() {
     assert_eq!(doc["metrics"]["terminal"], true);
 }
 
-/// The real Ctrl-C shape: `finish_blocking` is already in flight on another thread when
-/// `sigint_abort` lands.
-///
-/// This is what `hf` does. `start_download_file` only starts the transfer; the wait happens in the
-/// binding's `__exit__` via `finish_blocking`, which pyo3 runs on a spawned thread so it can poll
-/// for Python signals. SIGINT therefore arrives *during* `finish_blocking`, and the interrupt
-/// handler calls `sigint_abort()` while that thread is still inside the finalizing bridge - the
-/// bridge whose `select!` drops the future carrying `finalize_download_session`.
+/// The real Ctrl-C shape: `finish_blocking` is already in flight on another (pyo3-spawned)
+/// thread when `sigint_abort` lands, so the interrupt hits mid-bridge rather than before it
+/// starts.
 #[test]
 #[serial(env)]
 fn sigint_during_finish_still_reports() {

--- a/xet_pkg/tests/test_download_telemetry.rs
+++ b/xet_pkg/tests/test_download_telemetry.rs
@@ -317,3 +317,45 @@ fn stream_group_rejects_new_streams_after_finish() {
         "a finished group must not hand out new streams"
     );
 }
+
+/// The Ctrl-C path must still report the abandoned download.
+///
+/// `hf`'s `except KeyboardInterrupt` runs the group's `__exit__` (which calls `abort()`) and then
+/// `abort_xet_session()` -> `XetSession::sigint_abort()`. `abort()` deliberately leaves the session
+/// unfinalized so `Drop` can derive `dropped` from progress, but `sigint_abort()` tears the tokio
+/// runtime down first, so that `Drop` has nothing left to send on and the transfer is never
+/// reported. A user aborting a large download is the abandonment case most worth capturing.
+#[test]
+#[serial(env)]
+fn sigint_abort_still_reports_the_abandoned_download() {
+    let temp: TempDir = tempdir().unwrap();
+    let (server, _rt) = start_server();
+    let endpoint = server.http_endpoint();
+
+    let session = XetSessionBuilder::new().build().unwrap();
+    let data = vec![0x5Au8; 96 * 1024];
+    let file_info = upload_bytes_sync(&session, endpoint, &data, "aborted.bin");
+
+    let dest = temp.path().join("aborted.out");
+    let group = session
+        .new_file_download_group()
+        .unwrap()
+        .with_endpoint(endpoint)
+        .build_blocking()
+        .unwrap();
+
+    // Starts the download and returns without waiting, so there is something in flight.
+    group.download_file_to_path_blocking(file_info, dest).unwrap();
+
+    // Exactly the order huggingface_hub uses on Ctrl-C.
+    group.abort().unwrap();
+    session.sigint_abort().unwrap();
+    drop(group);
+
+    let docs = wait_for_docs(&server, 2);
+    let doc = download_doc(&docs);
+
+    assert_eq!(doc["metrics"]["direction"], "download");
+    assert_eq!(doc["metrics"]["outcome"], "dropped", "an interrupted download must report as dropped");
+    assert_eq!(doc["metrics"]["terminal"], true);
+}

--- a/xet_pkg/tests/test_download_telemetry.rs
+++ b/xet_pkg/tests/test_download_telemetry.rs
@@ -359,3 +359,48 @@ fn sigint_abort_still_reports_the_abandoned_download() {
     assert_eq!(doc["metrics"]["outcome"], "dropped", "an interrupted download must report as dropped");
     assert_eq!(doc["metrics"]["terminal"], true);
 }
+
+/// The real Ctrl-C shape: `finish_blocking` is already in flight on another thread when
+/// `sigint_abort` lands.
+///
+/// This is what `hf` does. `start_download_file` only starts the transfer; the wait happens in the
+/// binding's `__exit__` via `finish_blocking`, which pyo3 runs on a spawned thread so it can poll
+/// for Python signals. SIGINT therefore arrives *during* `finish_blocking`, and the interrupt
+/// handler calls `sigint_abort()` while that thread is still inside the finalizing bridge - the
+/// bridge whose `select!` drops the future carrying `finalize_download_session`.
+#[test]
+#[serial(env)]
+fn sigint_during_finish_still_reports() {
+    let temp: TempDir = tempdir().unwrap();
+    let (server, _rt) = start_server();
+    let endpoint = server.http_endpoint();
+
+    let session = XetSessionBuilder::new().build().unwrap();
+    let data = vec![0x5Au8; 96 * 1024];
+    let file_info = upload_bytes_sync(&session, endpoint, &data, "interrupted.bin");
+
+    let dest = temp.path().join("interrupted.out");
+    let group = session
+        .new_file_download_group()
+        .unwrap()
+        .with_endpoint(endpoint)
+        .build_blocking()
+        .unwrap();
+    group.download_file_to_path_blocking(file_info, dest).unwrap();
+
+    // finish_blocking on its own thread, exactly as the pyo3 signal-check bridge runs it.
+    let finisher = std::thread::spawn(move || {
+        let _ = group.finish_blocking();
+    });
+
+    // ...and the interrupt handler fires while it is still running. The pause is what makes
+    // that true: in the real flow SIGINT arrives during `finish_blocking`, not before it starts.
+    std::thread::sleep(std::time::Duration::from_millis(150));
+    session.sigint_abort().unwrap();
+    let _ = finisher.join();
+
+    let docs = wait_for_docs(&server, 2);
+    let doc = download_doc(&docs);
+    assert_eq!(doc["metrics"]["direction"], "download");
+    assert_eq!(doc["metrics"]["terminal"], true);
+}

--- a/xet_runtime/src/config/groups/telemetry.rs
+++ b/xet_runtime/src/config/groups/telemetry.rs
@@ -50,10 +50,10 @@ crate::config_group!({
     ///
     /// Set to zero to make the terminal send fully detached.
     ///
-    /// The default value is 2 seconds.
+    /// The default value is 500 milliseconds.
     ///
     /// Use the environment variable `HF_XET_TELEMETRY_FINAL_FLUSH_TIMEOUT` to set this value.
-    ref final_flush_timeout: Duration = Duration::from_secs(2);
+    ref final_flush_timeout: Duration = Duration::from_millis(500);
 
     /// Maximum number of telemetry requests allowed in flight at once, across the whole process.
     ///
@@ -115,7 +115,7 @@ mod tests {
         assert_eq!(t.heartbeat_after.as_secs(), 300);
         assert_eq!(t.heartbeat_interval.as_secs(), 300);
         assert_eq!(t.request_timeout.as_secs(), 5);
-        assert_eq!(t.final_flush_timeout.as_secs(), 2);
+        assert_eq!(t.final_flush_timeout.as_millis(), 500);
         // Process-wide, not per-transfer - see `max_in_flight`'s docs for why it is sized this way.
         assert_eq!(t.max_in_flight, 32);
     }

--- a/xet_runtime/src/core/runtime/native.rs
+++ b/xet_runtime/src/core/runtime/native.rs
@@ -98,6 +98,16 @@ pub fn register_pre_shutdown_drain(drain: fn()) {
     let _ = PRE_SHUTDOWN_DRAIN.set(drain);
 }
 
+/// Held for the duration of work a shutdown must not interrupt. See
+/// [`XetRuntime::enter_finalizing`].
+pub struct FinalizingGuard(Arc<XetRuntime>);
+
+impl Drop for FinalizingGuard {
+    fn drop(&mut self) {
+        self.0.finalizing.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
 #[derive(Debug)]
 enum RuntimeBackend {
     External { handle_id: Option<tokio::runtime::Id> },
@@ -144,6 +154,10 @@ pub struct XetRuntime {
     // Are we in the middle of a sigint shutdown?
     sigint_shutdown: AtomicBool,
 
+    // Callers currently inside work that must not be interrupted by a shutdown - see
+    // [`enter_finalizing`](XetRuntime::enter_finalizing).
+    finalizing: AtomicUsize,
+
     // PID of the process that created this runtime; used in Drop to detect fork.
     creation_pid: u32,
 
@@ -177,6 +191,7 @@ impl XetRuntime {
             handle_ref: OnceLock::new(),
             external_executor_count: 0.into(),
             sigint_shutdown: false.into(),
+            finalizing: AtomicUsize::new(0),
             creation_pid: std::process::id(),
             system_monitor: system_monitor_for_config(config),
         });
@@ -237,6 +252,7 @@ impl XetRuntime {
             handle_ref: rt_handle.into(),
             external_executor_count: 0.into(),
             sigint_shutdown: false.into(),
+            finalizing: AtomicUsize::new(0),
             creation_pid: std::process::id(),
             system_monitor: system_monitor_for_config(config),
         });
@@ -256,6 +272,7 @@ impl XetRuntime {
             handle_ref: rt_handle.into(),
             external_executor_count: 0.into(),
             sigint_shutdown: false.into(),
+            finalizing: AtomicUsize::new(0),
             creation_pid: std::process::id(),
             system_monitor: None,
         })
@@ -383,6 +400,21 @@ impl XetRuntime {
     /// and false otherwise.
     pub fn in_sigint_shutdown(&self) -> bool {
         self.sigint_shutdown.load(Ordering::SeqCst)
+    }
+
+    /// Marks the caller as inside work that a shutdown must not interrupt, until the guard drops.
+    ///
+    /// Shutting this runtime down cancels whatever is still running, so a caller about to do that
+    /// can poll [`finalizing_in_flight`](Self::finalizing_in_flight) first and give such work a
+    /// chance to finish. The runtime does not care what the work is; it only counts.
+    pub fn enter_finalizing(self: &Arc<Self>) -> FinalizingGuard {
+        self.finalizing.fetch_add(1, Ordering::AcqRel);
+        FinalizingGuard(self.clone())
+    }
+
+    /// How many [`enter_finalizing`](Self::enter_finalizing) guards are currently held.
+    pub fn finalizing_in_flight(&self) -> usize {
+        self.finalizing.load(Ordering::Acquire)
     }
 
     fn check_sigint(&self) -> Result<(), RuntimeError> {

--- a/xet_runtime/src/core/runtime/native.rs
+++ b/xet_runtime/src/core/runtime/native.rs
@@ -351,10 +351,8 @@ impl XetRuntime {
             return;
         };
 
-        // Let best-effort detached work finish before the drop below cancels it, exactly as
-        // `Drop for XetRuntime` does. Without this, a SIGINT teardown silently discards work that
-        // the graceful path delivers - notably the telemetry document reporting the very transfer
-        // the user just interrupted, which is the abandonment most worth capturing.
+        // Let best-effort detached work finish before the drop below cancels it - notably the
+        // telemetry document reporting the transfer the user just interrupted.
         if let Some(drain) = PRE_SHUTDOWN_DRAIN.get() {
             drain();
         }
@@ -406,7 +404,7 @@ impl XetRuntime {
     ///
     /// Shutting this runtime down cancels whatever is still running, so a caller about to do that
     /// can poll [`finalizing_in_flight`](Self::finalizing_in_flight) first and give such work a
-    /// chance to finish. The runtime does not care what the work is; it only counts.
+    /// chance to finish.
     pub fn enter_finalizing(self: &Arc<Self>) -> FinalizingGuard {
         self.finalizing.fetch_add(1, Ordering::AcqRel);
         FinalizingGuard(self.clone())

--- a/xet_runtime/src/core/runtime/native.rs
+++ b/xet_runtime/src/core/runtime/native.rs
@@ -334,6 +334,14 @@ impl XetRuntime {
             return;
         };
 
+        // Let best-effort detached work finish before the drop below cancels it, exactly as
+        // `Drop for XetRuntime` does. Without this, a SIGINT teardown silently discards work that
+        // the graceful path delivers - notably the telemetry document reporting the very transfer
+        // the user just interrupted, which is the abandonment most worth capturing.
+        if let Some(drain) = PRE_SHUTDOWN_DRAIN.get() {
+            drain();
+        }
+
         // Dropping the runtime will cancel all the tasks; shutdown occurs when the next async call
         // is encountered.  Ideally, all async code should be cancellation safe.
         drop(runtime);


### PR DESCRIPTION
## The bug

A download interrupted with Ctrl-C reported no telemetry at all. Verified against production: `hf download` interrupted mid-transfer produced zero documents; it now reports `outcome=cancelled`.

The terminal report is produced at the tail of the future handed to a `_finalizing` bridge, after the cancelled work returns:

```rust
let result = inner.handle_finish().await;
finalize_download_session(&ds, &result).await;   // <- the report
```

Both bridges wrapped that whole future in a `select!` against the cancellation token, so a cancel dropped the future and took the report with it. `perform_sigint_shutdown` then destroyed the runtime without running the pre-shutdown drain, so anything already in flight was cancelled rather than delivered.

## The fix

- **Non-racing finalizing bridges.** `bridge_sync_finalizing` / `bridge_async_finalizing` run their future to completion. The inner work still returns promptly on cancel — it observes the token through the per-task mapped handles. `upload_stream_handle` is the one caller whose inner future watches no token, so it keeps the old behaviour via explicit `_cancellable` variants.
- **`perform_sigint_shutdown` runs the pre-shutdown drain** before dropping the runtime, as `Drop for XetRuntime` already did.
- **`sigint_abort` cancels first and tears the runtime down last**, waiting in between for finalizing work to finish. `XetRuntime` counts that work (`enter_finalizing` / `finalizing_in_flight`) so the wait ends as soon as it is done.
- **`final_flush_timeout` 2s → 500ms**, now both the drain budget and the `sigint_abort` ceiling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SIGINT shutdown, task-runtime cancellation semantics, and telemetry flush timing; behavior change is intentional but affects all interrupt and finalize paths on native targets.
> 
> **Overview**
> **Ctrl-C and abort paths no longer drop download telemetry.** Interrupted transfers (e.g. `hf download`) used to emit no terminal document because finalizing bridges raced their futures against the cancellation token and dropped the tail that calls `finalize_download_session`, and `perform_sigint_shutdown` tore down the runtime before draining in-flight telemetry.
> 
> **Finalizing bridges** now run to completion by default (`run_inner_async_to_completion` / non-racing sync path) so cooperative cancel still returns quickly but the terminal report always runs. Upload stream `finish` keeps the old cancel race via explicit `_cancellable` variants because inner work does not watch the token. **`XetRuntime`** adds `enter_finalizing` / `finalizing_in_flight` so shutdown can wait for that work; **`sigint_abort`** cancels first, polls until finalizing work finishes (bounded by `final_flush_timeout`), then runs the pre-shutdown drain and drops the runtime. **`FileDownloadSession::finalize_abandoned`** is idempotent and called from `Drop` and from download group `abort()` before runtime destruction. Download **`finish`** moves session finalization inside the bridged future. Default **`final_flush_timeout`** is **500ms** (was 2s). Integration tests cover `abort` + `sigint_abort` and interrupt mid-`finish_blocking`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f62060885fa3b397d61c5a4fc7e7a7c1a8be07ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->