### PR TITLE
fix(download): let an aborted download group actually stop its transfers

### DIFF
--- a/api_changes/update_260824_download_cancellation_token.md
+++ b/api_changes/update_260824_download_cancellation_token.md
@@ -1,0 +1,50 @@
+# API Update: `download_file_background` takes a cancellation token
+
+## Background
+
+`XetFileDownloadGroup::abort()` returned promptly but the transfer it was meant to stop kept
+running to completion, holding bandwidth and then discarding the data (issue #942).
+
+`FileDownloadSession::setup_reconstructor` never called
+`FileReconstructor::with_cancellation_token`, so every reconstruction ran with a token the
+reconstructor had built for itself and nobody held a handle to. Its cancellation checks could
+not fire. The group's `abort()` aborted the wrapper join handle, which drops that one task but
+not the work the reconstruction had already spawned, since those are not its children.
+
+## Change
+
+`FileDownloadSession::download_file_background` takes a fourth argument:
+
+```rust
+pub async fn download_file_background(
+    self: &Arc<Self>,
+    file_info: XetFileInfo,
+    write_path: PathBuf,
+    cancellation_token: Option<CancellationToken>,
+) -> Result<(UniqueId, JoinHandle<Result<u64>>)>
+```
+
+The token is passed to the reconstructor, so cancelling it stops the term loop from
+scheduling further ranges.
+
+## Applying this downstream
+
+Pass `None` to keep the previous behaviour:
+
+```rust
+session.download_file_background(file_info, path, None).await?
+```
+
+Pass a token if the caller can be aborted. `XetFileDownloadGroup` now creates its per-file
+child task runtime before starting the transfer so it can hand over
+`task_runtime.cancellation_token()`.
+
+## Behaviour note
+
+A download stopped by its token returns the bytes written so far rather than
+`DataError::SizeMismatch`. The size check in `download_file_with_id` is skipped when the token
+is cancelled, because a short read is expected in that case and reporting a user abort as a
+corrupt download would be misleading.
+
+Private signatures changed alongside it: `setup_reconstructor` and `download_file_with_id`
+both take the same `Option<CancellationToken>`. Neither is public.

--- a/xet_data/src/processing/file_download_session.rs
+++ b/xet_data/src/processing/file_download_session.rs
@@ -9,6 +9,7 @@ use std::sync::{Arc, Mutex};
 
 #[cfg(not(target_family = "wasm"))]
 use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 use tracing::instrument;
 use xet_client::cas_client::Client;
 use xet_client::cas_types::FileRange;
@@ -146,7 +147,7 @@ impl FileDownloadSession {
         let id = UniqueId::new();
         let progress_updater = self.progress.new_item(id, "stream");
         let range = source_range.map(|r| FileRange::new(r.start, r.end));
-        let reconstructor = self.setup_reconstructor(file_info, range, Some(progress_updater))?;
+        let reconstructor = self.setup_reconstructor(file_info, range, Some(progress_updater), None)?;
         let stream = reconstructor.reconstruct_to_stream();
         self.register_stream_abort_callback(id, stream.abort_callback());
         Ok((id, stream))
@@ -174,7 +175,7 @@ impl FileDownloadSession {
         let id = UniqueId::new();
         let progress_updater = self.progress.new_item(id, "unordered_stream");
         let range = source_range.map(|r| FileRange::new(r.start, r.end));
-        let reconstructor = self.setup_reconstructor(file_info, range, Some(progress_updater))?;
+        let reconstructor = self.setup_reconstructor(file_info, range, Some(progress_updater), None)?;
         let stream = reconstructor.reconstruct_to_unordered_stream();
         self.register_stream_abort_callback(id, stream.abort_callback());
         Ok((id, stream))
@@ -195,7 +196,7 @@ impl FileDownloadSession {
         let file_range = range_bounds_to_file_range(&range)?;
         let id = UniqueId::new();
         let progress_updater = self.progress.new_item(id, "stream");
-        let reconstructor = self.setup_reconstructor(file_info, file_range, Some(progress_updater))?;
+        let reconstructor = self.setup_reconstructor(file_info, file_range, Some(progress_updater), None)?;
         let stream = reconstructor.reconstruct_to_stream();
         self.register_stream_abort_callback(id, stream.abort_callback());
         Ok((id, stream))
@@ -270,10 +271,18 @@ impl FileDownloadSession {
         file_info: &XetFileInfo,
         range: Option<FileRange>,
         progress_updater: Option<Arc<ItemProgressUpdater>>,
+        cancellation_token: Option<CancellationToken>,
     ) -> Result<FileReconstructor> {
         let file_id = file_info.merkle_hash()?;
 
         let mut reconstructor = FileReconstructor::new(&self.ctx, &self.client, file_id);
+
+        // Without a caller-supplied token the reconstructor builds its own, which nothing
+        // holds a handle to, so its cancellation checks can never fire. Callers that can be
+        // aborted pass their token here so the term loop stops scheduling new ranges.
+        if let Some(token) = cancellation_token {
+            reconstructor = reconstructor.with_cancellation_token(token);
+        }
 
         match range {
             Some(range) if range.end < u64::MAX => {
@@ -329,6 +338,7 @@ impl FileDownloadSession {
         self: &Arc<Self>,
         file_info: XetFileInfo,
         write_path: PathBuf,
+        cancellation_token: Option<CancellationToken>,
     ) -> Result<(UniqueId, JoinHandle<Result<u64>>)> {
         self.check_not_finalized()?;
         let id = UniqueId::new();
@@ -336,8 +346,13 @@ impl FileDownloadSession {
         let runtime = self.ctx.runtime.clone();
         let semaphore = self.ctx.common.file_download_semaphore.clone();
         let handle = runtime.spawn(async move {
+            // Aborting the returned handle only drops this task; work the reconstruction
+            // already spawned is not its child and keeps running. The token has to travel
+            // with the work itself so the term loop stops scheduling new ranges.
             let _permit = semaphore.acquire().await?;
-            session.download_file_with_id(&file_info, &write_path, id).await
+            session
+                .download_file_with_id(&file_info, &write_path, id, cancellation_token)
+                .await
         });
         Ok((id, handle))
     }
@@ -347,15 +362,29 @@ impl FileDownloadSession {
     pub async fn download_file(&self, file_info: &XetFileInfo, write_path: &Path) -> Result<(UniqueId, u64)> {
         self.check_not_finalized()?;
         let id = UniqueId::new();
-        let n_bytes = self.download_file_with_id(file_info, write_path, id).await?;
+        let n_bytes = self.download_file_with_id(file_info, write_path, id, None).await?;
         Ok((id, n_bytes))
     }
 
-    async fn download_file_with_id(&self, file_info: &XetFileInfo, write_path: &Path, id: UniqueId) -> Result<u64> {
+    async fn download_file_with_id(
+        &self,
+        file_info: &XetFileInfo,
+        write_path: &Path,
+        id: UniqueId,
+        cancellation_token: Option<CancellationToken>,
+    ) -> Result<u64> {
         let name = Arc::from(write_path.to_string_lossy().as_ref());
         let progress_updater = self.progress.new_item(id, name);
-        let reconstructor = self.setup_reconstructor(file_info, None, Some(progress_updater))?;
+        let cancellation = cancellation_token.clone();
+        let reconstructor = self.setup_reconstructor(file_info, None, Some(progress_updater), cancellation_token)?;
         let n_bytes = reconstructor.reconstruct_to_file(write_path, None, true).await?;
+
+        // A cancelled transfer stops short on purpose, so the short read is expected. Running
+        // it through the size check below would report a user abort as a corrupt download.
+        if cancellation.is_some_and(|token| token.is_cancelled()) {
+            return Ok(n_bytes);
+        }
+
         // Caller is responsible for cleaning up the file on error (consistent
         // with other error paths); see download_group.rs error handling.
         if let Some(expected_size) = file_info.file_size()
@@ -400,7 +429,7 @@ impl FileDownloadSession {
         let id = UniqueId::new();
         let name = Arc::from("");
         let progress_updater = self.progress.new_item(id, name);
-        let reconstructor = self.setup_reconstructor(file_info, range, Some(progress_updater))?;
+        let reconstructor = self.setup_reconstructor(file_info, range, Some(progress_updater), None)?;
         let n_bytes = reconstructor.reconstruct_to_writer(writer).await?;
 
         let expected_size = match range {
@@ -531,6 +560,101 @@ mod tests {
 
                 let out_path = temp.path().join("output.txt");
                 let (_id, n_bytes) = session.download_file(&xfi, &out_path).await.unwrap();
+
+                assert_eq!(n_bytes, original_data.len() as u64);
+                assert_eq!(read(&out_path).unwrap(), original_data);
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn test_download_file_background_honours_a_cancelled_token() {
+        // A token that is already cancelled must stop the transfer rather than run it to
+        // completion. Before the token was threaded through, the reconstructor built its own
+        // token that nothing could cancel, so the download finished and wrote the whole file.
+        let runtime = get_runtime();
+        runtime
+            .bridge_sync(async {
+                let temp = tempdir().unwrap();
+                let cas_path = temp.path().join("cas");
+                let original_data = b"cancelled before it starts";
+
+                let xfi = upload_data(&cas_path, original_data).await;
+
+                let config = TranslatorConfig::local_config(&XetContext::default().unwrap(), &cas_path).unwrap();
+                let session = FileDownloadSession::new(config.into(), None).await.unwrap();
+
+                let token = CancellationToken::new();
+                token.cancel();
+
+                let out_path = temp.path().join("cancelled.txt");
+                let (_id, handle) = session
+                    .download_file_background(xfi, out_path.clone(), Some(token))
+                    .await
+                    .unwrap();
+
+                let n_bytes = handle.await.unwrap().unwrap();
+
+                assert_eq!(n_bytes, 0, "a cancelled download must not transfer the file");
+                assert!(
+                    read(&out_path).map(|d| d.is_empty()).unwrap_or(true),
+                    "a cancelled download must not write the file contents"
+                );
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn test_download_file_background_without_a_token_still_downloads() {
+        // The token is optional; callers that cannot be aborted keep the old behaviour.
+        let runtime = get_runtime();
+        runtime
+            .bridge_sync(async {
+                let temp = tempdir().unwrap();
+                let cas_path = temp.path().join("cas");
+                let original_data = b"no token, ordinary download";
+
+                let xfi = upload_data(&cas_path, original_data).await;
+
+                let config = TranslatorConfig::local_config(&XetContext::default().unwrap(), &cas_path).unwrap();
+                let session = FileDownloadSession::new(config.into(), None).await.unwrap();
+
+                let out_path = temp.path().join("plain.txt");
+                let (_id, handle) = session
+                    .download_file_background(xfi, out_path.clone(), None)
+                    .await
+                    .unwrap();
+
+                let n_bytes = handle.await.unwrap().unwrap();
+
+                assert_eq!(n_bytes, original_data.len() as u64);
+                assert_eq!(read(&out_path).unwrap(), original_data);
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn test_download_file_background_with_a_live_token_downloads() {
+        // An uncancelled token must not interfere with a normal transfer.
+        let runtime = get_runtime();
+        runtime
+            .bridge_sync(async {
+                let temp = tempdir().unwrap();
+                let cas_path = temp.path().join("cas");
+                let original_data = b"live token, ordinary download";
+
+                let xfi = upload_data(&cas_path, original_data).await;
+
+                let config = TranslatorConfig::local_config(&XetContext::default().unwrap(), &cas_path).unwrap();
+                let session = FileDownloadSession::new(config.into(), None).await.unwrap();
+
+                let out_path = temp.path().join("live.txt");
+                let (_id, handle) = session
+                    .download_file_background(xfi, out_path.clone(), Some(CancellationToken::new()))
+                    .await
+                    .unwrap();
+
+                let n_bytes = handle.await.unwrap().unwrap();
 
                 assert_eq!(n_bytes, original_data.len() as u64);
                 assert_eq!(read(&out_path).unwrap(), original_data);

--- a/xet_pkg/src/legacy/data_client.rs
+++ b/xet_pkg/src/legacy/data_client.rs
@@ -167,7 +167,7 @@ pub async fn download_async(
 
     for ((file_info, file_path), updater) in file_infos.into_iter().zip(updaters) {
         let path = PathBuf::from(&file_path);
-        let (id, handle) = session.download_file_background(file_info, path).await?;
+        let (id, handle) = session.download_file_background(file_info, path, None).await?;
 
         let bridge = updater.map(|u| ItemProgressCallbackUpdater::start(session.clone(), id, u));
 

--- a/xet_pkg/src/xet_session/file_download_group.rs
+++ b/xet_pkg/src/xet_session/file_download_group.rs
@@ -354,13 +354,17 @@ impl XetFileDownloadGroupInner {
         parent_task_runtime: &Arc<TaskRuntime>,
     ) -> Result<XetFileDownload, XetError> {
         let absolute_path = std::path::absolute(dest_path)?;
-        let (task_id, join_handle) = self
-            .download_session
-            .download_file_background(file_info.clone(), absolute_path.clone())
-            .await?;
 
+        // The child runtime is created before the download starts so its token can be handed
+        // to the transfer itself. Aborting the join handle below only drops the wrapper task;
+        // the reconstruction's own work is not its child and would otherwise run to completion.
         let task_runtime = parent_task_runtime.child()?;
         let token = task_runtime.cancellation_token();
+
+        let (task_id, join_handle) = self
+            .download_session
+            .download_file_background(file_info.clone(), absolute_path.clone(), Some(token.clone()))
+            .await?;
 
         let fi = file_info.clone();
         let dp = absolute_path.clone();


### PR DESCRIPTION
Fixes #942.

## What was happening

`XetFileDownloadGroup::abort()` unblocked the caller straight away, but the transfer it was
meant to stop carried on. The report has a 1 GB file aborted after five seconds still pulling
data for another three minutes, roughly 1.2 GB moved and then discarded.

## Why

Two separate things, and each one on its own would have been enough.

`FileDownloadSession::setup_reconstructor` never called
`FileReconstructor::with_cancellation_token`. Every reconstruction therefore ran with the
token `FileReconstructor::new` builds for itself, which no caller holds a handle to. The
reconstruction loop does check that token, at the outer term loop, at each term, and while
waiting on the download buffer semaphore, but nothing could ever cancel it. Searching for
`with_cancellation_token` in the tree turns up three call sites, all inside
`mod cancellation_tests`. The mechanism was live in tests and dead in production.

Separately, `abort()` calls `download_join_handle.abort()`. That drops the wrapper task, which
is why the Python caller returns immediately and `wait_to_finish()` raises. But the work the
reconstruction had already spawned is not a child of that task, so aborting the handle does
nothing to it. Tokio does not cancel the tasks a cancelled task spawned.

So the caller saw a cancelled download and the network saw a download running to completion.

## The change

`download_file_background` takes an `Option<CancellationToken>` and passes it down through
`download_file_with_id` to `setup_reconstructor`, which hands it to the reconstructor. The
existing checks in the term loop then do what they were written to do.

`XetFileDownloadGroup::start_download_file_to_path` creates its per-file child task runtime
before starting the transfer rather than after, so it has a token to pass. That reorder is the
whole change on the `xet_pkg` side.

One behaviour change worth calling out. `download_file_with_id` validates the byte count
against `file_info.file_size()` and returns `DataError::SizeMismatch` on a mismatch. A
cancelled download stops short by design, so it tripped that check and a user abort surfaced
as a corrupt download. The size check is now skipped when the token is cancelled.

`download_file_background` is public, so `api_changes/update_260824_download_cancellation_token.md`
is included per the convention in `api_changes/README.md`. The one other caller,
`legacy/data_client.rs`, passes `None` and is unchanged in behaviour.

## What this does and does not do

It stops new ranges being scheduled. Ranges already in flight when the token fires still run to
completion, so abort frees bandwidth progressively rather than instantly. That matches the
issue's stated expectation ("cancel outstanding chunk transfers or prevent scheduling new
ranges") on the second count.

If you want in-flight range requests torn down as well, that is a larger change into the
transfer scheduler and I would rather do it as a follow-up than bundle it here. Happy to take
it on if you point me at where you would want the seam.

## Testing

Three tests in `xet_data/src/processing/file_download_session.rs`, using the existing local-CAS
harness, so no network:

- an already-cancelled token stops the transfer: 0 bytes, no file contents written
- `None` still downloads normally, so the token is genuinely optional
- a live, uncancelled token downloads normally, so passing one does not interfere

```
cargo test -p xet-data --lib
cargo test -p hf-xet --lib
```

280 passing in `xet-data` and 142 in `hf-xet`.

I checked the tests against the unfixed code by leaving the plumbing in place and removing only
the `with_cancellation_token` hand-off. The cancellation test fails, the other two pass. That is
the isolation I wanted: the two that pass either way are regression cover, and the one that
flips is the one demonstrating the bug.

`cargo fmt --check` is clean. `cargo clippy --all-targets` reports the same two warnings in
`file_download_session.rs` before and after this change, both well away from the lines touched,
so I left them alone.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core download cancellation and error classification for aborted transfers; behavior change is intentional but affects bandwidth and how partial downloads surface to callers.
> 
> **Overview**
> Fixes aborted download groups continuing to pull data (#942) by threading a caller-owned **`CancellationToken`** through background file downloads into **`FileReconstructor`**, so the reconstruction term loop can stop scheduling new ranges when the group is cancelled.
> 
> **`FileDownloadSession::download_file_background`** now takes `Option<CancellationToken>`; **`setup_reconstructor`** applies **`with_cancellation_token`** when a token is supplied (streaming paths pass `None`). **`XetFileDownloadGroup`** creates the per-file child **`TaskRuntime`** before starting the transfer and passes **`task_runtime.cancellation_token()`** into the session. The legacy **`download_async`** path passes **`None`**, preserving prior behavior.
> 
> When a download is stopped via cancellation, **`download_file_with_id`** returns bytes written so far and **skips** the expected-size **`SizeMismatch`** check so user abort is not reported as corruption. An **`api_changes`** note documents the public signature change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19b079b0490fb5156c778ccb4da9671b15a0ee54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->