### PR TITLE
perf(xet_client): stream multipart byte-range responses

### DIFF
--- a/xet_client/src/cas_client/multipart.rs
+++ b/xet_client/src/cas_client/multipart.rs
@@ -1,4 +1,4 @@
-use bytes::Bytes;
+use bytes::{Buf, Bytes, BytesMut};
 
 use crate::cas_types::HttpRange;
 use crate::error::{ClientError, Result};
@@ -9,10 +9,155 @@ pub struct MultipartPart {
     pub data: Bytes,
 }
 
-/// Parse a `multipart/byteranges` HTTP response body (RFC 7233 §4.1).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ParserState {
+    Preamble,
+    AfterBoundary,
+    Part,
+}
+
+/// Incrementally parses a `multipart/byteranges` HTTP response body (RFC 7233 §4.1).
+///
+/// Completed parts are returned as soon as their terminating boundary is received, so the parser
+/// does not explicitly aggregate the entire response. Its logical payload buffer is limited to
+/// the incomplete current part, aside from the incoming transport chunk and allocator capacity.
+pub(crate) struct StreamingMultipartParser {
+    delimiter: Vec<u8>,
+    buffer: BytesMut,
+    search_from: usize,
+    state: ParserState,
+    done: bool,
+}
+
+impl StreamingMultipartParser {
+    pub(crate) fn new(content_type: &str) -> Result<Self> {
+        let boundary = extract_boundary(content_type)?;
+
+        // Include the preceding CRLF so it is not left attached to the part body. Seed the
+        // buffer with a virtual CRLF so a body may also start directly with `--boundary`.
+        let delimiter = format!("\r\n--{boundary}").into_bytes();
+        let mut buffer = BytesMut::with_capacity(delimiter.len());
+        buffer.extend_from_slice(b"\r\n");
+
+        Ok(Self {
+            delimiter,
+            buffer,
+            search_from: 0,
+            state: ParserState::Preamble,
+            done: false,
+        })
+    }
+
+    /// Pushes another response-body chunk and returns every part completed by that chunk.
+    pub(crate) fn push(&mut self, chunk: Bytes) -> Result<Vec<MultipartPart>> {
+        if self.done {
+            return Ok(Vec::new());
+        }
+
+        self.buffer.extend_from_slice(&chunk);
+        self.parse_available()
+    }
+
+    /// Finishes parsing after the response stream reaches EOF.
+    ///
+    /// For compatibility with the previous whole-body parser, a final part without a closing
+    /// boundary is accepted if it otherwise has valid headers.
+    pub(crate) fn finish(&mut self) -> Result<Vec<MultipartPart>> {
+        let mut parts = self.parse_available()?;
+        if self.done {
+            return Ok(parts);
+        }
+
+        match self.state {
+            ParserState::Preamble => {
+                return Err(ClientError::Other("No boundary found in multipart body".to_string()));
+            },
+            ParserState::AfterBoundary => {
+                // The previous whole-body parser stopped successfully after an exact boundary,
+                // even when neither CRLF nor the closing `--` followed it. Preserve that EOF
+                // behavior while moving to incremental parsing.
+                self.buffer.clear();
+                self.done = true;
+            },
+            ParserState::Part => {
+                let part = self.buffer.split().freeze();
+                parts.push(parse_part(part)?);
+                self.done = true;
+            },
+        }
+
+        Ok(parts)
+    }
+
+    fn parse_available(&mut self) -> Result<Vec<MultipartPart>> {
+        let mut parts = Vec::new();
+
+        loop {
+            match self.state {
+                ParserState::Preamble | ParserState::Part => {
+                    let delimiter_position = find_subsequence(&self.buffer[self.search_from..], &self.delimiter)
+                        .map(|position| self.search_from + position);
+
+                    let Some(delimiter_position) = delimiter_position else {
+                        if self.state == ParserState::Preamble {
+                            // Discard confirmed preamble while preserving a possible partial delimiter.
+                            let keep = self.delimiter.len().saturating_sub(1);
+                            let discard = self.buffer.len().saturating_sub(keep);
+                            self.buffer.advance(discard);
+                            self.search_from = 0;
+                        } else {
+                            // Only the new suffix can begin a delimiter on the next push.
+                            self.search_from = self.buffer.len().saturating_sub(self.delimiter.len() - 1);
+                        }
+                        break;
+                    };
+
+                    if self.state == ParserState::Part {
+                        let part = self.buffer.split_to(delimiter_position).freeze();
+                        parts.push(parse_part(part)?);
+                    } else {
+                        self.buffer.advance(delimiter_position);
+                    }
+
+                    self.buffer.advance(self.delimiter.len());
+                    self.search_from = 0;
+                    self.state = ParserState::AfterBoundary;
+                },
+                ParserState::AfterBoundary => {
+                    if self.buffer.len() < 2 {
+                        break;
+                    }
+
+                    if self.buffer.starts_with(b"--") {
+                        self.buffer.advance(2);
+                        self.buffer.clear();
+                        self.done = true;
+                        break;
+                    }
+
+                    if self.buffer.starts_with(b"\r\n") {
+                        self.buffer.advance(2);
+                        self.search_from = 0;
+                        self.state = ParserState::Part;
+                        continue;
+                    }
+
+                    return Err(ClientError::Other(
+                        "Malformed multipart body: expected CRLF or closing delimiter after boundary".to_string(),
+                    ));
+                },
+            }
+        }
+
+        Ok(parts)
+    }
+}
+
+/// Parse a complete `multipart/byteranges` HTTP response body (RFC 7233 §4.1).
 ///
 /// Extracts the boundary from `content_type`, splits the body by boundary markers,
-/// parses `Content-Range` headers from each part, and returns parts sorted by byte range start.
+/// parses `Content-Range` headers from each part, and returns zero-copy parts sorted by byte
+/// range start. The HTTP client uses its crate-private streaming parser instead.
 pub fn parse_multipart_byteranges(content_type: &str, body: Bytes) -> Result<Vec<MultipartPart>> {
     let boundary = extract_boundary(content_type)?;
 
@@ -21,12 +166,12 @@ pub fn parse_multipart_byteranges(content_type: &str, body: Bytes) -> Result<Vec
 
     let mut parts = Vec::new();
 
-    let first_delim = format!("--{boundary}");
-    let Some(start) = find_subsequence(body_slice, first_delim.as_bytes()) else {
+    let first_delimiter = format!("--{boundary}");
+    let Some(start) = find_subsequence(body_slice, first_delimiter.as_bytes()) else {
         return Err(ClientError::Other("No boundary found in multipart body".to_string()));
     };
 
-    let mut remaining = &body_slice[start + first_delim.len()..];
+    let mut remaining = &body_slice[start + first_delimiter.len()..];
 
     loop {
         if remaining.starts_with(b"\r\n") {
@@ -37,7 +182,7 @@ pub fn parse_multipart_byteranges(content_type: &str, body: Bytes) -> Result<Vec
 
         let next_boundary = find_subsequence(remaining, delimiter.as_bytes());
         let part_data = match next_boundary {
-            Some(pos) => &remaining[..pos],
+            Some(position) => &remaining[..position],
             None => remaining,
         };
 
@@ -50,8 +195,8 @@ pub fn parse_multipart_byteranges(content_type: &str, body: Bytes) -> Result<Vec
         let data = &part_data[data_start..];
 
         let range = parse_content_range(headers)?;
-        // Compute the absolute byte offset into the original `body` so we can
-        // use Bytes::slice for zero-copy extraction of this part's data.
+        // Compute the absolute byte offset into the original `body` so we can use Bytes::slice
+        // for zero-copy extraction of this part's data.
         let offset =
             body.len() - body_slice.len() + (remaining.as_ptr() as usize - body_slice.as_ptr() as usize) + data_start;
         parts.push(MultipartPart {
@@ -60,16 +205,29 @@ pub fn parse_multipart_byteranges(content_type: &str, body: Bytes) -> Result<Vec
         });
 
         match next_boundary {
-            Some(pos) => {
-                remaining = &remaining[pos + delimiter.len()..];
+            Some(position) => {
+                remaining = &remaining[position + delimiter.len()..];
             },
             None => break,
         }
     }
 
-    parts.sort_by_key(|p| p.range.start);
-
+    parts.sort_by_key(|part| part.range.start);
     Ok(parts)
+}
+
+fn parse_part(part: Bytes) -> Result<MultipartPart> {
+    let Some(header_end) = find_subsequence(&part, b"\r\n\r\n") else {
+        return Err(ClientError::Other("Malformed multipart part: missing header/data separator".to_string()));
+    };
+
+    let range = parse_content_range(&part[..header_end])?;
+    let data_start = header_end + 4;
+
+    Ok(MultipartPart {
+        range,
+        data: part.slice(data_start..),
+    })
 }
 
 fn extract_boundary(content_type: &str) -> Result<String> {
@@ -124,6 +282,23 @@ fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
 mod tests {
     use super::*;
 
+    fn multipart_body(boundary: &str, parts: &[(HttpRange, &[u8])]) -> Bytes {
+        let mut body = Vec::new();
+        for (range, data) in parts {
+            body.extend_from_slice(
+                format!(
+                    "--{boundary}\r\nContent-Type: application/octet-stream\r\nContent-Range: bytes {}-{}/1000\r\n\r\n",
+                    range.start, range.end
+                )
+                .as_bytes(),
+            );
+            body.extend_from_slice(data);
+            body.extend_from_slice(b"\r\n");
+        }
+        body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
+        Bytes::from(body)
+    }
+
     #[test]
     fn test_extract_boundary() {
         assert_eq!(extract_boundary("multipart/byteranges; boundary=something").unwrap(), "something");
@@ -138,34 +313,136 @@ mod tests {
     #[test]
     fn test_parse_single_part() {
         let boundary = "abc123";
-        let body = format!(
-            "--{boundary}\r\nContent-Type: application/octet-stream\r\nContent-Range: bytes 0-99/1000\r\n\r\nHello World\r\n--{boundary}--\r\n"
-        );
+        let body = multipart_body(boundary, &[(HttpRange::new(0, 99), b"Hello World")]);
+        let body_start = body.as_ptr() as usize;
+        let body_end = body_start + body.len();
         let content_type = format!("multipart/byteranges; boundary={boundary}");
 
-        let parts = parse_multipart_byteranges(&content_type, Bytes::from(body)).unwrap();
+        let parts = parse_multipart_byteranges(&content_type, body).unwrap();
         assert_eq!(parts.len(), 1);
         assert_eq!(parts[0].range.start, 0);
         assert_eq!(parts[0].range.end, 99);
         assert_eq!(&parts[0].data[..], b"Hello World");
+        let data_start = parts[0].data.as_ptr() as usize;
+        assert!((body_start..body_end).contains(&data_start), "part data must slice the input Bytes");
     }
 
     #[test]
-    fn test_parse_multiple_parts() {
+    fn test_parse_multiple_parts_sorts_by_range() {
         let boundary = "sep";
-        let body = format!(
-            "--{boundary}\r\nContent-Range: bytes 100-199/1000\r\n\r\nPart2Data\r\n--{boundary}\r\nContent-Range: bytes 0-49/1000\r\n\r\nPart1Data\r\n--{boundary}--\r\n"
+        let body = multipart_body(
+            boundary,
+            &[
+                (HttpRange::new(100, 199), b"Part2Data"),
+                (HttpRange::new(0, 49), b"Part1Data"),
+            ],
         );
         let content_type = format!("multipart/byteranges; boundary={boundary}");
 
-        let parts = parse_multipart_byteranges(&content_type, Bytes::from(body)).unwrap();
+        let parts = parse_multipart_byteranges(&content_type, body).unwrap();
         assert_eq!(parts.len(), 2);
         assert_eq!(parts[0].range.start, 0);
-        assert_eq!(parts[0].range.end, 49);
         assert_eq!(&parts[0].data[..], b"Part1Data");
         assert_eq!(parts[1].range.start, 100);
-        assert_eq!(parts[1].range.end, 199);
         assert_eq!(&parts[1].data[..], b"Part2Data");
+    }
+
+    #[test]
+    fn test_streaming_emits_part_before_end_of_body() {
+        let boundary = "streaming";
+        let body = multipart_body(
+            boundary,
+            &[
+                (HttpRange::new(0, 9), b"first-part"),
+                (HttpRange::new(100, 110), b"second-part"),
+            ],
+        );
+        let split = find_subsequence(&body, b"second-part").unwrap();
+        let content_type = format!("multipart/byteranges; boundary={boundary}");
+        let mut parser = StreamingMultipartParser::new(&content_type).unwrap();
+
+        let first = parser.push(body.slice(..split)).unwrap();
+        assert_eq!(first.len(), 1);
+        assert_eq!(&first[0].data[..], b"first-part");
+        assert!(!parser.done);
+
+        let mut rest = parser.push(body.slice(split..)).unwrap();
+        rest.extend(parser.finish().unwrap());
+        assert_eq!(rest.len(), 1);
+        assert_eq!(&rest[0].data[..], b"second-part");
+    }
+
+    #[test]
+    fn test_streaming_handles_every_two_chunk_split() {
+        let boundary = "split-boundary";
+        let body = multipart_body(boundary, &[(HttpRange::new(0, 4), b"hello"), (HttpRange::new(10, 15), b"world!")]);
+        let content_type = format!("multipart/byteranges; boundary={boundary}");
+
+        for split in 0..=body.len() {
+            let mut parser = StreamingMultipartParser::new(&content_type).unwrap();
+            let mut parts = parser.push(body.slice(..split)).unwrap();
+            parts.extend(parser.push(body.slice(split..)).unwrap());
+            parts.extend(parser.finish().unwrap());
+
+            assert_eq!(parts.len(), 2, "split at {split}");
+            assert_eq!(&parts[0].data[..], b"hello", "split at {split}");
+            assert_eq!(&parts[1].data[..], b"world!", "split at {split}");
+        }
+    }
+
+    #[test]
+    fn test_streaming_one_byte_chunks_release_completed_parts() {
+        let boundary = "tiny-chunks";
+        let large_part = vec![0x5a; 4096];
+        let parts = (0..32)
+            .map(|index| {
+                let start = index * 5000;
+                (HttpRange::new(start, start + 4095), large_part.as_slice())
+            })
+            .collect::<Vec<_>>();
+        let body = multipart_body(boundary, &parts);
+        let content_type = format!("multipart/byteranges; boundary={boundary}");
+        let mut parser = StreamingMultipartParser::new(&content_type).unwrap();
+        let mut emitted = 0;
+        let mut max_retained = 0;
+        let mut max_retained_capacity = 0;
+
+        for byte in body.iter().copied() {
+            emitted += parser.push(Bytes::from(vec![byte])).unwrap().len();
+            max_retained = max_retained.max(parser.buffer.len());
+            max_retained_capacity = max_retained_capacity.max(parser.buffer.capacity());
+        }
+        emitted += parser.finish().unwrap().len();
+
+        assert_eq!(emitted, parts.len());
+        assert!(
+            max_retained <= large_part.len() + 256,
+            "retained {max_retained} bytes while the largest part is {} bytes",
+            large_part.len()
+        );
+        assert!(
+            max_retained_capacity < body.len() / 4,
+            "retained capacity {max_retained_capacity} for a {}-byte multipart body",
+            body.len()
+        );
+    }
+
+    #[test]
+    fn test_streaming_handles_binary_delimiter_prefixes() {
+        let boundary = "binary";
+        let data = b"\x00\r\n--binar\xff\r\n---\x00\xff";
+        let body = multipart_body(boundary, &[(HttpRange::new(0, data.len() as u64 - 1), data)]);
+        let content_type = format!("multipart/byteranges; boundary={boundary}");
+        let mut parser = StreamingMultipartParser::new(&content_type).unwrap();
+        let mut parts = Vec::new();
+
+        for byte in body.iter().copied() {
+            parts.extend(parser.push(Bytes::from(vec![byte])).unwrap());
+        }
+        parts.extend(parser.finish().unwrap());
+
+        assert_eq!(parts.len(), 1);
+        assert_eq!(&parts[0].data[..], data);
     }
 
     #[test]
@@ -182,5 +459,18 @@ mod tests {
         let content_type = format!("multipart/byteranges; boundary={boundary}");
         let result = parse_multipart_byteranges(&content_type, Bytes::from(body));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_streaming_finish_accepts_eof_immediately_after_boundary() {
+        let boundary = "legacy-eof";
+        let body = Bytes::from(format!("--{boundary}\r\nContent-Range: bytes 0-4/5\r\n\r\nhello\r\n--{boundary}"));
+        let content_type = format!("multipart/byteranges; boundary={boundary}");
+        let mut parser = StreamingMultipartParser::new(&content_type).unwrap();
+
+        let mut parts = parser.push(body).unwrap();
+        parts.extend(parser.finish().unwrap());
+        assert_eq!(parts.len(), 1);
+        assert_eq!(&parts[0].data[..], b"hello");
     }
 }

--- a/xet_client/src/cas_client/remote_client.rs
+++ b/xet_client/src/cas_client/remote_client.rs
@@ -654,35 +654,70 @@ impl Client for RemoteClient {
                         let is_multipart = content_type.contains("multipart/byteranges");
 
                         if is_multipart {
-                            let body = resp
-                                .bytes()
-                                .await
-                                .map_err(|e| RetryableReqwestError::RetryableError(ClientError::from(e)))?;
-
-                            let multipart_parts = crate::cas_client::multipart::parse_multipart_byteranges(&content_type, body)
+                            let mut incoming_stream = resp.bytes_stream();
+                            let mut parser = crate::cas_client::multipart::StreamingMultipartParser::new(&content_type)
                                 .map_err(RetryableReqwestError::FatalError)?;
-
                             let mut all_decompressed = Vec::with_capacity(uncompressed_size_if_known.unwrap_or(0));
-                            let mut all_chunk_indices = Vec::<u32>::new();
+                            let mut decoded_parts = Vec::new();
                             let mut total_compressed_bytes = 0u64;
 
-                            for part in multipart_parts {
-                                total_compressed_bytes += part.data.len() as u64;
+                            let mut process_parts = |parts: Vec<crate::cas_client::multipart::MultipartPart>| {
+                                for part in parts {
+                                    total_compressed_bytes += part.data.len() as u64;
+                                    let data_start = all_decompressed.len();
+                                    let mut reader = std::io::Cursor::new(part.data.as_ref());
+                                    let (_, chunk_indices) = xet_core_structures::xorb_object::deserialize_chunks_to_writer(
+                                        &mut reader,
+                                        &mut all_decompressed,
+                                    )
+                                    .map_err(|e| {
+                                        RetryableReqwestError::RetryableError(ClientError::FormatError(e))
+                                    })?;
 
-                                let (data, chunk_indices) =
-                                    xet_core_structures::xorb_object::deserialize_chunks(&mut std::io::Cursor::new(part.data.as_ref()))
-                                        .map_err(|e| {
-                                            RetryableReqwestError::RetryableError(ClientError::FormatError(e))
-                                        })?;
+                                    let data_end = all_decompressed.len();
+                                    decoded_parts.push((part.range, data_start..data_end, chunk_indices));
+                                    transfer_reporter.report_progress(total_compressed_bytes as usize);
+                                }
+                                Ok::<_, RetryableReqwestError>(())
+                            };
 
-                                xet_core_structures::xorb_object::append_chunk_segment(
-                                    &mut all_decompressed,
-                                    &mut all_chunk_indices,
-                                    &data,
-                                    &chunk_indices,
-                                );
+                            while let Some(chunk) = incoming_stream
+                                .try_next()
+                                .await
+                                .map_err(|e| RetryableReqwestError::RetryableError(ClientError::from(e)))?
+                            {
+                                let parts = parser.push(chunk).map_err(RetryableReqwestError::FatalError)?;
+                                process_parts(parts)?;
+                            }
 
-                                transfer_reporter.report_progress(total_compressed_bytes as usize);
+                            let final_parts = parser.finish().map_err(RetryableReqwestError::FatalError)?;
+                            process_parts(final_parts)?;
+
+                            // Servers normally return parts in request order, so the common path writes directly
+                            // into the final buffer. Preserve the previous parser's range ordering without an extra
+                            // allocation unless a server actually returns parts out of order.
+                            let response_was_ordered = decoded_parts
+                                .windows(2)
+                                .all(|parts| parts[0].0.start <= parts[1].0.start);
+                            decoded_parts.sort_by_key(|(range, _, _)| range.start);
+                            if !response_was_ordered {
+                                let mut reordered = Vec::with_capacity(all_decompressed.len());
+                                for (_, data_range, _) in &decoded_parts {
+                                    reordered.extend_from_slice(&all_decompressed[data_range.clone()]);
+                                }
+                                all_decompressed = reordered;
+                            }
+
+                            let mut all_chunk_indices = Vec::<u32>::new();
+                            let mut base_offset = 0u32;
+                            for (_, data_range, chunk_indices) in decoded_parts {
+                                if all_chunk_indices.is_empty() {
+                                    all_chunk_indices.extend_from_slice(&chunk_indices);
+                                } else {
+                                    all_chunk_indices
+                                        .extend(chunk_indices.iter().skip(1).map(|&offset| offset + base_offset));
+                                }
+                                base_offset += (data_range.end - data_range.start) as u32;
                             }
 
                             if let Some(expected) = uncompressed_size_if_known
@@ -979,13 +1014,84 @@ impl Client for RemoteClient {
 #[cfg(test)]
 #[cfg(not(target_family = "wasm"))]
 mod tests {
+    use std::io::{Read, Write};
+    use std::net::{TcpListener, TcpStream};
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::Duration;
+
     use tracing_test::traced_test;
     use xet_core_structures::xorb_object::CompressionScheme;
     use xet_core_structures::xorb_object::xorb_format_test_utils::{
-        ChunkSize, build_and_verify_xorb_object, build_raw_xorb,
+        ChunkSize, build_and_verify_xorb_object, build_raw_xorb, build_xorb_object,
     };
 
     use super::*;
+
+    struct FixedURLProvider {
+        url: String,
+        ranges: Vec<HttpRange>,
+    }
+
+    #[async_trait::async_trait]
+    impl URLProvider for FixedURLProvider {
+        async fn retrieve_url(&self) -> Result<(String, Vec<HttpRange>)> {
+            Ok((self.url.clone(), self.ranges.clone()))
+        }
+
+        async fn refresh_url(&self) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    fn write_http_chunk(stream: &mut TcpStream, data: &[u8]) {
+        write!(stream, "{:x}\r\n", data.len()).unwrap();
+        stream.write_all(data).unwrap();
+        stream.write_all(b"\r\n").unwrap();
+        stream.flush().unwrap();
+    }
+
+    fn spawn_staged_multipart_server(
+        boundary: &'static str,
+        first_stage: Vec<u8>,
+        second_stage: Vec<u8>,
+        progress_received: mpsc::Receiver<()>,
+    ) -> (String, mpsc::Receiver<bool>, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let (observed_sender, observed_receiver) = mpsc::channel();
+
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            stream.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+
+            let mut request = Vec::new();
+            let mut read_buffer = [0u8; 1024];
+            while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                let count = stream.read(&mut read_buffer).unwrap();
+                assert_ne!(count, 0, "client closed before sending HTTP headers");
+                request.extend_from_slice(&read_buffer[..count]);
+            }
+
+            write!(
+                stream,
+                "HTTP/1.1 206 Partial Content\r\nContent-Type: multipart/byteranges; boundary={boundary}\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n"
+            )
+            .unwrap();
+            write_http_chunk(&mut stream, &first_stage);
+
+            // The second part and terminating HTTP chunk are deliberately withheld. With the
+            // old `resp.bytes().await` path no progress can be reported before this wait expires.
+            let progressed_before_eof = progress_received.recv_timeout(Duration::from_secs(2)).is_ok();
+            observed_sender.send(progressed_before_eof).unwrap();
+
+            write_http_chunk(&mut stream, &second_stage);
+            stream.write_all(b"0\r\n\r\n").unwrap();
+            stream.flush().unwrap();
+        });
+
+        (format!("http://{address}/xorb"), observed_receiver, server)
+    }
 
     #[test]
     fn test_clients_share_controllers_per_ctx_and_endpoint() {
@@ -1009,6 +1115,72 @@ mod tests {
         let ctx2 = XetContext::default().unwrap();
         let c4 = RemoteClient::new(ctx2, "https://cas-a.example.com", &None, "", false, None);
         assert!(!Arc::ptr_eq(&c1.upload_concurrency_controller, &c4.upload_concurrency_controller));
+    }
+
+    #[test]
+    fn test_multirange_streams_before_eof_and_preserves_range_order() {
+        let (_, compressed_low, raw_low, _) = build_xorb_object(1, ChunkSize::Fixed(2048), CompressionScheme::None);
+        let (_, compressed_high, raw_high, _) = build_xorb_object(1, ChunkSize::Fixed(3072), CompressionScheme::None);
+
+        let boundary = "staged-xet-boundary";
+        let low_range = HttpRange::new(0, compressed_low.len() as u64 - 1);
+        let high_range = HttpRange::new(100_000, 100_000 + compressed_high.len() as u64 - 1);
+
+        // Return the higher range first to exercise the legacy range-sorting behavior while the
+        // response itself is consumed incrementally.
+        let mut first_stage = format!(
+            "--{boundary}\r\nContent-Type: application/octet-stream\r\nContent-Range: bytes {}-{}/200000\r\n\r\n",
+            high_range.start, high_range.end
+        )
+        .into_bytes();
+        first_stage.extend_from_slice(&compressed_high);
+        first_stage.extend_from_slice(
+            format!(
+                "\r\n--{boundary}\r\nContent-Type: application/octet-stream\r\nContent-Range: bytes {}-{}/200000\r\n\r\n",
+                low_range.start, low_range.end
+            )
+            .as_bytes(),
+        );
+
+        let mut second_stage = compressed_low;
+        second_stage.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+
+        let (progress_sender, progress_receiver) = mpsc::channel();
+        let (url, progress_before_eof, server) =
+            spawn_staged_multipart_server(boundary, first_stage, second_stage, progress_receiver);
+
+        let ctx = XetContext::default().unwrap();
+        let client = RemoteClient::new(ctx.clone(), &url, &None, "", false, None);
+        let expected_len = raw_low.len() + raw_high.len();
+        let provider = FixedURLProvider {
+            url,
+            ranges: vec![low_range, high_range],
+        };
+        let progress_callback: ProgressCallback = Arc::new(move |_, _, _| {
+            let _ = progress_sender.send(());
+        });
+
+        let result = ctx
+            .runtime
+            .bridge_sync(async move {
+                let permit = client.acquire_download_permit().await.unwrap();
+                client
+                    .get_file_term_data(Box::new(provider), permit, Some(progress_callback), Some(expected_len))
+                    .await
+            })
+            .unwrap()
+            .unwrap();
+
+        server.join().unwrap();
+        assert!(
+            progress_before_eof.recv().unwrap(),
+            "the first multipart part did not report progress before the server sent EOF"
+        );
+
+        let mut expected = raw_low;
+        expected.extend_from_slice(&raw_high);
+        assert_eq!(result.0.as_ref(), expected);
+        assert_eq!(result.1, vec![0, 2048, 5120]);
     }
 
     #[ignore = "requires a running CAS server"]


### PR DESCRIPTION
## Summary

- parse `multipart/byteranges` responses incrementally from `Response::bytes_stream()`
- deserialize each completed Xorb part directly into the final output buffer
- avoid an extra full-buffer reorder for the normal in-order response while preserving range ordering for out-of-order servers
- retain the public whole-body parser's zero-copy `Bytes::slice` behavior and existing EOF compatibility

This removes the explicit whole compressed-response aggregation that previously happened before any part could be processed. The final decompressed output still remains resident by design; the streaming parser's logical payload buffer holds only the incomplete current part, in addition to the incoming transport chunk and allocator capacity.

Closes #929.

## Compatibility

The new parser is crate-private. Existing public API and multipart ordering semantics are unchanged, including out-of-order responses and the prior exact-boundary EOF behavior.

## Validation

- `cargo test -p xet-client multipart --lib`: 11 passed
- staged local HTTP test: the first part is decoded and reports progress before the server sends the second part or EOF; the old whole-body path fails this negative control
- `cargo test -p xet-client --all-targets`: 212 passed, 4 ignored
- `cargo test -p xet-client --features simulation --all-targets`: 239 passed, 4 ignored, plus 2 integration tests passed
- `cargo clippy -r -p xet-client --features simulation -- -D warnings`: passed
- `cargo +nightly fmt --manifest-path ./Cargo.toml --all -- --check`: passed
- `cargo check -p xet-client --target wasm32-unknown-unknown`: passed with eight pre-existing warnings in untouched code
- `git diff --check`: passed

All validation used CPU execution or a local deterministic HTTP simulation; no GPU or production CAS service was required.

## AI disclosure

The implementation, tests, and this description were generated with OpenAI Codex at the account owner's request. Codex re-checked the final diff against repository code and ran the validations listed above. No separate human line-by-line code review was performed before submission.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core multi-range download parsing and Xorb reassembly; behavior is heavily tested but mistakes could corrupt reconstructed file data or progress reporting.
> 
> **Overview**
> Multi-range downloads no longer buffer the full compressed **multipart/byteranges** body before work begins. **`RemoteClient::get_file_term_data`** now reads **`bytes_stream()`**, feeds chunks into a new crate-private **`StreamingMultipartParser`**, and deserializes each completed range with **`deserialize_chunks_to_writer`** as it arrives—so transfer progress can fire before EOF.
> 
> The parser keeps only the in-flight part (plus boundary search state), matching the old whole-body semantics for EOF-after-boundary and out-of-order **`Content-Range`** parts; in-order responses avoid an extra reorder copy. The public **`parse_multipart_byteranges`** API is unchanged aside from shared **`parse_part`** helpers and expanded unit tests, including a staged local HTTP test that progress happens before the second chunk is sent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 086f117c77612c3b6418a0b4db2a071a4d07228f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->