### PR TITLE
docs: list every value with_high_performance() sets and its memory cost

### DIFF
--- a/xet_runtime/src/config/xet_config.rs
+++ b/xet_runtime/src/config/xet_config.rs
@@ -157,9 +157,34 @@ impl XetConfig {
     /// - HF_XET_HIGH_PERFORMANCE
     /// - HF_XET_HP
     ///
-    /// This method raises file ingestion concurrency, widens the adaptive concurrency
-    /// bands, raises the reconstruction fetch sizes, and applies the high performance
-    /// (memory-derived) download buffer values.
+    /// This method sets the following values (default -> high performance):
+    /// - data.max_concurrent_file_ingestion: 8 -> 100
+    /// - client.ac_max_upload_concurrency: 64 -> 124
+    /// - client.ac_max_download_concurrency: 64 -> 124
+    /// - client.ac_min_upload_concurrency: 1 -> 4
+    /// - client.ac_min_download_concurrency: 1 -> 4
+    /// - client.ac_initial_upload_concurrency: 2 -> 16
+    /// - client.ac_initial_download_concurrency: 4 -> 16
+    /// - reconstruction.min_reconstruction_fetch_size: 256MB -> 1GB
+    /// - reconstruction.max_reconstruction_fetch_size: 8GB -> 16GB
+    /// - reconstruction.download_buffer_size: usable/16 -> usable/8, clamped to [64MB, 16GB]
+    /// - reconstruction.download_buffer_perfile_size: usable/64 -> usable/32, clamped to [16MB, 2GB]
+    /// - reconstruction.download_buffer_limit: usable/4 -> usable/2, clamped to [264MB, 64GB]
+    ///
+    /// "usable" is the minimum of host RAM and the effective cgroup limit (see
+    /// `utils::system_memory`); if it cannot be determined, or derivation is disabled via
+    /// `HF_XET_DISABLE_MEMORY_DERIVED_DOWNLOAD_BUFFERS=1`, the three buffer values fall back
+    /// to the static high performance constants 16GB / 2GB / 64GB regardless of actual RAM.
+    ///
+    /// Memory cost: downloads may buffer up to `download_buffer_size +
+    /// n_active_downloads * download_buffer_perfile_size` bytes in memory, capped at
+    /// `download_buffer_limit` — up to 32GB at the high performance ceilings with the
+    /// default 8 concurrent file downloads. Note that `data.max_concurrent_file_downloads`
+    /// itself is not raised by this preset; only its ingestion counterpart is.
+    ///
+    /// Every field above also has its own `HF_XET_*` environment variable (see the field
+    /// docs in `config/groups/`), so individual values can be adopted without enabling the
+    /// whole preset.
     ///
     /// Note: This method is automatically called by `XetConfig::new()` if high performance mode
     /// is enabled, before environment variable overrides are applied; explicitly set environment


### PR DESCRIPTION
Fixes #926.

Answering the scoping question in the issue thread: this PR takes the xet-core code comment half. The hub docs describe each `HF_XET_*` variable individually, but the doc comment on `with_high_performance()` is the one place that defines what the preset itself does, and it summarized twelve assignments in one sentence with no memory figure.

Since #943 the buffer values are memory-derived, so the comment now lists:

- all twelve fields with default -> high performance values, the buffer entries as their derivation formulas (`usable/16 -> usable/8` etc.) with floors/ceilings, plus the static fallbacks used when memory cannot be probed;
- the worst-case buffer allocation, `download_buffer_size + n_active * download_buffer_perfile_size` capped at `download_buffer_limit` (verified against `FileReconstructor`'s target formula) — up to 32GB at the ceilings with the default 8 concurrent downloads;
- that `data.max_concurrent_file_downloads` is *not* raised by the preset, only its ingestion twin;
- that every field has its own `HF_XET_*` variable, so parts of the preset can be adopted individually on memory-constrained machines.

All values checked against the field defaults in `config/groups/` and the constants in `utils/system_memory.rs` on current main.

Comment-only diff; no Rust toolchain on this machine so I did not run cargo locally, but no code is touched and the `[floor, ceiling]` notation matches the existing field docs in `reconstruction.rs`.

Written with Claude Code, values verified against the source as described above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change with no code or configuration logic modified.
> 
> **Overview**
> Expands the **`with_high_performance()`** doc comment so the high-performance preset is documented in one place instead of a single vague sentence.
> 
> The comment now lists **twelve fields** with **default → preset** values (ingestion concurrency, adaptive concurrency bounds, reconstruction fetch sizes, and memory-derived download buffer formulas with clamps). It explains how **usable** memory is computed, static **16GB / 2GB / 64GB** fallbacks when probing is disabled or fails, and the worst-case download buffer formula (up to **~32GB** at ceilings with default concurrent downloads). It also notes that **`max_concurrent_file_downloads`** is **not** raised by the preset, and that each field can be tuned via its own **`HF_XET_*`** env var without enabling the full preset.
> 
> **No runtime behavior changes** — documentation only on `xet_config.rs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49fb4e86308b6651af68ec6bc0293bae376c3e53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->