### PR TITLE
fix: gate xet_pkg examples on the internal-tools feature

### DIFF
--- a/xet_pkg/Cargo.toml
+++ b/xet_pkg/Cargo.toml
@@ -35,6 +35,17 @@ required-features = ["internal-tools"]
 name = "test_xtool_cli"
 required-features = ["internal-tools"]
 
+# The examples are CLIs built on clap, which is only available with this feature.
+[[example]]
+name = "example"
+path = "examples/example.rs"
+required-features = ["internal-tools"]
+
+[[example]]
+name = "example_sync"
+path = "examples/example_sync.rs"
+required-features = ["internal-tools"]
+
 [dependencies]
 xet-runtime = { version = "1.6.0", path = "../xet_runtime" }
 xet-core-structures = { version = "1.6.0", path = "../xet_core_structures" }


### PR DESCRIPTION
Fixes #944.

`xet_pkg/examples/example.rs` and `example_sync.rs` both use `clap`, which is optional and only enabled by `internal-tools`. Because `cargo test` compiles examples by default, the plain `cargo test` documented under "Local Development" in the root README failed with unresolved `clap` imports. CI never caught it since every test job already passes `--features "strict simulation internal-tools ..."`.

- Declares explicit `[[example]]` targets with `required-features = ["internal-tools"]`, matching how `[[bin]] xtool` and `[[test]] test_xtool_cli` are already gated.
- `cargo test --no-run -p hf-xet` now succeeds and skips the examples; `cargo build --examples -p hf-xet --features internal-tools` still builds both, so CI coverage is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cargo manifest-only change; no runtime or library API behavior is modified.
> 
> **Overview**
> **Fixes default `cargo test` failures** on `hf-xet` when examples are compiled without optional `clap`.
> 
> The crate now declares **`example`** and **`example_sync`** as explicit `[[example]]` targets with `required-features = ["internal-tools"]`, the same pattern already used for **`xtool`** and **`test_xtool_cli`**. Plain `cargo test -p hf-xet` no longer tries to build those CLIs; building them still works with `--features internal-tools`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 460e3878d17e0792b1a02dbe45e0b68024e1ea39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->