### PR TITLE
feat: add rustls-no-provider TLS feature

### DIFF
--- a/xet_client/Cargo.toml
+++ b/xet_client/Cargo.toml
@@ -74,6 +74,7 @@ default = ["rustls-tls"]
 elevated_information_level = []
 fd-track = ["xet-runtime/fd-track"]
 rustls-tls = ["reqwest/rustls"]
+rustls-no-provider = ["reqwest/rustls-no-provider"]
 native-tls = ["reqwest/native-tls"]
 native-tls-vendored = ["reqwest/native-tls-vendored"]
 # The cache_analysis binary needs clap for argument parsing.

--- a/xet_data/Cargo.toml
+++ b/xet_data/Cargo.toml
@@ -97,6 +97,7 @@ harness = false
 default = ["rustls-tls"]
 # TLS backend for the underlying reqwest client; see the xet-client crate.
 rustls-tls = ["xet-client/rustls-tls"]
+rustls-no-provider = ["xet-client/rustls-no-provider"]
 native-tls = ["xet-client/native-tls"]
 native-tls-vendored = ["xet-client/native-tls-vendored"]
 strict = []

--- a/xet_pkg/Cargo.toml
+++ b/xet_pkg/Cargo.toml
@@ -81,6 +81,7 @@ simulation = ["xet-client/simulation"]
 # the platform-native TLS stack instead, depend on this crate with
 # `default-features = false` and enable `native-tls` (or `native-tls-vendored`).
 rustls-tls = ["xet-client/rustls-tls", "xet-data/rustls-tls"]
+rustls-no-provider = ["xet-client/rustls-no-provider", "xet-data/rustls-no-provider"]
 native-tls = ["xet-client/native-tls", "xet-data/native-tls"]
 native-tls-vendored = ["xet-client/native-tls-vendored", "xet-data/native-tls-vendored"]
 elevated_information_level = ["xet-client/elevated_information_level", "xet-runtime/elevated_information_level"]


### PR DESCRIPTION
`reqwest` has a `rustls-no-provider` feature for builds that want `rustls` without the bundled `aws-lc-rs` provider. Forward it through `xet-client`, `xet-data` and `hf-xet` so consumers can install their own `CryptoProvider`, such as `ring`, and keep `aws-lc-rs` and its `cmake` build dependency out of the tree.

It stays off by default, so existing builds keep `rustls` with `aws-lc-rs`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cargo-only feature forwarding with no runtime code changes; default TLS behavior stays on rustls with aws-lc-rs.
> 
> **Overview**
> Adds an optional **`rustls-no-provider`** Cargo feature on **`xet-client`**, **`xet-data`**, and **`hf-xet`**, wired the same way as existing TLS features: **`xet-client`** enables **`reqwest/rustls-no-provider`**, and the other crates forward it through **`xet-client`**.
> 
> This lets downstream builds use **rustls** without the default **aws-lc-rs** crypto provider so they can install their own **`CryptoProvider`** (e.g. **ring**) and avoid **aws-lc-rs** / **cmake** in the dependency tree. The feature is **not** in **`default`**, so existing **`rustls-tls`** behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ffca18e6e892fce598decf55ac98612be2bfda9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->