### PR TITLE
Fix malformed chunk cache directory handling

### DIFF
--- a/xet_client/src/chunk_cache/disk.rs
+++ b/xet_client/src/chunk_cache/disk.rs
@@ -262,15 +262,17 @@ impl DiskCache {
                 };
 
                 let key_dir_name = key_dir.file_name();
+                let key_dir_name_bytes = key_dir_name.as_encoded_bytes();
+                let Some(key_dir_prefix) = key_dir_name_bytes.get(..PREFIX_DIR_NAME_LEN) else {
+                    debug!("key dir name len < {PREFIX_DIR_NAME_LEN}: {key_dir_name:?}");
+                    continue;
+                };
+                if key_dir_prefix != key_prefix_dir_name.as_encoded_bytes() {
+                    debug!("key dir prefix does not match parent directory: {key_dir_name:?}");
+                    continue;
+                }
 
-                // asserts that the prefix dir name is actually the prefix of this key dir
-                debug_assert_eq!(
-                    key_dir_name.as_encoded_bytes()[..PREFIX_DIR_NAME_LEN].to_ascii_uppercase(),
-                    key_prefix_dir_name.as_encoded_bytes().to_ascii_uppercase(),
-                    "{key_dir_name:?}",
-                );
-
-                let key = match try_parse_key(key_dir_name.as_encoded_bytes()) {
+                let key = match try_parse_key(key_dir_name_bytes) {
                     Ok(key) => key,
                     Err(e) => {
                         debug!("failed to decoded a directory name as a key: {e}");
@@ -783,7 +785,10 @@ fn check_remove_dir(dir_path: impl AsRef<Path>) -> Result<(), ChunkCacheError> {
 /// expects only the key portion of the file path, with the prefix not present.
 fn try_parse_key(file_name: &[u8]) -> Result<Key, ChunkCacheError> {
     let buf = BASE64_ENGINE.decode(file_name)?;
-    let hash = MerkleHash::from_slice(&buf[..size_of::<MerkleHash>()])?;
+    let hash_bytes = buf
+        .get(..size_of::<MerkleHash>())
+        .ok_or_else(|| ChunkCacheError::parse("decoded key is shorter than a MerkleHash"))?;
+    let hash = MerkleHash::from_slice(hash_bytes)?;
     let prefix = String::from(std::str::from_utf8(&buf[size_of::<MerkleHash>()..])?);
     Ok(Key { prefix, hash })
 }
@@ -854,6 +859,48 @@ mod tests {
                 .unwrap()
                 .is_none()
         );
+    }
+
+    #[test]
+    fn test_initialize_ignores_short_key_directory_name() {
+        let cache_root = TempDir::new().unwrap();
+        std::fs::create_dir_all(cache_root.path().join("ab").join("x")).unwrap();
+        let config = CacheConfig {
+            cache_directory: cache_root.path().to_path_buf(),
+            cache_size: DEFAULT_CHUNK_CACHE_CAPACITY,
+        };
+
+        let cache = DiskCache::initialize(&XetConfig::new(), &config).unwrap();
+
+        assert_eq!(cache.state.blocking_read().num_items, 0);
+    }
+
+    #[test]
+    fn test_initialize_ignores_short_decoded_key() {
+        let cache_root = TempDir::new().unwrap();
+        std::fs::create_dir_all(cache_root.path().join("AA").join("AA")).unwrap();
+        let config = CacheConfig {
+            cache_directory: cache_root.path().to_path_buf(),
+            cache_size: DEFAULT_CHUNK_CACHE_CAPACITY,
+        };
+
+        let cache = DiskCache::initialize(&XetConfig::new(), &config).unwrap();
+
+        assert_eq!(cache.state.blocking_read().num_items, 0);
+    }
+
+    #[test]
+    fn test_initialize_ignores_key_directory_under_wrong_prefix() {
+        let cache_root = TempDir::new().unwrap();
+        std::fs::create_dir_all(cache_root.path().join("ab").join("cd000000000000000000000000000000")).unwrap();
+        let config = CacheConfig {
+            cache_directory: cache_root.path().to_path_buf(),
+            cache_size: DEFAULT_CHUNK_CACHE_CAPACITY,
+        };
+
+        let cache = DiskCache::initialize(&XetConfig::new(), &config).unwrap();
+
+        assert_eq!(cache.state.blocking_read().num_items, 0);
     }
 
     #[tokio::test]

--- a/xet_client/src/chunk_cache/disk.rs
+++ b/xet_client/src/chunk_cache/disk.rs
@@ -267,7 +267,7 @@ impl DiskCache {
                     debug!("key dir name len < {PREFIX_DIR_NAME_LEN}: {key_dir_name:?}");
                     continue;
                 };
-                if key_dir_prefix != key_prefix_dir_name.as_encoded_bytes() {
+                if !key_dir_prefix.eq_ignore_ascii_case(key_prefix_dir_name.as_encoded_bytes()) {
                     debug!("key dir prefix does not match parent directory: {key_dir_name:?}");
                     continue;
                 }


### PR DESCRIPTION
## Summary

- skip malformed chunk-cache key directories instead of panicking during cache initialization
- require each encoded key directory to live under its exact two-byte prefix directory
- reject decoded key names shorter than a `MerkleHash` before slicing
- add regression coverage for short encoded names, short decoded keys, and mismatched prefixes

## Why

`DiskCache::initialize_state` scanned cache directories before fully validating their names. A stray directory such as `<cache>/ab/x` caused an out-of-bounds panic while slicing the first two bytes. A matching Base64 name such as `<cache>/AA/AA` passed that check but decoded to fewer than 32 bytes and panicked while extracting the hash. In debug builds, a valid-looking key under the wrong prefix also triggered an assertion; in release builds it could be admitted under an inconsistent path.

Cache initialization already skips other malformed entries, so this keeps that fail-soft behavior consistent without changing valid cache entries.

## Verification

- RED: `test_initialize_ignores_short_key_directory_name` reproduced `range end index 2 out of range for slice of length 1`
- RED: `test_initialize_ignores_key_directory_under_wrong_prefix` reproduced the prefix assertion failure
- focused regressions: 3 passed
- `cargo +1.95.0 test -p xet-client --lib`: 209 passed, 4 ignored
- `cargo +1.95.0 test --no-fail-fast --features "strict simulation internal-tools git-xet-for-integration-test"`: passed
- `cargo +1.95.0 clippy -r -p xet-client --lib -- -D warnings`: passed
- `rustup run 1.95.0 rustfmt --edition 2024 --check xet_client/src/chunk_cache/disk.rs`: passed
- `git diff --check`: passed

## Scope

One Rust source file; no dependency or public API changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect scanning of existing cache directories at init; valid entries behave the same and malformed paths are ignored rather than crashing.
> 
> **Overview**
> **Disk cache startup** no longer panics or asserts when the on-disk layout contains stray or invalid key directories. During `initialize_state`, encoded key folder names are validated before parsing: names shorter than the two-byte prefix are skipped, and the name’s prefix must match the parent prefix directory (case-insensitive)—replacing a debug-only assertion that could fail in debug builds or admit inconsistent paths in release.
> 
> **Key decoding** in `try_parse_key` now checks that Base64-decoded data is at least `MerkleHash`-sized before slicing, returning a parse error instead of panicking on truncated payloads (e.g. `AA/AA`).
> 
> Three unit tests lock in fail-soft behavior for short directory names, undersized decoded keys, and keys stored under the wrong prefix folder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a5da45dbf3acdc3d74df17b071bd1e7b970e059. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->