### PR TITLE
fix(simulation): store uploaded shards the way CAS does for LocalClient

### DIFF
--- a/xet_client/src/cas_client/simulation/local_client.rs
+++ b/xet_client/src/cas_client/simulation/local_client.rs
@@ -15,13 +15,14 @@ use redb::{ReadableDatabase, ReadableTable, TableDefinition};
 use tempfile::TempDir;
 use tokio::time::{Duration, Instant};
 use tracing::{error, info, warn};
-use xet_core_structures::merklehash::{MerkleHash, compute_data_hash};
+use xet_core_structures::merklehash::{HashedWrite, MerkleHash, compute_data_hash};
 use xet_core_structures::metadata_shard::file_structs::{FileDataSequenceHeader, MDBFileInfo, MDBFileInfoView};
-use xet_core_structures::metadata_shard::shard_file_reconstructor::FileReconstructor;
 use xet_core_structures::metadata_shard::shard_format::MDB_FILE_INFO_ENTRY_SIZE;
+#[cfg(test)]
 use xet_core_structures::metadata_shard::shard_in_memory::MDBInMemoryShard;
 use xet_core_structures::metadata_shard::streaming_shard::MDBMinimalShard;
 use xet_core_structures::metadata_shard::utils::{parse_shard_filename, shard_file_name};
+#[cfg(test)]
 use xet_core_structures::metadata_shard::xorb_structs::MDBXorbInfo;
 use xet_core_structures::metadata_shard::{MDBShardFile, MDBShardFileHeader, ShardFileManager};
 use xet_core_structures::serialization_utils::read_u32;
@@ -325,8 +326,11 @@ impl LocalClient {
             write_txn.commit().map_err(map_redb_db_error)?;
         }
 
-        // Open / set up the shard lookup
-        let shard_manager = ShardFileManager::new_in_session_directory(&ctx, shard_dir.clone(), true).await?;
+        // Open / set up the shard lookup. Not scanned on open: the scan prunes shards whose
+        // key expiry has passed, and shards here are stored as CAS stores them, which records
+        // a zero expiry. This directory is a server-side store, not an expiring client cache,
+        // and nothing reads it back through the manager.
+        let shard_manager = ShardFileManager::new_in_session_directory(&ctx, shard_dir.clone(), false).await?;
         #[cfg(feature = "fd-track")]
         report_fd_count("LocalClient::new_internal after shard manager init");
 
@@ -1522,34 +1526,33 @@ impl Client for LocalClient {
         let mut reader = Cursor::new(&shard_data);
         let minimal_shard = MDBMinimalShard::from_reader(&mut reader, true, true)?;
 
-        // Rebuild a full in-memory shard to rebuild the new shard.  Quick and convenient.
-        let mut in_memory_shard = MDBInMemoryShard::default();
+        // Store the shard exactly as CAS does: re-serialize the validated shard through the
+        // streaming serializer and store those bytes under their own hash, discarding the
+        // hash the client sent (see `validate_shard_from_async_read` in cas_server). That
+        // footer stamps a creation timestamp, so re-uploading identical content produces a
+        // distinct object rather than reusing one hash forever.
+        let mut cas_form = Vec::with_capacity(minimal_shard.serialized_size(false));
+        let mut hashed_writer = HashedWrite::new(&mut cas_form);
+        minimal_shard.serialize(&mut hashed_writer, false)?;
+        hashed_writer.flush()?;
+        let shard_hash = hashed_writer.hash();
 
-        // Add file info from the views
-        for i in 0..minimal_shard.num_files() {
-            let file_view = minimal_shard.file(i).unwrap();
-            in_memory_shard.add_file_reconstruction_info(MDBFileInfo::from(file_view))?;
-        }
+        // Temp name first: two concurrent uploads of the same content must not race on the
+        // final path, and a reader must never observe a partial shard.
+        let shard_path = self.shard_dir.join(shard_file_name(&shard_hash));
+        let tmp_path = shard_path.with_extension(format!("upload_{:x}", rand::random::<u64>()));
+        std::fs::write(&tmp_path, &cas_form)?;
+        std::fs::rename(&tmp_path, &shard_path)?;
 
-        // Add XORB info from the views
-        for i in 0..minimal_shard.num_xorb() {
-            let xorb_view = minimal_shard.xorb(i).unwrap();
-            in_memory_shard.add_xorb_block(MDBXorbInfo::from(xorb_view))?;
-        }
-
-        // Write the rebuilt shard to disk (creates proper lookup tables)
-        let shard_path = in_memory_shard.write_to_directory(&self.shard_dir, None)?;
         let shard = MDBShardFile::load_from_file(&shard_path, self.shard_manager.shard_file_cache())?;
-        let shard_hash = shard.shard_hash;
 
         self.shard_manager.register_shards(&[shard]).await?;
 
         // Get global dedup chunks from the minimal shard
         let chunk_hashes = minimal_shard.global_dedup_eligible_chunks();
 
-        // Compute byte ranges for each file entry in the written shard
-        let written_shard_bytes = std::fs::read(&shard_path)?;
-        let file_ranges = file_entry_byte_ranges(&written_shard_bytes)?;
+        // Byte ranges into the stored shard, which is `cas_form` itself.
+        let file_ranges = file_entry_byte_ranges(&cas_form)?;
 
         let shard_hash_redb = RedbHash::from(shard_hash);
         let write_txn = self.db().begin_write().map_err(map_redb_db_error)?;
@@ -1787,7 +1790,7 @@ impl Client for LocalClient {
     ) -> Result<FileChunkHashesResponse> {
         self.apply_api_delay().await;
 
-        let Some((file_info, _)) = self.shard_manager.get_file_reconstruction_info(file_id).await? else {
+        let Some((file_info, _)) = self.get_file_info_from_table(file_id)? else {
             return Err(ClientError::FileNotFound(*file_id));
         };
 

--- a/xet_client/src/cas_client/simulation/local_client.rs
+++ b/xet_client/src/cas_client/simulation/local_client.rs
@@ -1878,38 +1878,6 @@ mod tests {
         .await;
     }
 
-    /// Stored shards are what file lookups read here, so a shard uploaded with verification
-    /// entries must still have them afterwards — `gap_verification` is built from this.
-    #[tokio::test]
-    async fn test_upload_shard_keeps_file_verification() {
-        use xet_core_structures::metadata_shard::shard_format::test_routines::gen_random_shard_with_xorb_references;
-
-        let client = LocalClient::temporary(test_context()).await.unwrap();
-
-        let shard_in = gen_random_shard_with_xorb_references(0, &[16; 8], &[2; 20], true, true).unwrap();
-        let file_hashes: Vec<MerkleHash> = shard_in.file_content.keys().copied().collect();
-        assert!(!file_hashes.is_empty());
-
-        let permit = client.acquire_upload_permit().await.unwrap();
-        client
-            .upload_shard(shard_in.to_bytes().unwrap().into(), permit, None)
-            .await
-            .unwrap();
-
-        for file_hash in &file_hashes {
-            let (file_info, _) = client
-                .get_file_info_from_table(file_hash)
-                .unwrap()
-                .unwrap_or_else(|| panic!("file {} missing from the table", file_hash.hex()));
-            assert_eq!(
-                file_info.verification.len(),
-                file_info.segments.len(),
-                "file {} lost its verification entries on upload",
-                file_hash.hex()
-            );
-        }
-    }
-
     /// Two different path strings for the same directory (symlink) must share one `redb::Database`
     /// in `DB_CACHE`. Without `canonicalize` in `new_internal`, `redb` returns
     /// `Database already open. Cannot acquire lock.` (duplicate opens for the same file).

--- a/xet_client/src/cas_client/simulation/local_client.rs
+++ b/xet_client/src/cas_client/simulation/local_client.rs
@@ -1531,9 +1531,16 @@ impl Client for LocalClient {
         // hash the client sent (see `validate_shard_from_async_read` in cas_server). That
         // footer stamps a creation timestamp, so re-uploading identical content produces a
         // distinct object rather than reusing one hash forever.
-        let mut cas_form = Vec::with_capacity(minimal_shard.serialized_size(false));
+        // Verification is kept, where CAS trims it: CAS serves file info from its own
+        // database, which retains verification, while here the stored shard is what file
+        // lookups read, and `gap_verification` is built from it. `serialize` rejects the
+        // request unless every file carries it, so ask only when they all do.
+        let with_verification =
+            (0..minimal_shard.num_files()).all(|i| minimal_shard.file(i).is_some_and(|f| f.contains_verification()));
+
+        let mut cas_form = Vec::with_capacity(minimal_shard.serialized_size(with_verification));
         let mut hashed_writer = HashedWrite::new(&mut cas_form);
-        minimal_shard.serialize(&mut hashed_writer, false)?;
+        minimal_shard.serialize(&mut hashed_writer, with_verification)?;
         hashed_writer.flush()?;
         let shard_hash = hashed_writer.hash();
 
@@ -1869,6 +1876,38 @@ mod tests {
                 as std::sync::Arc<dyn crate::cas_client::simulation::DirectAccessClient>
         })
         .await;
+    }
+
+    /// Stored shards are what file lookups read here, so a shard uploaded with verification
+    /// entries must still have them afterwards — `gap_verification` is built from this.
+    #[tokio::test]
+    async fn test_upload_shard_keeps_file_verification() {
+        use xet_core_structures::metadata_shard::shard_format::test_routines::gen_random_shard_with_xorb_references;
+
+        let client = LocalClient::temporary(test_context()).await.unwrap();
+
+        let shard_in = gen_random_shard_with_xorb_references(0, &[16; 8], &[2; 20], true, true).unwrap();
+        let file_hashes: Vec<MerkleHash> = shard_in.file_content.keys().copied().collect();
+        assert!(!file_hashes.is_empty());
+
+        let permit = client.acquire_upload_permit().await.unwrap();
+        client
+            .upload_shard(shard_in.to_bytes().unwrap().into(), permit, None)
+            .await
+            .unwrap();
+
+        for file_hash in &file_hashes {
+            let (file_info, _) = client
+                .get_file_info_from_table(file_hash)
+                .unwrap()
+                .unwrap_or_else(|| panic!("file {} missing from the table", file_hash.hex()));
+            assert_eq!(
+                file_info.verification.len(),
+                file_info.segments.len(),
+                "file {} lost its verification entries on upload",
+                file_hash.hex()
+            );
+        }
     }
 
     /// Two different path strings for the same directory (symlink) must share one `redb::Database`


### PR DESCRIPTION
The simulation rebuilt each uploaded shard through `MDBInMemoryShard`, while CAS re-serializes through the streaming serializer and keys the object by the hash of those bytes. Only the streaming path stamps `shard_creation_timestamp`, so identical content collapsed onto a single hash forever in the simulation but not in production. That let a re-upload land back on a hash GC had already deregistered from the global dedup table and still had queued for deletion, leaving dedup rows pointing at a condemned shard — `stress_test_high_fp` failed on it 7 runs out of 7.

Two consequences of storing what CAS stores:
- shards carry no lookup tables, so `get_file_chunk_hashes` reads its file entry from the authoritative table, as the reconstruction path already did
- they record a zero key expiry, so this server-side store is no longer scanned on open as if it were a client cache — that scan prunes by exactly that field

Test plan: full GC stress suite against this branch with no GC-side change, all three variants green and `integrity=36ok/0FAIL` each (`stress_test_high_fp` 14/14 epochs, `stress_test`, `stress_test_convergence`), at unchanged throughput and unchanged collection rates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes simulation shard hashing, on-disk layout, and file lookup paths that GC stress tests depend on; behavior is intentional parity with CAS but affects dedup/GC edge cases in tests only.
> 
> **Overview**
> Aligns **simulation `LocalClient` shard persistence** with production CAS so GC stress tests match real dedup/GC behavior.
> 
> **Shard uploads** no longer rebuild via `MDBInMemoryShard`; validated input is re-serialized through the streaming path (`HashedWrite` + `minimal_shard.serialize`), keyed by the hash of those bytes (client-supplied hash ignored), written atomically via temp file + rename. Identical logical content therefore gets a **new shard hash** when the footer stamps a creation timestamp—fixing cases where re-upload reused a hash already deregistered/queued for deletion while dedup rows still pointed at it.
> 
> **Shard manager init** disables directory scan on open (`scan: false`) because CAS-form shards use zero key expiry; scanning would incorrectly prune them as if this were an expiring client cache.
> 
> **`get_file_chunk_hashes`** resolves file metadata from **`FILE_TO_SHARD_TABLE`** (`get_file_info_from_table`) instead of shard-manager reconstruction lookup, consistent with shards stored without embedded lookup tables.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cec0e0586d2efafae5dfa588abe6886188e7404. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->