### PR TITLE
chore(deps): move off the yanked der 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1202,9 +1202,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+checksum = "a878c850e9e421b20262e9b41f9c860e4785fa07541c266b62ff9d1ef998a80a"
 dependencies = [
  "const-oid 0.10.2",
  "pem-rfc7468",


### PR DESCRIPTION
`cargo audit -D warnings` fails on `der 0.8.0`, which has been yanked, so the Cargo Audit job is red on every PR (including #952, now `main`'s HEAD). Bumps it to 0.8.2 — lockfile only, no manifest change. `der` arrives transitively via `russh` in `git_xet`'s dev-dependencies.

`cargo check -p git_xet --all-targets` passes; local `cargo audit` can't verify against the registry proxy, so the Cargo Audit job here is the real check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only transitive dependency bump with no application code changes.
> 
> **Overview**
> **Unblocks Cargo Audit** by replacing the yanked `der` **0.8.0** with **0.8.2** in `Cargo.lock` only—no `Cargo.toml` changes. The crate is pulled in transitively (e.g. via `russh` in `git_xet` dev-dependencies), so this fixes the failing `cargo audit -D warnings` check that was red on CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d3077c2ad72e69cbdbdb5e6227ffafbe58e2067. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->